### PR TITLE
Create single CPER file for 2P systems

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -4,9 +4,10 @@
 #define CPER_SIG_SIZE               (4)
 #define CPER_SIG_RECORD             ("CPER")
 #define CPER_RECORD_REV             (0x0100)
+#define SECTION_COUNT               (1)
 #define CPER_SIG_END                (0xffffffff)
 #define CPER_SEV_FATAL              (1)
-#define CTX_TYPE_MSR                (0x02)
+#define CTX_OOB_CRASH               (0x01)
 #define CPER_PRIMARY                (0)
 #define RSVD                        (0)
 #define TBD                         (0)
@@ -30,7 +31,7 @@
 
 #define CPU_ID_VALID                    (0x02)
 #define LOCAL_APIC_ID_VALID             (0x01)
-
+#define PROC_CONTEXT_STRUCT_VALID       (0x100)
 #define INFO_VALID_CHECK_INFO           (0x01)
 
 #define FRU_ID_VALID                    (0x01)
@@ -55,8 +56,8 @@ typedef struct {
     GUID_INIT(0x61fa3fac, 0xcb80, 0x4292, 0x8b, 0xfb, 0xd6, 0x43,   \
           0xb1, 0xde, 0x17, 0xf4)
 #define VENDOR_OOB_CRASHDUMP                    \
-    GUID_INIT(0xbe44d8de, 0xe33b, 0x49f7, 0xb7, 0x0a, 0x1b, 0x07,   \
-          0x07, 0x7e, 0x2e, 0xb4)
+    GUID_INIT(0x32AC0C78, 0x2623, 0x48F6, 0xB0, 0xD0, 0x73, 0x65,   \
+          0x72, 0x5F, 0xD6, 0xAE)
 #define AMD_ERR_STRUCT_TYPE                     \
     GUID_INIT(0xcda04b87, 0x16c8, 0x45c8, 0x8d, 0x2d, 0x08, 0x02,   \
           0x15, 0xb1, 0x0c, 0xe8)
@@ -153,13 +154,20 @@ struct context_info {
 typedef struct context_info CONTEXT_INFO;
 
 struct error_record {
-    COMMON_ERROR_RECORD_HEADER        Header;
-    ERROR_SECTION_DESCRIPTOR          SectionDescriptor;
     PROCESSOR_ERROR_SECTION           ProcError;
     PROCINFO                          ProcessorInfo;
     CONTEXT_INFO                      ContextInfo;
-}  __attribute__((packed));
+} __attribute__((packed));
 
 typedef struct error_record ERROR_RECORD;
+
+struct cper_record {
+    COMMON_ERROR_RECORD_HEADER        Header;
+    ERROR_SECTION_DESCRIPTOR          SectionDescriptor[2];
+    ERROR_RECORD                      P0_ErrorRecord;
+    ERROR_RECORD                      P1_ErrorRecord;
+}  __attribute__((packed));
+
+typedef struct cper_record CPER_RECORD;
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,15 +87,15 @@ constexpr auto TITANITE_6   = 78;   //0x4E
 
 std::mutex harvest_in_progress_mtx;           // mutex for critical section
 
-static bool P0_MCADataHarvested = false;
-static bool P1_MCADataHarvested = false;
+static bool P0_AlertProcessed = false;
+static bool P1_AlertProcessed = false;
 
 static uint64_t RecordId = 1;
 unsigned int board_id = 0;
 static uint32_t p0_eax , p0_ebx , p0_ecx , p0_edx;
 static uint32_t p1_eax , p1_ebx , p1_ecx , p1_edx;
 
-bool harvest_ras_errors(uint8_t info,std::string alert_name);
+bool harvest_ras_errors(uint8_t info,std::string alert_name,CPER_RECORD *rcd);
 
 bool getPlatformID()
 {
@@ -290,8 +290,14 @@ static void P0AlertEventHandler()
     {
         sd_journal_print(LOG_DEBUG, "Falling Edge: P0 APML Alert received\n");
 
+        CPER_RECORD *rcd;
+        if( rcd == NULL)
+        {
+            rcd = (CPER_RECORD *)malloc(sizeof(CPER_RECORD));
+        }
+
         harvest_in_progress_mtx.lock();
-        harvest_ras_errors(p0_info,"P0_ALERT");
+        harvest_ras_errors(p0_info,"P0_ALERT",rcd);
         harvest_in_progress_mtx.unlock();
 
     }
@@ -319,8 +325,15 @@ static void P1AlertEventHandler()
     if (gpioLineEvent.event_type == gpiod::line_event::FALLING_EDGE)
     {
         sd_journal_print(LOG_DEBUG, "Falling Edge: P1 APML Alert received\n");
+
+        CPER_RECORD *rcd;
+        if( rcd == NULL)
+        {
+            rcd = (CPER_RECORD *)malloc(sizeof(CPER_RECORD));
+        }
+
         harvest_in_progress_mtx.lock();
-        harvest_ras_errors(p1_info,"P1_ALERT");
+        harvest_ras_errors(p1_info,"P1_ALERT",rcd);
         harvest_in_progress_mtx.unlock();
     }
     else if (gpioLineEvent.event_type == gpiod::line_event::RISING_EDGE)
@@ -351,7 +364,7 @@ static void write_register(uint8_t info, uint32_t reg, uint32_t value)
     sd_journal_print(LOG_DEBUG, "Write to register 0x%x is successful\n", reg);
 }
 
-void calculate_time_stamp(ERROR_RECORD *rcd)
+void calculate_time_stamp(CPER_RECORD *rcd)
 {
     using namespace std;
     using namespace std::chrono;
@@ -383,12 +396,12 @@ void calculate_time_stamp(ERROR_RECORD *rcd)
     rcd->Header.TimeStamp.Year = rcd->Header.TimeStamp.Year % 100;
 }
 
-void dump_cper_header_section(ERROR_RECORD *rcd ,uint16_t numbanks, uint16_t bytespermca)
+void dump_cper_header_section(CPER_RECORD *rcd ,uint16_t numbanks, uint16_t bytespermca)
 {
     memcpy(rcd->Header.Signature, CPER_SIG_RECORD, CPER_SIG_SIZE);
     rcd->Header.Revision = CPER_RECORD_REV;
     rcd->Header.SignatureEnd = CPER_SIG_END;
-    rcd->Header.SectionCount = 1;
+    rcd->Header.SectionCount = SECTION_COUNT;
     rcd->Header.ErrorSeverity = CPER_SEV_FATAL;
 
     /*Bit 0 = 1 -> PlatformID field contains valid info
@@ -397,7 +410,7 @@ void dump_cper_header_section(ERROR_RECORD *rcd ,uint16_t numbanks, uint16_t byt
 
     rcd->Header.ValidationBits = (CPER_VALID_PLATFORM_ID | CPER_VALID_TIMESTAMP);
 
-    rcd->Header.RecordLength = sizeof(ERROR_RECORD) + (numbanks * bytespermca);
+    rcd->Header.RecordLength = sizeof(CPER_RECORD);
 
     calculate_time_stamp(rcd);
 
@@ -409,100 +422,82 @@ void dump_cper_header_section(ERROR_RECORD *rcd ,uint16_t numbanks, uint16_t byt
     rcd->Header.RecordId = RecordId++;
 }
 
-void dump_error_descriptor_section(ERROR_RECORD *rcd, uint16_t numbanks, uint16_t bytespermca)
+void dump_error_descriptor_section(CPER_RECORD *rcd, uint16_t numbanks, uint16_t bytespermca,uint8_t info)
 {
 
-    rcd->SectionDescriptor.SectionOffset = sizeof(COMMON_ERROR_RECORD_HEADER) +
-                                           sizeof(ERROR_SECTION_DESCRIPTOR);
-
-    rcd->SectionDescriptor.SectionLength = sizeof(PROCESSOR_ERROR_SECTION) +
-                                           sizeof(PROCINFO) + sizeof(CONTEXT_INFO);
-
-    rcd->SectionDescriptor.Revision = CPER_SEC_REV;
-    /* fru_id and fru_text is invalid */
-    /* Bit 0 - the FRUId field contains valid information
-       Bit 1 - the FRUString field contains valid information*/
-	rcd->SectionDescriptor.SecValidMask = FRU_ID_VALID | FRU_TEXT_VALID;
-
-    rcd->SectionDescriptor.SectionFlags = CPER_PRIMARY;
-
-    rcd->SectionDescriptor.SectionType = VENDOR_OOB_CRASHDUMP;
-
-    rcd->SectionDescriptor.Severity = CPER_SEV_FATAL;
+    rcd->SectionDescriptor[0].SectionOffset = sizeof(COMMON_ERROR_RECORD_HEADER) +
+                              (2 * sizeof(ERROR_SECTION_DESCRIPTOR));
+    rcd->SectionDescriptor[0].SectionLength = sizeof(ERROR_RECORD);
+    rcd->SectionDescriptor[0].Revision = CPER_SEC_REV;
+    rcd->SectionDescriptor[0].SecValidMask = FRU_ID_VALID | FRU_TEXT_VALID;
+    rcd->SectionDescriptor[0].SectionFlags = CPER_PRIMARY;
+    rcd->SectionDescriptor[0].SectionType = VENDOR_OOB_CRASHDUMP;
+    rcd->SectionDescriptor[0].Severity = CPER_SEV_FATAL;
+    rcd->SectionDescriptor[0].FRUText[0] = 'P';
+    rcd->SectionDescriptor[0].FRUText[1] = '0';
 
 
-    if(P0_MCADataHarvested == true)
-    {
-
-        rcd->SectionDescriptor.FRUText[0] = 'P';
-        rcd->SectionDescriptor.FRUText[1] = '0';
-
-    } else if(P1_MCADataHarvested == true)
-    {
-
-        rcd->SectionDescriptor.FRUText[0] = 'P';
-        rcd->SectionDescriptor.FRUText[1] = '1';
-
-    }
+    rcd->SectionDescriptor[1].SectionOffset = sizeof(COMMON_ERROR_RECORD_HEADER) +
+                             (2 * sizeof(ERROR_SECTION_DESCRIPTOR)) + sizeof(ERROR_RECORD);
+    rcd->SectionDescriptor[1].SectionLength = sizeof(ERROR_RECORD);
+    rcd->SectionDescriptor[1].Revision = CPER_SEC_REV;
+    rcd->SectionDescriptor[1].SecValidMask = FRU_ID_VALID | FRU_TEXT_VALID;
+    rcd->SectionDescriptor[1].SectionFlags = CPER_PRIMARY;
+    rcd->SectionDescriptor[1].SectionType = VENDOR_OOB_CRASHDUMP;
+    rcd->SectionDescriptor[1].Severity = CPER_SEV_FATAL;
+    rcd->SectionDescriptor[1].FRUText[0] = 'P';
+    rcd->SectionDescriptor[1].FRUText[1] = '1';
 }
 
-void dump_processor_error_section(ERROR_RECORD *rcd,uint8_t info)
+void dump_processor_error_section(CPER_RECORD *rcd,uint8_t info)
 {
 
-    rcd->ProcError.ValidBits = CPU_ID_VALID | LOCAL_APIC_ID_VALID;
+    rcd->P0_ErrorRecord.ProcError.ValidBits = CPU_ID_VALID |
+              LOCAL_APIC_ID_VALID | PROC_CONTEXT_STRUCT_VALID;
+    rcd->P0_ErrorRecord.ProcError.CpuId[0] = p0_eax;
+    rcd->P0_ErrorRecord.ProcError.CpuId[1] = p0_ebx;
+    rcd->P0_ErrorRecord.ProcError.CpuId[2] = p0_ecx;
+    rcd->P0_ErrorRecord.ProcError.CpuId[3] = p0_edx;
+    rcd->P0_ErrorRecord.ProcError.CPUAPICId = ((p0_ebx >> SHIFT_24) & 0xff);
+
+    if(num_of_proc == TWO_SOCKET)
+    {
+        rcd->P1_ErrorRecord.ProcError.ValidBits = CPU_ID_VALID |
+                  LOCAL_APIC_ID_VALID | PROC_CONTEXT_STRUCT_VALID;
+        rcd->P1_ErrorRecord.ProcError.CpuId[0] = p1_eax;
+        rcd->P1_ErrorRecord.ProcError.CpuId[1] = p1_ebx;
+        rcd->P1_ErrorRecord.ProcError.CpuId[2] = p1_ecx;
+        rcd->P1_ErrorRecord.ProcError.CpuId[3] = p1_edx;
+        rcd->P1_ErrorRecord.ProcError.CPUAPICId = ((p1_ebx >> SHIFT_24) & 0xff);
+    }
+
+   if(info == p0_info)
+   {
+       rcd->P0_ErrorRecord.ProcError.ValidBits |= PROC_CONTEXT_STRUCT_VALID;
+   }
+   if(info == p1_info)
+   {
+       rcd->P1_ErrorRecord.ProcError.ValidBits |= PROC_CONTEXT_STRUCT_VALID;
+   }
+}
+
+void dump_context_info(CPER_RECORD *rcd,uint16_t numbanks,uint16_t bytespermca,uint8_t info)
+{
 
     if(info == p0_info)
     {
-        rcd->ProcError.CpuId[0] = p0_eax;
-        rcd->ProcError.CpuId[1] = p0_ebx;
-        rcd->ProcError.CpuId[2] = p0_ecx;
-        rcd->ProcError.CpuId[3] = p0_edx;
-        rcd->ProcError.CPUAPICId = ((p0_ebx >> SHIFT_24) & 0xff);
+        rcd->P0_ErrorRecord.ContextInfo.RegisterContextType = CTX_OOB_CRASH;
+        rcd->P0_ErrorRecord.ContextInfo.RegisterArraySize = numbanks * bytespermca;
     }
     else if(info == p1_info)
     {
-        rcd->ProcError.CpuId[0] = p1_eax;
-        rcd->ProcError.CpuId[1] = p1_ebx;
-        rcd->ProcError.CpuId[2] = p1_ecx;
-        rcd->ProcError.CpuId[3] = p1_edx;
-        rcd->ProcError.CPUAPICId = ((p1_ebx >> SHIFT_24) & 0xff);
+        rcd->P1_ErrorRecord.ContextInfo.RegisterContextType = CTX_OOB_CRASH;
+        rcd->P1_ErrorRecord.ContextInfo.RegisterArraySize = numbanks * bytespermca;
     }
-
 }
 
-void dump_processor_info(ERROR_RECORD *rcd)
-{
-    /*AMD Vendor specific GUID for Crashdump error structure*/
-    rcd->ProcessorInfo.ErrorStructureType = AMD_ERR_STRUCT_TYPE;
-
-    /*Bit 0 – Check Info Valid
-      Bit 1 – Target Address Identifier Valid
-      Bit 2 – Requestor Identifier Valid
-      Bit 3 – Responder Identifier Valid
-      Bit 4 – Instruction Pointer Valid
-      Bits 5-63 – Reserved*/
-
-    rcd->ProcessorInfo.ValidBits = INFO_VALID_CHECK_INFO;
-
-    /*valid bits for each Raw crashdump section/mailbox cmd*/
-    rcd->ProcessorInfo.CheckInfo = RSVD;
-
-    rcd->ProcessorInfo.TargetId = RSVD;
-    rcd->ProcessorInfo.RequesterId = RSVD;
-    rcd->ProcessorInfo.ResponderId = RSVD;
-    rcd->ProcessorInfo.InstructionPointer = TBD;
-}
-
-void dump_context_info(ERROR_RECORD *rcd,uint16_t numbanks,uint16_t bytespermca)
-{
-    rcd->ContextInfo.RegisterContextType = CTX_TYPE_MSR;
-    rcd->ContextInfo.RegisterArraySize = numbanks * bytespermca;
-    rcd->ContextInfo.MSRAddress = RSVD;
-    rcd->ContextInfo.MmRegisterAddress = RSVD;
-}
-
-static bool harvest_mca_data_banks(std::string cperFilePath,
-            std::string rawFilePath ,uint8_t info, uint16_t numbanks, uint16_t bytespermca)
+static bool harvest_mca_data_banks(CPER_RECORD *rcd ,
+                          uint8_t info, uint16_t numbanks, uint16_t bytespermca)
 {
     FILE *file;
     uint16_t n = 0;
@@ -512,21 +507,15 @@ static bool harvest_mca_data_banks(std::string cperFilePath,
     oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
     uint16_t retryCount = MAX_RETRIES;
 
-    ERROR_RECORD  *rcd =  (ERROR_RECORD *)malloc(sizeof(ERROR_RECORD));
-
     memset(rcd, 0, sizeof(*rcd));
 
     dump_cper_header_section(rcd,numbanks,bytespermca);
 
-    dump_error_descriptor_section(rcd,numbanks,bytespermca);
+    dump_error_descriptor_section(rcd,numbanks,bytespermca,info);
 
     dump_processor_error_section(rcd,info);
 
-    dump_processor_info(rcd);
-
-    dump_context_info(rcd,numbanks,bytespermca);
-
-    file = fopen(rawFilePath.c_str(), "w");
+    dump_context_info(rcd,numbanks,bytespermca,info);
 
     maxOffset32 = ((bytespermca % 4) ? 1 : 0) + (bytespermca >> 2);
     sd_journal_print(LOG_DEBUG, "Number of Valid MCA bank:%d\n", numbanks);
@@ -535,8 +524,6 @@ static bool harvest_mca_data_banks(std::string cperFilePath,
 
     while(n < numbanks)
     {
-        fprintf(file, "Valid MCA bank entry: 0x%x\n", n);
-
         for (int offset = 0; offset < maxOffset32; offset++)
         {
             memset(&buffer, 0, sizeof(buffer));
@@ -570,33 +557,26 @@ static bool harvest_mca_data_banks(std::string cperFilePath,
                 if (ret != OOB_SUCCESS)
                 {
                     sd_journal_print(LOG_DEBUG, "Failed to get MCA bank data from Bank:%d, Offset:0x%x\n", n, offset);
-                    fprintf(file, "Offset: 0x%x\n", mca_dump.offset);
-                    fprintf(file, "buffer: 0x%x\n", BAD_DATA);
-                    rcd->ContextInfo.CrashDumpData[n].mca_data[offset] = BAD_DATA;
+                    if(info == p0_info) {
+                        rcd->P0_ErrorRecord.ContextInfo.CrashDumpData[n].mca_data[offset] = BAD_DATA;
+                    } else if(info == p1_info) {
+                       rcd->P1_ErrorRecord.ContextInfo.CrashDumpData[n].mca_data[offset] = BAD_DATA;
+                    }
                     continue;
                 }
 
             } // if (ret != OOB_SUCCESS)
 
-            fprintf(file, "Offset: 0x%x\n", mca_dump.offset);
-            fprintf(file, "buffer: 0x%x\n", buffer);
-            rcd->ContextInfo.CrashDumpData[n].mca_data[offset] = buffer;
+            if(info == p0_info) {
+                rcd->P0_ErrorRecord.ContextInfo.CrashDumpData[n].mca_data[offset] = buffer;
+            } else if(info == p1_info) {
+                rcd->P1_ErrorRecord.ContextInfo.CrashDumpData[n].mca_data[offset] = buffer;
+            }
         } // for loop
 
-        fprintf(file, "______________________\n");
         n++;
     }
-    fclose(file);
 
-    file = fopen(cperFilePath.c_str(), "w");
-    fwrite(rcd, sizeof(ERROR_RECORD), 1, file);
-    fclose(file);
-
-    if(rcd != NULL)
-    {
-        free(rcd);
-        rcd =  NULL;
-    }
     return true;
 }
 
@@ -639,13 +619,12 @@ static bool harvest_mca_validity_check(uint8_t info, uint16_t *numbanks, uint16_
     return mac_validity_check;
 }
 
-bool harvest_ras_errors(uint8_t info,std::string alert_name)
+bool harvest_ras_errors(uint8_t info,std::string alert_name,CPER_RECORD *rcd)
 {
 
     uint16_t bytespermca = 0;
     uint16_t numbanks = 0;
 
-    std::string cperFilePath,rawFilePath;
     uint8_t buf;
     bool ResetReady  = false;
     FILE *file;
@@ -660,41 +639,49 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
         {
             sd_journal_print(LOG_DEBUG, "The alert signaled is due to a RAS fatal error\n");
 
-            std::string ras_err_msg = "RAS FATAL Error detected. System will reset after harvesting MCA data";
-
-            sd_journal_send("MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i",
-                LOG_ERR, "REDFISH_MESSAGE_ID=%s",
-                "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
-                ras_err_msg.c_str(), NULL);
-
-            if(alert_name.compare("P0_ALERT") == 0 )
+            if (buf & 0x04)
             {
-                P0_MCADataHarvested = true;
+                /*if RasStatus[reset_ctrl_err] is set in any of the processors,
+                  proceed to cold reset, regardless of the status of the other P */
+                std::string ras_err_msg = "Fatal error detected in the control fabric. "
+                                           "BMC will trigger a cold reset";
+
+                sd_journal_send("MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i",
+                    LOG_ERR, "REDFISH_MESSAGE_ID=%s",
+                    "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
+                    ras_err_msg.c_str(), NULL);
+
+                P0_AlertProcessed = true;
+                P1_AlertProcessed = true;
 
             }
-
-            if(alert_name.compare("P1_ALERT") == 0 )
+            else
             {
-                P1_MCADataHarvested = true;
+                std::string ras_err_msg = "RAS FATAL Error detected. "
+                                          "System will reset after harvesting MCA data";
 
+                sd_journal_send("MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i",
+                    LOG_ERR, "REDFISH_MESSAGE_ID=%s",
+                    "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
+                    ras_err_msg.c_str(), NULL);
+
+                if(alert_name.compare("P0_ALERT") == 0 )
+                {
+                    P0_AlertProcessed = true;
+
+                }
+
+                if(alert_name.compare("P1_ALERT") == 0 )
+                {
+                    P1_AlertProcessed = true;
+
+                }
             }
-
-            // RAS MCA Validity Check
+                // RAS MCA Validity Check
             if ( true == harvest_mca_validity_check(info, &numbanks, &bytespermca) )
             {
-                rawFilePath = "/var/lib/amd-ras/ras-error" + std::to_string(err_count) + ".txt";
-                cperFilePath = "/var/lib/amd-ras/ras-error" + std::to_string(err_count) + ".cper";
 
-                harvest_mca_data_banks(cperFilePath, rawFilePath, info, numbanks, bytespermca);
-                err_count++;
-
-                file = fopen(index_file, "w");
-
-                if(file != NULL)
-                {
-                    fprintf(file,"%d",err_count);
-                    fclose(file);
-                }
+                harvest_mca_data_banks(rcd, info, numbanks, bytespermca);
 
             }
 
@@ -705,8 +692,8 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
 
             if (num_of_proc == TWO_SOCKET)
             {
-                if ( (P0_MCADataHarvested == true) &&
-                     (P1_MCADataHarvested == true) )
+                if ( (P0_AlertProcessed == true) &&
+                     (P1_AlertProcessed == true) )
                 {
                     ResetReady = true;
                 }
@@ -718,6 +705,32 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
 
             if (ResetReady == true)
             {
+
+                std::string cperFilePath = "/var/lib/amd-ras/ras-error" + std::to_string(err_count) + ".cper";
+                err_count++;
+
+                file = fopen(index_file, "w");
+
+                if(file != NULL)
+                {
+                    fprintf(file,"%d",err_count);
+                    fclose(file);
+                }
+
+                file = fopen(cperFilePath.c_str(), "w");
+                if((rcd != NULL) && (file != NULL))
+                {
+                    sd_journal_print(LOG_DEBUG, "Generating CPER file\n");
+                    fwrite(rcd, sizeof(CPER_RECORD), 1, file);
+                    fclose(file);
+                }
+
+                if(rcd != NULL)
+                {
+                    free(rcd);
+                    rcd =  NULL;
+                }
+
                 FILE* fp = fopen(config_file, "r");
 
                 char * line = NULL;
@@ -763,8 +776,8 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
                 }
                 fclose(fp);
 
-                P0_MCADataHarvested = false;
-                P1_MCADataHarvested = false;
+                P0_AlertProcessed = false;
+                P1_AlertProcessed = false;
 
             }
         }
@@ -831,7 +844,7 @@ int main() {
             fprintf(file,"# 0 ---> warm\n");
             fprintf(file,"# 1 ---> cold\n");
             fprintf(file,"# 2 ---> no reset\n");
-            fprintf(file,"0");
+            fprintf(file,"2");
             fclose(file);
         }
     }


### PR DESCRIPTION
1. Create single CPER file if fatal errors are detected in both the processors of 2P systems
2. Trigger cold reboot when an MP1 error is detected in one of the processor without waiting for the second APML alert in the system.
3. Remove raw crashdump files.
4. Change default policy as "NO Reset" in the config file

Signed-off-by: Abinaya <abinaya.dhandapani@amd.com>