### PR TITLE
Harvest last transaction address

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -13,8 +13,11 @@
 #define GENOA_MCA_BANKS             (32)
 #define MCA_BANK_MAX_OFFSET         (128)
 #define SYS_MGMT_CTRL_ERR           (0x04)
-#define DF_DUMP_RESERVED            (6143)
+#define DF_DUMP_RESERVED            (6128)
 #define MAX_ERROR_FILE              (10)
+#define LAST_TRANS_ADDR_OFFSET      (4)
+#define CCM_COUNT                   (8)
+
 /*
  * CPER section header revision, used in revision field in struct
  * cper_section_descriptor
@@ -64,6 +67,10 @@ typedef struct {
 typedef struct {
   uint32_t mca_data[MCA_BANK_MAX_OFFSET];
 } CRASHDUMP_T;
+
+typedef struct {
+  uint32_t WdtData[LAST_TRANS_ADDR_OFFSET];
+} LAST_TRANS_ADDR;
 
 struct error_time_stamp {
   uint8_t    Seconds;
@@ -135,8 +142,7 @@ struct proc_info {
 typedef struct proc_info PROCINFO;
 
 struct df_dump {
-  uint32_t                           dfwdtdump_low;
-  uint32_t                           dfwdtdump_high;
+  LAST_TRANS_ADDR                    LastTransAddr[CCM_COUNT];
   uint64_t                           reserved[DF_DUMP_RESERVED];
 }  __attribute__((packed));
 
@@ -148,7 +154,7 @@ struct context_info {
   uint32_t                           MSRAddress;
   uint64_t                           MmRegisterAddress;
   CRASHDUMP_T                        CrashDumpData[GENOA_MCA_BANKS];
-  DF_DUMP                            dfdumpdata;
+  DF_DUMP                            DfDumpData;
 } __attribute__((packed));
 
 typedef struct context_info CONTEXT_INFO;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@ extern "C" {
 #include "esmi_cpuid_msr.h"
 #include "esmi_mailbox.h"
 #include "esmi_rmi.h"
+#include "esmi_mailbox_nda.h"
 }
 
 #define COMMAND_BOARD_ID    ("/sbin/fw_printenv -n board_id")
@@ -250,27 +251,74 @@ void getCpuID()
 
 }
 
-void getLastTransAddr()
+void getLastTransAddr(uint8_t info)
 {
     oob_status_t ret;
+    uint8_t blk_id = 0;
+    uint16_t n = 0;
+    uint16_t maxOffset32;
+    uint32_t data;
+    struct ras_df_err_chk err_chk;
+    union ras_df_err_dump df_err = {0};
 
-    ret = read_ras_last_transaction_address(p0_info, &p0_last_transact_addr);
-    if (ret) {
-        sd_journal_print(LOG_ERR, "Failed to get the last transaction address for socket 0\n");
-    }
+    ret = read_ras_df_err_validity_check(info, blk_id, &err_chk);
 
-    if(num_of_proc == TWO_SOCKET)
+    if (ret)
     {
-        ret = read_ras_last_transaction_address(p1_info, &p1_last_transact_addr);
-        if (ret) {
-            sd_journal_print(LOG_ERR, "Failed to get the last transaction address for socket 1\n");
+        sd_journal_print(LOG_ERR, "Failed to read RAS DF validity check\n");
+    }
+    else
+    {
+        if(err_chk.df_block_instances != 0)
+        {
+            maxOffset32 = ((err_chk.err_log_len % 4) ? 1 : 0) + (err_chk.err_log_len >> 2);
+            while(n < err_chk.df_block_instances)
+            {
+                for (int offset = 0; offset < maxOffset32; offset++)
+                {
+                    memset(&data, 0, sizeof(data));
+                    /* Offset */
+                    df_err.input[0] = offset * 4;
+                    /* DF block ID */
+                    df_err.input[1] = blk_id;
+                    /* DF block ID instance */
+                    df_err.input[2] = n;
+
+                    ret = read_ras_df_err_dump(info, df_err, &data);
+
+                    if(info == p0_info) {
+                        rcd->P0_ErrorRecord.ContextInfo.DfDumpData.LastTransAddr[n].WdtData[offset] = data;
+                    } else if(info == p1_info) {
+                        rcd->P1_ErrorRecord.ContextInfo.DfDumpData.LastTransAddr[n].WdtData[offset] = data;
+                    }
+                }
+                n++;
+            }
         }
     }
