### PR TITLE
Harvest PCIE dump

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -14,9 +14,11 @@
 #define MCA_BANK_MAX_OFFSET         (128)
 #define SYS_MGMT_CTRL_ERR           (0x04)
 #define RESET_HANG_ERR              (0x02)
-#define DF_DUMP_RESERVED            (6128)
+#define DF_DUMP_RESERVED            (11571)
 #define MAX_ERROR_FILE              (10)
 #define LAST_TRANS_ADDR_OFFSET      (4)
+#define PCIE_DUMP_OFFSET            (49)
+#define MAX_PCIE_INSTANCES          (12)
 #define CCM_COUNT                   (8)
 #define BYTE_4                      (4)
 #define BYTE_2                      (2)
@@ -51,10 +53,11 @@
 #define PROC_CONTEXT_STRUCT_VALID       (0x100)
 #define INFO_VALID_CHECK_INFO           (0x01)
 
+#define BLOCK_ID_33                     (33)
 #define FRU_ID_VALID                    (0x01)
 #define FRU_TEXT_VALID                  (0x02)
 #define FOUR_BYTE_MASK                  (0xFFFFFFFF)
-
+#define TWO_BYTE_MASK                   (0xFFFF)
 #define INT_15                          (0x0F)
 #define INT_255                         (0xFF)
 #define SHIFT_4                         (4)
@@ -67,6 +70,7 @@
 #define INDEX_4                         (4)
 #define INDEX_5                         (5)
 #define INDEX_8                         (8)
