### PR TITLE
amd-ras: Re-organize the RAS application

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,20 +15,24 @@
 #include <sdbusplus/asio/property.hpp>
 #include <phosphor-logging/log.hpp>
 #include <sdbusplus/asio/object_server.hpp>
+#include <mutex>          // std::mutex
 
 extern "C" {
 #include <sys/stat.h>
 #include "linux/i2c-dev.h"
 #include "i2c/smbus.h"
 #include "esmi_common.h"
+#include "esmi_i2c.h"
 #include "esmi_mailbox.h"
 #include "esmi_rmi.h"
 }
 
 #define COMMAND_BOARD_ID    ("/sbin/fw_printenv -n board_id")
 #define COMMAND_LEN         3
+#define MAX_MCA_BANKS       (32)
 
 #define MAX_RETRIES 10
+#define RAS_STATUS_REGISTER (0x4C)
 
 static boost::asio::io_service io;
 std::shared_ptr<sdbusplus::asio::connection> conn;
@@ -45,7 +49,30 @@ static boost::asio::posix::stream_descriptor P1_apmlAlertEvent(io);
 struct i2c_info p0_info = {4, 0x22400000002, 0};
 struct i2c_info p1_info = {5, 0x22400000002, 0};
 
+static int num_of_proc = 0;
+
 const static constexpr int resetPulseTimeMs = 100;
+constexpr auto ONYX_SLT     = 61;   //0x3D
+constexpr auto ONYX_1       = 64;   //0x40
+constexpr auto ONYX_2       = 65;   //0x41
+constexpr auto ONYX_3       = 66;   //0x42
+constexpr auto ONYX_FR4     = 82;   //0x52
+constexpr auto QUARTZ_DAP   = 62;   //0x3E
+constexpr auto QUARTZ_1     = 67;   //0x43
+constexpr auto QUARTZ_2     = 68;   //0x44
+constexpr auto QUARTZ_3     = 69;   //0x45
+constexpr auto QUARTZ_FR4   = 81;   //0x51
+constexpr auto RUBY_1       = 70;   //0x46
+constexpr auto RUBY_2       = 71;   //0x47
+constexpr auto RUBY_3       = 72;   //0x48
+constexpr auto TITANITE_1   = 73;   //0x49
+constexpr auto TITANITE_2   = 74;   //0x4A
+constexpr auto TITANITE_3   = 75;   //0x4B
+constexpr auto TITANITE_4   = 76;   //0x4C
+constexpr auto TITANITE_5   = 77;   //0x4D
+constexpr auto TITANITE_6   = 78;   //0x4E
+
+std::mutex harvest_in_progress_mtx;           // mutex for critical section
 
 bool harvest_ras_errors(struct i2c_info info,std::string alert_name);
 
