### PR TITLE
Create single CPER file for 2P systems

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -4,9 +4,10 @@
 #define CPER_SIG_SIZE               (4)
 #define CPER_SIG_RECORD             ("CPER")
 #define CPER_RECORD_REV             (0x0100)
+#define SECTION_COUNT               (1)
 #define CPER_SIG_END                (0xffffffff)
 #define CPER_SEV_FATAL              (1)
-#define CTX_TYPE_MSR                (0x02)
+#define CTX_OOB_CRASH               (0x01)
 #define CPER_PRIMARY                (0)
 #define RSVD                        (0)
 #define TBD                         (0)
@@ -30,7 +31,7 @@
 
 #define CPU_ID_VALID                    (0x02)
 #define LOCAL_APIC_ID_VALID             (0x01)
-
+#define PROC_CONTEXT_STRUCT_VALID       (0x100)
 #define INFO_VALID_CHECK_INFO           (0x01)
 
 #define FRU_ID_VALID                    (0x01)
@@ -55,8 +56,8 @@ typedef struct {
     GUID_INIT(0x61fa3fac, 0xcb80, 0x4292, 0x8b, 0xfb, 0xd6, 0x43,   \
           0xb1, 0xde, 0x17, 0xf4)
 #define VENDOR_OOB_CRASHDUMP                    \
-    GUID_INIT(0xbe44d8de, 0xe33b, 0x49f7, 0xb7, 0x0a, 0x1b, 0x07,   \
-          0x07, 0x7e, 0x2e, 0xb4)
+    GUID_INIT(0x32AC0C78, 0x2623, 0x48F6, 0xB0, 0xD0, 0x73, 0x65,   \
+          0x72, 0x5F, 0xD6, 0xAE)
 #define AMD_ERR_STRUCT_TYPE                     \
     GUID_INIT(0xcda04b87, 0x16c8, 0x45c8, 0x8d, 0x2d, 0x08, 0x02,   \
           0x15, 0xb1, 0x0c, 0xe8)
@@ -153,13 +154,20 @@ struct context_info {
 typedef struct context_info CONTEXT_INFO;
 
 struct error_record {
-    COMMON_ERROR_RECORD_HEADER        Header;
-    ERROR_SECTION_DESCRIPTOR          SectionDescriptor;
     PROCESSOR_ERROR_SECTION           ProcError;
     PROCINFO                          ProcessorInfo;
     CONTEXT_INFO                      ContextInfo;
-}  __attribute__((packed));
+} __attribute__((packed));
 
 typedef struct error_record ERROR_RECORD;
+
+struct cper_record {
+    COMMON_ERROR_RECORD_HEADER        Header;
+    ERROR_SECTION_DESCRIPTOR          SectionDescriptor[2];
+    ERROR_RECORD                      P0_ErrorRecord;
+    ERROR_RECORD                      P1_ErrorRecord;
+}  __attribute__((packed));
+
+typedef struct cper_record CPER_RECORD;
 
 #endif


### PR DESCRIPTION
1. Create single CPER file if fatal errors are detected in both the processors of 2P systems
2. Trigger cold reboot when an MP1 error is detected in one of the processor without waiting for the second APML alert in the system.
3. Remove raw crashdump files.

Signed-off-by: Abinaya <abinaya.dhandapani@amd.com>