+#define INDEX_16                        (0x10)
 #define BASE_16                         (16)
 
 typedef struct {
@@ -98,6 +102,10 @@ typedef struct {
 typedef struct {
   uint32_t WdtData[LAST_TRANS_ADDR_OFFSET];
 } LAST_TRANS_ADDR;
+
+typedef struct {
+  uint32_t PcieData[PCIE_DUMP_OFFSET];
+} PCIE_DUMP;
 
 struct error_time_stamp {
   uint8_t    Seconds;
@@ -161,10 +169,18 @@ typedef struct processor_error_section PROCESSOR_ERROR_SECTION;
 
 struct df_dump {
   LAST_TRANS_ADDR                    LastTransAddr[CCM_COUNT];
-  uint64_t                           reserved[DF_DUMP_RESERVED];
 }  __attribute__((packed));
 
 typedef struct df_dump DF_DUMP;
+
+struct pcie_dump {
+  uint8_t                            BlockID;
+  uint8_t                            ValidLogInstance;
+  uint16_t                           LogInstanceSize;
+  PCIE_DUMP                          PcieDump[MAX_PCIE_INSTANCES];
+}  __attribute__((packed));
+
+typedef struct pcie_dump PCIE_DUMP_DATA;
 
 struct context_info {
   uint16_t                           RegisterContextType;
@@ -173,6 +189,9 @@ struct context_info {
   uint64_t                           Ppin;
   CRASHDUMP_T                        CrashDumpData[GENOA_MCA_BANKS];
   DF_DUMP                            DfDumpData;
+  uint32_t                           Reserved[96];
+  PCIE_DUMP_DATA                     PcieDumpData;
+  uint32_t                           reserved[DF_DUMP_RESERVED];
 } __attribute__((packed));
 
 typedef struct context_info CONTEXT_INFO;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -379,6 +379,95 @@ void getLastTransAddr(uint8_t info)
     }
 }
 
+void harvestPcieDump(uint8_t info)
+{
+    oob_status_t ret;
+    uint8_t blk_id = BLOCK_ID_33;
+    uint16_t n = 0;
+    uint16_t maxOffset32;
+    uint32_t data;
+    struct ras_df_err_chk err_chk;
+    union ras_df_err_dump df_err = {0};
+
+    sd_journal_print(LOG_INFO, "Harvesting PCIE dump\n");
+
+    ret = read_ras_df_err_validity_check(info, blk_id, &err_chk);
+
+    if (ret)
+    {
+        sd_journal_print(LOG_ERR, "Failed to read Pcie dump validity check\n");
+
+        /*If 5Bh command fails ,0xBAADDA7A is written thrice in the PCIE dump region*/
+        if(info == p0_info)
+        {
+            rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.BlockID = (BAD_DATA & INT_255);
+            rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.ValidLogInstance = (BAD_DATA >> INDEX_8) & INT_255;
+            rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.LogInstanceSize = (BAD_DATA >> INDEX_16) & TWO_BYTE_MASK;
+            rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.PcieDump[INDEX_0].PcieData[INDEX_0] = BAD_DATA;
+            rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.PcieDump[INDEX_0].PcieData[INDEX_1] = BAD_DATA;
+        }
+        else if(info == p1_info)
+        {
+            rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.BlockID = (BAD_DATA & INT_255);
+            rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.ValidLogInstance = (BAD_DATA >> INDEX_8) & INT_255;
+            rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.LogInstanceSize = (BAD_DATA >> INDEX_16) & TWO_BYTE_MASK;
+            rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.PcieDump[INDEX_0].PcieData[INDEX_0] = BAD_DATA;
+            rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.PcieDump[INDEX_0].PcieData[INDEX_1] = BAD_DATA;
+        }
+    }
+    else
+    {
+        if(err_chk.df_block_instances != 0)
+        {
+            if(info == p0_info)
+            {
+                rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.BlockID = blk_id;
+                rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.ValidLogInstance =
+                                                         err_chk.df_block_instances;
+                rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.LogInstanceSize = err_chk.err_log_len;
+            }
+            else if(info == p1_info)
+            {
+                rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.BlockID = blk_id;
+                rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.ValidLogInstance =
+                                                             err_chk.df_block_instances;
+                rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.LogInstanceSize = err_chk.err_log_len;
+            }
+
+            maxOffset32 = ((err_chk.err_log_len % BYTE_4) ? INDEX_1 : INDEX_0) + (err_chk.err_log_len >> BYTE_2);
+
+            while(n < err_chk.df_block_instances)
+            {
+                for (int offset = 0; offset < maxOffset32; offset++)
+                {
+                    memset(&data, 0, sizeof(data));
+                    /* Offset */
+                    df_err.input[INDEX_0] = offset * BYTE_4;
+                    /* DF block ID */
+                    df_err.input[INDEX_1] = blk_id;
+                    /* DF block ID instance */
+                    df_err.input[INDEX_2] = n;
+
+                    ret = read_ras_df_err_dump(info, df_err, &data);
+
+                    if (ret != OOB_SUCCESS)
+                    {
+                        sd_journal_print(LOG_ERR, "Failed to read Pcie dump data\n");
+                        data = BAD_DATA;
+                    }
+
+                    if(info == p0_info) {
+                        rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.PcieDump[n].PcieData[offset] = data;
+                    } else if(info == p1_info) {
+                        rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.PcieDump[n].PcieData[offset] = data;
+                    }
+                }
+                n++;
+            }
+        }
+    }
+}
+
 void triggerColdReset()
 {
     sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
@@ -833,6 +922,9 @@ void dump_processor_error_section(uint8_t info)
 void dump_context_info(uint16_t numbanks,uint16_t bytespermca,uint8_t info)
 {
     getLastTransAddr(info);
+
+    harvestPcieDump(info);
+
     if(info == p0_info)
     {
         rcd->P0_ErrorRecord.ContextInfo.RegisterContextType = CTX_OOB_CRASH;
@@ -947,8 +1039,6 @@ static bool harvest_mca_data_banks(uint8_t info, uint16_t numbanks, uint16_t byt
                 {
                     ValidSignatureID = true;
                 }
-                sd_journal_print(LOG_INFO,"ValidSignatureID %d\n",ValidSignatureID);
-
             }
             if(mca_dump.offset == ipid_lo_offset)
             {


### PR DESCRIPTION
pull-in PCIe dump support in OOB Crashdump feature.
PCIE dump is harvested using BLOCK_ID = 33 of the existing APML mailbox commands 5Bh and 5Ch.
The APML responses from is posted to the new DBG LOG section in the CPER definition