-    sd_journal_print(LOG_DEBUG, "Last trancation address for P0 = %llu\n",p0_last_transact_addr);
-    sd_journal_print(LOG_DEBUG, "Last trancation address for P1 = %llu\n",p1_last_transact_addr);
-
 }
 
+void triggerColdReset()
+{
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+    boost::system::error_code ec;
+    boost::asio::io_context io;
+    auto conn = std::make_shared<sdbusplus::asio::connection>(io);
+    std::string command = "xyz.openbmc_project.State.Host.Transition.Reboot";
+
+    conn->async_method_call(
+        [](boost::system::error_code ec) {
+            if (ec)
+            {
+                sd_journal_print(LOG_ERR, "Failed to trigger cold reset of the system\n");
+            }
+        },
+        "xyz.openbmc_project.State.Host",
+        "/xyz/openbmc_project/state/host0",
+        "org.freedesktop.DBus.Properties", "Set",
+        "xyz.openbmc_project.State.Host", "RequestedHostTransition",
+        std::variant<std::string>{command});
+}
 
 inline std::string getCperFilename(int num) {
     return "ras-error" + std::to_string(num) + ".cper";
@@ -701,20 +749,16 @@ void dump_processor_error_section(uint8_t info)
 
 void dump_context_info(uint16_t numbanks,uint16_t bytespermca,uint8_t info)
 {
-    getLastTransAddr();
+    getLastTransAddr(info);
     if(info == p0_info)
     {
         rcd->P0_ErrorRecord.ContextInfo.RegisterContextType = CTX_OOB_CRASH;
         rcd->P0_ErrorRecord.ContextInfo.RegisterArraySize = numbanks * bytespermca;
-        rcd->P0_ErrorRecord.ContextInfo.dfdumpdata.dfwdtdump_low = p0_last_transact_addr & FOUR_BYTE_MASK;
-        rcd->P0_ErrorRecord.ContextInfo.dfdumpdata.dfwdtdump_high = (p0_last_transact_addr >> SHIFT_32 ) & FOUR_BYTE_MASK;
     }
     else if(info == p1_info)
     {
         rcd->P1_ErrorRecord.ContextInfo.RegisterContextType = CTX_OOB_CRASH;
         rcd->P1_ErrorRecord.ContextInfo.RegisterArraySize = numbanks * bytespermca;
-        rcd->P1_ErrorRecord.ContextInfo.dfdumpdata.dfwdtdump_low = p1_last_transact_addr & FOUR_BYTE_MASK;
-        rcd->P1_ErrorRecord.ContextInfo.dfdumpdata.dfwdtdump_high = (p1_last_transact_addr >> SHIFT_32 ) & FOUR_BYTE_MASK;
     }
 }
 
@@ -801,7 +845,7 @@ static bool harvest_mca_data_banks(uint8_t info, uint16_t numbanks, uint16_t byt
                 }
                 if (ret != OOB_SUCCESS)
                 {
-                    sd_journal_print(LOG_ERR, "Failed to get MCA bank data from Bank:%d, Offset:0x%x\n", n, offset);
+                    sd_journal_print(LOG_ERR, "Socket %d : Failed to get MCA bank data from Bank:%d, Offset:0x%x\n", info, n, offset);
                     if(info == p0_info) {
                         rcd->P0_ErrorRecord.ContextInfo.CrashDumpData[n].mca_data[offset] = BAD_DATA;
                     } else if(info == p1_info) {
@@ -870,6 +914,7 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
 
     uint16_t bytespermca = 0;
     uint16_t numbanks = 0;
+    bool ControlFabricError = false;
 
     uint8_t buf;
     bool ResetReady  = false;
@@ -899,6 +944,7 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
 
                 P0_AlertProcessed = true;
                 P1_AlertProcessed = true;
+                ControlFabricError = true;
 
             }
             else
@@ -923,12 +969,17 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
 
                 }
             }
