### PR TITLE
Add Minor and Major revision to CPER

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -22,10 +22,18 @@
 #define BYTE_2                      (2)
 
 /*
- * CPER section header revision, used in revision field in struct
+ * CPER section descriptor revision, used in revision field in struct
  * cper_section_descriptor
  */
-#define CPER_SEC_REV                (0x0100)
+#define CPER_MINOR_REV                (0x0001)
+
+#define ADDC_GEN_NUMBER_1             (0x01)
+#define ADDC_GEN_NUMBER_2             (0x02)
+#define ADDC_GEN_NUMBER_3             (0x03)
+
+#define EPYC_PROG_SEG_ID              (0x01)
+#define MI_PROG_SEG_ID                (0x02)
+#define NAVI_PROG_SEG_ID              (0x03)
 
 /*
  * Validation bits definition for validation_bits in struct
@@ -44,6 +52,9 @@
 #define FRU_ID_VALID                    (0x01)
 #define FRU_TEXT_VALID                  (0x02)
 #define FOUR_BYTE_MASK                  (0xFFFFFFFF)
+
+#define INT_15                          (0x0F)
+#define SHIFT_4                         (4)
 
 typedef struct {
   unsigned char b[16];
@@ -112,7 +123,8 @@ typedef struct common_error_record_header COMMON_ERROR_RECORD_HEADER;
 struct error_section_descriptor {
   uint32_t                           SectionOffset;
   uint32_t                           SectionLength;
-  uint16_t                           Revision;
+  uint8_t                            RevisionMinor;
+  uint8_t                            RevisionMajor;
   uint8_t                            SecValidMask;
   uint8_t                            Reserved;
   uint32_t                           SectionFlags;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -763,7 +763,8 @@ void dump_error_descriptor_section(uint16_t numbanks, uint16_t bytespermca,uint8
     rcd->SectionDescriptor[0].SectionOffset = sizeof(COMMON_ERROR_RECORD_HEADER) +
                               (2 * sizeof(ERROR_SECTION_DESCRIPTOR));
     rcd->SectionDescriptor[0].SectionLength = sizeof(ERROR_RECORD);
-    rcd->SectionDescriptor[0].Revision = CPER_SEC_REV;
+    rcd->SectionDescriptor[0].RevisionMinor = CPER_MINOR_REV;
+    rcd->SectionDescriptor[0].RevisionMajor = ((ADDC_GEN_NUMBER_1 & INT_15) << SHIFT_4) | EPYC_PROG_SEG_ID;
     rcd->SectionDescriptor[0].SecValidMask = FRU_ID_VALID | FRU_TEXT_VALID;
     rcd->SectionDescriptor[0].SectionFlags = CPER_PRIMARY;
     rcd->SectionDescriptor[0].SectionType = VENDOR_OOB_CRASHDUMP;
@@ -775,7 +776,8 @@ void dump_error_descriptor_section(uint16_t numbanks, uint16_t bytespermca,uint8
     rcd->SectionDescriptor[1].SectionOffset = sizeof(COMMON_ERROR_RECORD_HEADER) +
                              (2 * sizeof(ERROR_SECTION_DESCRIPTOR)) + sizeof(ERROR_RECORD);
     rcd->SectionDescriptor[1].SectionLength = sizeof(ERROR_RECORD);
-    rcd->SectionDescriptor[1].Revision = CPER_SEC_REV;
+    rcd->SectionDescriptor[1].RevisionMinor = CPER_MINOR_REV;
+    rcd->SectionDescriptor[1].RevisionMajor = ((ADDC_GEN_NUMBER_1 & INT_15) << SHIFT_4) | EPYC_PROG_SEG_ID;
     rcd->SectionDescriptor[1].SecValidMask = FRU_ID_VALID | FRU_TEXT_VALID;
     rcd->SectionDescriptor[1].SectionFlags = CPER_PRIMARY;
     rcd->SectionDescriptor[1].SectionType = VENDOR_OOB_CRASHDUMP;
@@ -1132,10 +1134,10 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
                 {
                     sd_journal_print(LOG_ERR, "CdumpResetPolicy is not valid\n");
                 }
-            }
 
-            P0_AlertProcessed = false;
-            P1_AlertProcessed = false;
+                P0_AlertProcessed = false;
+                P1_AlertProcessed = false;
+            }
 
         }
     }


### PR DESCRIPTION
1. Add Minor and Major revision number to CPER
    The minor number starts with 0.
    Major number definition
    - [7:4] = ADDC Gen #
    - [3:0] = Program ID:
    0x1 = EPYC, 0x2 = MI,
    0x3 = Navi, Rest = RSVD
2. Fix the regression issue "CPER file not getting created for 2P system which is introduced in the commit "Redfish implementation

Signed-off-by: Abinaya <abinaya.dhandapani@amd.com>