### PR TITLE
amd-bmc-ras: Fix FPGA lockout error message

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -612,7 +612,7 @@ static void HPMFPGALockoutEventHandler()
             [](const boost::system::error_code ec) {
         if (ec)
         {
-            sd_journal_print(LOG_ERR, "P1 PMIC DIMM A-F alert handler error: %s\n", ec.message().c_str());
+            sd_journal_print(LOG_ERR, "HPM FPGA lockout alert handler error: %s\n", ec.message().c_str());
             return;
         }
         HPMFPGALockoutEventHandler();


### PR DESCRIPTION
Fixed a copy paste error in FPGA lockout handler

Signed-off-by: Rajaganesh Rathinasabapathi <Rajaganesh.Rathinasabapathi@amd.com>