-                // RAS MCA Validity Check
-            if ( true == harvest_mca_validity_check(info, &numbanks, &bytespermca) )
+
+            //Do not harvest MCA banks in case of control fabric errors
+            if(ControlFabricError == false)
             {
+                // RAS MCA Validity Check
+                if ( true == harvest_mca_validity_check(info, &numbanks, &bytespermca) )
+                {
 
-                harvest_mca_data_banks(info, numbanks, bytespermca);
+                    harvest_mca_data_banks(info, numbanks, bytespermca);
 
+                }
             }
 
             // Clear RAS status register
@@ -951,30 +1002,34 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
 
             if (ResetReady == true)
             {
-                std::string cperFilePath =
-                    kRasDir.data() + getCperFilename(err_count);
-                err_count++;
 
-                if(err_count >= MAX_ERROR_FILE)
+                if(ControlFabricError == false)
                 {
-                    /*The maximum number of error files supported is 10.
-                      The counter will be rotated once it reaches max count*/
-                    err_count = (err_count % MAX_ERROR_FILE);
-                }
+                    std::string cperFilePath =
+                        kRasDir.data() + getCperFilename(err_count);
+                    err_count++;
 
-                file = fopen(index_file, "w");
+                    if(err_count >= MAX_ERROR_FILE)
+                    {
+                        /*The maximum number of error files supported is 10.
+                          The counter will be rotated once it reaches max count*/
+                        err_count = (err_count % MAX_ERROR_FILE);
+                    }
 
-                if(file != NULL)
-                {
-                    fprintf(file,"%d",err_count);
-                    fclose(file);
-                }
+                    file = fopen(index_file, "w");
 
-                file = fopen(cperFilePath.c_str(), "w");
-                if ((rcd != nullptr) && (file != NULL)) {
-                    sd_journal_print(LOG_DEBUG, "Generating CPER file\n");
-                    fwrite(rcd.get(), sizeof(CPER_RECORD), 1, file);
-                    fclose(file);
+                    if(file != NULL)
+                    {
+                        fprintf(file,"%d",err_count);
+                        fclose(file);
+                    }
+
+                    file = fopen(cperFilePath.c_str(), "w");
+                    if ((rcd != nullptr) && (file != NULL)) {
+                        sd_journal_print(LOG_DEBUG, "Generating CPER file\n");
+                        fwrite(rcd.get(), sizeof(CPER_RECORD), 1, file);
+                        fclose(file);
+                    }
                 }
 
                 rcd = nullptr;
@@ -995,7 +1050,7 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
                         {
                             if ((buf & SYS_MGMT_CTRL_ERR))
                             {
-                                setGPIOValue("ASSERT_RST_BTN_L", 0, resetPulseTimeMs);
+                                triggerColdReset();
                                 sd_journal_print(LOG_INFO, "COLD RESET triggered\n");
 
                             } else {
@@ -1008,7 +1063,7 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
                         else if(*line == COLD_RESET)
                         {
 
-                            setGPIOValue("ASSERT_RST_BTN_L", 0, resetPulseTimeMs);
+                            triggerColdReset();
                             sd_journal_print(LOG_INFO, "COLD RESET triggered\n");
 
                         }


### PR DESCRIPTION
1. Harvest last transaction address for 8 CCM's
2. Remove direct toggling of GPIO for cold reset and replace it with dbus cold reset routine
3. Remove harvesting of MCA banks for errors in control fabric
4. Add performance metrics into the journalctrl log

Signed-off-by: Abinaya <abinaya.dhandapani@amd.com>