@@ -53,57 +80,50 @@ bool getPlatformID()
 {
     FILE *pf;
     char data[COMMAND_LEN];
+    bool PLATID = false;
+    std::stringstream ss;
+    unsigned int board_id = 0;
 
     // Setup pipe for reading and execute to get u-boot environment
     // variable board_id.
     pf = popen(COMMAND_BOARD_ID,"r");
-
     // Error handling
-    if(pf < 0)
+    if(pf > 0)
     {
-        std::cerr << "Unable to get Board ID, errno: " << errno << "message: " << strerror(errno) << "\n";
-        return false;
+        // Get the data from the process execution
+        if (fgets(data, COMMAND_LEN, pf) > 0)
+        {
+            ss << std::hex << (std::string)data;
+            ss >> board_id;
+            PLATID = true;
+            sd_journal_print(LOG_DEBUG, "Board ID: 0x%x, Board ID String: %s\n", board_id, data);
+        }
+
+        // the data is now in 'data'
+        pclose(pf);
+
+
+        switch (board_id)
+        {
+        case ONYX_SLT:
+        case ONYX_1 ... ONYX_3:
+        case ONYX_FR4:
+        case RUBY_1 ... RUBY_3:
+        num_of_proc = 1;
+        break;
+        case QUARTZ_DAP:
+        case QUARTZ_1 ... QUARTZ_3:
+        case QUARTZ_FR4:
+        case TITANITE_1 ... TITANITE_6:
+        num_of_proc = 2;
+        break;
+        default:
+            num_of_proc = 1;
+            break;
+        }//switch
     }
 
-    // Get the data from the process execution
-    if (fgets(data, COMMAND_LEN, pf) == NULL)
-    {
-        std::cerr << "Board ID data is null, errno: " << errno << "message: " << strerror(errno) << "\n";
-        return false;
-    }
-
-    // the data is now in 'data'
-    if (pclose(pf) != 0)
-    {
-        std::cerr << " Error: Failed to close command stream\n";
-        return false;
-    }
-    std::string board_id(data);
-    if((board_id.compare("3D") == 0) || (board_id.compare("40") == 0) || (board_id.compare("41") == 0)
-        || (board_id.compare("42") == 0) || (board_id.compare("52") == 0))
-    {
-        BoardName = "Onyx";
-        return true;
-    }
-    if((board_id.compare("3E") == 0 ) || (board_id.compare("43") == 0) || (board_id.compare("44") ==0)
-        || (board_id.compare("45") == 0) || (board_id.compare("51") == 0))
-    {
-        BoardName = "Quartz";
-        return true;
-    }
-    if((board_id.compare("46")== 0) || (board_id.compare("47") == 0) || (board_id.compare("48") == 0))
-    {
-        BoardName = "Ruby";
-        return true;
-    }
-    if((board_id.compare("49") == 0 ) || (board_id.compare("4A") == 0) || (board_id.compare("4B") == 0)
-        || (board_id.compare("4C") == 0) || (board_id.compare("4D") == 0) || (board_id.compare("4E") == 0))
-    {
-        BoardName = "Titanite";
-        return true;
-    }
-
-    return false;
+    return PLATID;
 }
 
 static bool requestGPIOEvents(
@@ -115,7 +135,7 @@ static bool requestGPIOEvents(
     gpioLine = gpiod::find_line(name);
     if (!gpioLine)
     {
-        std::cerr << "Failed to find the " << name << " line\n";
+        sd_journal_print(LOG_ERR, "Failed to find gpio line %s \n", name.c_str());
         return false;
     }
 
@@ -126,14 +146,14 @@ static bool requestGPIOEvents(
     }
     catch (std::exception& exc)
     {
-        std::cerr << "Failed to request events for " << name << exc.what() << "\n";
+        sd_journal_print(LOG_ERR, "Failed to request events for gpio line %s, exception: %s \n", name.c_str(), exc.what());
         return false;
     }
 
     int gpioLineFd = gpioLine.event_get_fd();
     if (gpioLineFd < 0)
     {
-        std::cerr << "Failed to get " << name << " fd\n";
+        sd_journal_print(LOG_ERR, "Failed to get gpio line %s fd\n", name.c_str());
         return false;
     }
 
@@ -144,8 +164,7 @@ static bool requestGPIOEvents(
         [&name, handler](const boost::system::error_code ec) {
             if (ec)
             {
-                std::cerr << name << " fd handler error: " << ec.message()
-                          << "\n";
+                sd_journal_print(LOG_ERR, "fd handler error: %s \n", ec.message().c_str());
                 // TODO: throw here to force power-control to restart?
                 return;
             }
@@ -162,7 +181,7 @@ static bool setGPIOOutput(const std::string& name, const int value,
     gpioLine = gpiod::find_line(name);
     if (!gpioLine)
     {
-        std::cerr << "Failed to find the " << name << " line.\n";
+        sd_journal_print(LOG_ERR, "Failed to find gpio line %s \n", name.c_str());
         return false;
     }
 
@@ -172,7 +191,7 @@ static bool setGPIOOutput(const std::string& name, const int value,
     }
     catch (std::system_error& exc)
     {
-        std::cerr << "Error setting gpio as Output: " << name << exc.what() << "\n";
+        sd_journal_print(LOG_ERR, "Error setting gpio as Output: %s, exception: %s \n", name.c_str(), exc.what());
     }
 
     try
@@ -182,12 +201,12 @@ static bool setGPIOOutput(const std::string& name, const int value,
     }
     catch (std::exception& exc)
     {
-        std::cerr << "Failed to set value for " << name << exc.what()<< "\n";
+        sd_journal_print(LOG_ERR, "Failed to set value for %s, exception: %s \n", name.c_str(), exc.what());
         return false;
     }
 
 
-    std::cerr << name << " set to " << std::to_string(value) << "\n";
+    sd_journal_print(LOG_DEBUG, "%s set to %d \n", name.c_str(), value);
 
     return true;
 }
@@ -206,80 +225,93 @@ static int setGPIOValue(const std::string& name, const int value,
     return 0;
 }
 
-static void P0_apmlAlertHandler()
+
+/* Schedule a wait event */
+static void P0AlertEventHandler()
 {
     gpiod::line_event gpioLineEvent = P0_apmlAlertLine.event_read();
 
     if (gpioLineEvent.event_type == gpiod::line_event::FALLING_EDGE)
     {
-        std::cerr << "P0 APML Alert received\n";
+        sd_journal_print(LOG_DEBUG, "Falling Edge: P0 APML Alert received\n");
 
+        harvest_in_progress_mtx.lock();
         harvest_ras_errors(p0_info,"P0_ALERT");
+        harvest_in_progress_mtx.unlock();
 
     }
+    else if (gpioLineEvent.event_type == gpiod::line_event::RISING_EDGE)
+    {
+        sd_journal_print(LOG_DEBUG, "Rising Edge: P0 APML Alert cancelled\n");
+    }
+
+    P0_apmlAlertEvent.async_wait(
+            boost::asio::posix::stream_descriptor::wait_read,
+            [](const boost::system::error_code ec) {
+        if (ec)
+        {
+            sd_journal_print(LOG_ERR, "P0 APML alert handler error: %s\n", ec.message().c_str());
+            return;
+        }
+        P0AlertEventHandler();
+    });
 }
 
-static void P1_apmlAlertHandler()
+static void P1AlertEventHandler()
 {
     gpiod::line_event gpioLineEvent = P1_apmlAlertLine.event_read();
 
     if (gpioLineEvent.event_type == gpiod::line_event::FALLING_EDGE)
     {
-        std::cerr << "P1 APML Alert received\n";
+        sd_journal_print(LOG_DEBUG, "Falling Edge: P1 APML Alert received\n");
+        harvest_in_progress_mtx.lock();
         harvest_ras_errors(p1_info,"P1_ALERT");
+        harvest_in_progress_mtx.unlock();
     }
+    else if (gpioLineEvent.event_type == gpiod::line_event::RISING_EDGE)
+    {
+        sd_journal_print(LOG_DEBUG, "Rising Edge: P0 APML Alert cancelled\n");
+    }
+    P1_apmlAlertEvent.async_wait(
+            boost::asio::posix::stream_descriptor::wait_read,
+            [](const boost::system::error_code ec) {
+        if (ec)
+        {
+            sd_journal_print(LOG_ERR, "P1 APML alert handler error: %s\n", ec.message().c_str());
+            return;
+        }
+        P1AlertEventHandler();
+    });
 }
 
-bool harvest_ras_errors(struct i2c_info info,std::string alert_name)
+static void write_register(struct i2c_info info, uint32_t reg, uint32_t value)
 {
+    oob_status_t ret;
+
+    ret = esmi_oob_write_byte(info, reg, value);
+    if (ret != OOB_SUCCESS) {
+        sd_journal_print(LOG_ERR, "Failed to write register: 0x%x\n", reg);
+        return;
+    }
+    sd_journal_print(LOG_DEBUG, "Write to register 0x%x is successful\n", reg);
+}
+
+static bool harvest_mca_data_banks(std::string filePath, struct i2c_info info, uint16_t numbanks, uint16_t bytespermca)
+{
+    FILE *file;
     uint16_t n = 0;
-    uint16_t retries = 0;
-    uint16_t bytespermca;
     uint16_t maxOffset32;
-    uint16_t numbanks = 0;
     uint32_t buffer;
     struct mca_bank mca_dump;
     oob_status_t ret = OOB_MAILBOX_ERR;
-    FILE *file;
-    std::string filePath;
-    uint8_t buf;
-
-    std::cerr << "read_bmc_ras_mca_validity_check" << std::endl;
-
-    while (ret != OOB_SUCCESS)
-    {
-        retries++;
-
-        ret = read_bmc_ras_mca_validity_check(info, &bytespermca, &numbanks);
-
-        if (retries > MAX_RETRIES)
-        {
-            std::cerr << "Failed to get MCA banks with valid status Error :" << ret << std::endl;
-            break;
-        }
-
-        if (numbanks == 0)
-        {
-            std::cerr << "Invalid MCA bank data. Retry Count = " << retries << std::endl;
-            ret = OOB_MAILBOX_ERR;
-            continue;
-        }
-    }
-
-    if (numbanks == 0)
-    {
-        std::cerr << "No Valid MCA bank data " << std::endl;
-        return true;
-    }
-
-    filePath = "/var/lib/amd-ras/ras-error" + std::to_string(err_count) + ".txt";
-    err_count++;
+    uint16_t retryCount = MAX_RETRIES;
 
     file = fopen(filePath.c_str(), "w");
 
     maxOffset32 = ((bytespermca % 4) ? 1 : 0) + (bytespermca >> 2);
-    std::cerr << "Number of Valid MCA bank:" << numbanks << " Bytes per MCA:" << bytespermca << std::endl;
-    std::cerr << "Harvesting RAS Errors ...MAX 32 Bit Words:" << maxOffset32 << std::endl;
+    sd_journal_print(LOG_DEBUG, "Number of Valid MCA bank:%d\n", numbanks);
+    sd_journal_print(LOG_DEBUG, "Number of 32 Bit Words:%d\n", maxOffset32);
+
 
     while(n < numbanks)
     {
@@ -291,12 +323,33 @@ bool harvest_ras_errors(struct i2c_info info,std::string alert_name)
             memset(&mca_dump, 0, sizeof(mca_dump));
             mca_dump.index  = n;
             mca_dump.offset = offset * 4;
+            retryCount = MAX_RETRIES;
 
             ret = read_bmc_ras_mca_msr_dump(info, mca_dump, &buffer);
 
             if (ret != OOB_SUCCESS)
             {
-                std::cerr << "Failed to get MCA bank data from Bank =" << n << "Offset Addr =" << offset << std::endl;
+                // retry
+                while(retryCount > 0)
+                {
+                    memset(&buffer, 0, sizeof(buffer));
+                    memset(&mca_dump, 0, sizeof(mca_dump));
+                    mca_dump.index  = n;
+                    mca_dump.offset = offset * 4;
+
+                    ret = read_bmc_ras_mca_msr_dump(info, mca_dump, &buffer);
+
+                    if (ret == OOB_SUCCESS)
+                    {
+                        break;
+                    }
+                    retryCount--;
+                    usleep(1000 * 1000);
+
+                }
+                if (ret != OOB_SUCCESS)
+                    sd_journal_print(LOG_DEBUG, "Failed to get MCA bank data from Bank:%d, Offset:0x%x\n", n, offset);
+
                 continue;
             }
 
@@ -306,38 +359,107 @@ bool harvest_ras_errors(struct i2c_info info,std::string alert_name)
         fprintf(file, "______________________\n");
         n++;
     }
-    fclose(file);
 
+    fclose(file);
+    return true;
+}
+
+static bool harvest_mca_validity_check(struct i2c_info info, uint16_t *numbanks, uint16_t *bytespermca)
+{
+    oob_status_t ret = OOB_MAILBOX_ERR;
+    uint16_t retries = 0;
+    bool mac_validity_check = true;
+
+    while (ret != OOB_SUCCESS)
+    {
+        retries++;
+
+        ret = read_bmc_ras_mca_validity_check(info, bytespermca, numbanks);
+
+        if (retries > MAX_RETRIES)
+        {
+            sd_journal_print(LOG_ERR, "Failed to get MCA banks with valid status. Error: %d\n", ret);
+            break;
+        }
+
+        if ( (*numbanks == 0) ||
+             (*numbanks > MAX_MCA_BANKS) )
+        {
+            sd_journal_print(LOG_ERR, "Invalid MCA bank validity status. Retry Count: %d\n", retries);
+            ret = OOB_MAILBOX_ERR;
+            usleep(1000 * 1000);
+            continue;
+        }
+    }
+
+
+    if ( (*numbanks <= 0)            ||
+         (*numbanks > MAX_MCA_BANKS) )
+    {
+        mac_validity_check = false;
+
+    }
+
+    return mac_validity_check;
+}
+
+bool harvest_ras_errors(struct i2c_info info,std::string alert_name)
+{
+
+    uint16_t bytespermca = 0;
+    uint16_t numbanks = 0;
+
+    std::string filePath;
+    uint8_t buf;
+    bool ras_harvest = false;
+
+    // Check if APML ALERT is because of RAS
     if (read_sbrmi_ras_status(info, &buf) == OOB_SUCCESS)
     {
+        sd_journal_print(LOG_DEBUG, "Read RAS status register. Value: 0x%x\n", buf);
 
-    	if ((buf & 0x04))
-    	{
-    		setGPIOValue("ASSERT_RST_BTN_L", 0, resetPulseTimeMs);
-    		std::cerr << "ASSERT_RST_BTN_L triggered" << std::endl;
+        // check RAS Status Register
+        if (buf & 0x0F)
+        {
+            sd_journal_print(LOG_DEBUG, "The alert signaled is due to a RAS fatal error\n");
 
-    	}
-    	else {
-    		setGPIOValue("ASSERT_WARM_RST_BTN_L", 0, resetPulseTimeMs);
-    		std::cerr << "ASSERT_WARM_RST_BTN_L triggered" << std::endl;
+            // RAS MCA Validity Check
+            if ( true == harvest_mca_validity_check(info, &numbanks, &bytespermca) )
+            {
+                filePath = "/var/lib/amd-ras/ras-error" + std::to_string(err_count) + ".txt";
+                err_count++;
+                harvest_mca_data_banks(filePath, info, numbanks, bytespermca);
+            }
 
-    	}
+            // Clear RAS status register
+            // 0x4c is a SB-RMI register acting as write to clear
+            // check PPR to determine whether potential bug in PPR or in implementation of SMU?
+            write_register(info, RAS_STATUS_REGISTER, 1);
+
+            // Trigger Cold or WARM reset
+            if ((buf & 0x04))
+            {
+                setGPIOValue("ASSERT_RST_BTN_L", 0, resetPulseTimeMs);
+                sd_journal_print(LOG_DEBUG, "COLD RESET triggered\n");
+
+            }
+            else
+            {
+                setGPIOValue("ASSERT_WARM_RST_BTN_L", 0, resetPulseTimeMs);
+                sd_journal_print(LOG_DEBUG, "WARM RESET triggered\n");
+
+            }
+
+            ras_harvest = true;
+        }
+
+    }
+    else
+    {
+        sd_journal_print(LOG_DEBUG, "Nothing to Harvest. Not RAS Error\n");
     }
 
-
-    if(alert_name.compare("P0_ALERT")   == 0 ) {
-        P0_apmlAlertEvent.release();
-        P0_apmlAlertLine.release();
-        requestGPIOEvents("P0_I3C_APML_ALERT_L", P0_apmlAlertHandler, P0_apmlAlertLine, P0_apmlAlertEvent);
-    }
-
-    if(alert_name.compare("P1_ALERT")   == 0 ) {
-        P1_apmlAlertEvent.release();
-        P1_apmlAlertLine.release();
-        requestGPIOEvents("P1_I3C_APML_ALERT_L", P1_apmlAlertHandler, P1_apmlAlertLine, P1_apmlAlertEvent);
-    }
-
-    return true;
+    return ras_harvest;
 }
 
 int main() {
@@ -348,29 +470,25 @@ int main() {
 
     if(getPlatformID() == false)
     {
-        phosphor::logging::log<phosphor::logging::level::INFO>(
-            "Couldnt find the board id of the platform");
+        sd_journal_print(LOG_ERR, "Could not find the board id of the platform\n");
         return false;
     }
 
     if (stat(ras_dir.c_str(), &buffer) != 0) {
         dir = mkdir("/var/lib/amd-ras",0777);
 
-        if(dir) {
-            phosphor::logging::log<phosphor::logging::level::INFO>
-                ("ras-errror-logging directory not created");
+        if(dir != 0) {
+            sd_journal_print(LOG_ERR, "ras-errror-logging directory not created\n");
         }
     }
 
     conn = std::make_shared<sdbusplus::asio::connection>(io);
 
-    requestGPIOEvents("P0_I3C_APML_ALERT_L", P0_apmlAlertHandler, P0_apmlAlertLine, P0_apmlAlertEvent);
+    requestGPIOEvents("P0_I3C_APML_ALERT_L", P0AlertEventHandler, P0_apmlAlertLine, P0_apmlAlertEvent);
 
-    if( (BoardName.compare("Quartz")   == 0 )  ||
-        (BoardName.compare("Titanite") == 0 ))
+    if (num_of_proc == 2)
     {
-
-        requestGPIOEvents("P1_I3C_APML_ALERT_L", P1_apmlAlertHandler, P1_apmlAlertLine, P1_apmlAlertEvent);
+        requestGPIOEvents("P1_I3C_APML_ALERT_L", P1AlertEventHandler, P1_apmlAlertLine, P1_apmlAlertEvent);
     }
 
     io.run();


### PR DESCRIPTION
Re-organizes the RAS application
   1. Add critical section mutex to process multiple APML alerts which
   differentiates between RAS error and general mailbox completion
   indication.
   2. Most of the function/methods flow has only one exit/return point.
   3. Replace std:cerr with sd_journal_log with right priority (LOG_ERR,
   LOG_DEBUG).
   4. Clear the RAS status register after harvesting RAS error.
   5. Board Id logic simplified.

To-Dos:
   1. Tested only on Onyx. Quartz, Ruby, Titanite (TBD)
   2. Clear RAS status register 0x4c is a SB-RMI register acting as write
   to clear. Check PPR to confirm its write 1 to clear register, otherwise
   its a potential bug in PPR or in implementation of SMU.

Signed-off-by: Supreeth Venkatesh <supreeth.venkatesh@amd.com>