### PR TITLE
Add PPIN and Microcode to CPER

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -153,8 +153,8 @@ typedef struct df_dump DF_DUMP;
 struct context_info {
   uint16_t                           RegisterContextType;
   uint16_t                           RegisterArraySize;
-  uint32_t                           MSRAddress;
-  uint64_t                           MmRegisterAddress;
+  uint32_t                           MicrocodeVersion;
+  uint64_t                           Ppin;
   CRASHDUMP_T                        CrashDumpData[GENOA_MCA_BANKS];
   DF_DUMP                            DfDumpData;
 } __attribute__((packed));

--- a/service_files/com.amd.crashdump.service
+++ b/service_files/com.amd.crashdump.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Crash dump manager
+After=xyz.openbmc_project.Chassis.Control.Power.service
 
 [Service]
 ExecStart=/usr/bin/amd-ras


### PR DESCRIPTION
1. Add PPIN and MicroCode to the CPER file 
2. Harvesting of this info is configurable in BMC config file

Signed-off-by: Abinaya <abinaya.dhandapani@amd.com>