### PR TITLE
amd-ras: Add range check for DBus array

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -940,6 +940,16 @@ void exportCrashdumpToDBus(int num) {
         sd_journal_print(LOG_ERR, "Broken crashdump data\n");
         return;
     }
+    if (num < 0 || num >= MAX_ERROR_FILE) {
+        sd_journal_print(LOG_ERR, "Crashdump only allows index 0~9\n");
+        return;
+    }
+
+    // remove the interface if it exists
+    if (crashdumpInterfaces[num].second != nullptr) {
+        server->remove_interface(crashdumpInterfaces[num].second);
+        crashdumpInterfaces[num].second.reset();
+    }
 
     const std::string filename = getCperFilename(num);
     const std::string fullFilePath = kRasDir.data() + filename;


### PR DESCRIPTION
Supposedly CPER file number is between 0 to 9, but it still worth to
have a range check in case unexpected number appears.
When CPER files is up to 10, the counter will be rotated to 0. In this
case the old CPER file will be overwritten, so corresponding DBus needs
to be overwritten too.

Signed-off-by: Michael Shen <gpgpgp@google.com>
Change-Id: I01845e51977b57ce485b0e0aaf38c37b2e015475