### PR TITLE
Add SEL event for FCH hang error

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -13,6 +13,7 @@
 #define GENOA_MCA_BANKS             (32)
 #define MCA_BANK_MAX_OFFSET         (128)
 #define SYS_MGMT_CTRL_ERR           (0x04)
+#define RESET_HANG_ERR              (0x02)
 #define DF_DUMP_RESERVED            (6128)
 #define MAX_ERROR_FILE              (10)
 #define LAST_TRANS_ADDR_OFFSET      (4)


### PR DESCRIPTION
1. Bit 1 of RAS status register will be set if FCH is hung during reset after syncflood. BMC will be logging a SEL event to notify the user that FCH hang has occured 

Signed-off-by: Abinaya <abinaya.dhandapani@amd.com>