### PR TITLE
Add Major number for MI300

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -37,6 +37,9 @@
 #define MI_PROG_SEG_ID                (0x02)
 #define NAVI_PROG_SEG_ID              (0x03)
 
+#define MI300A_MODEL_NUMBER           (0x90)
+#define MI300C_MODEL_NUMBER           (0x80)
+
 /*
  * Validation bits definition for validation_bits in struct
  * cper_record_header. If set, corresponding fields in struct


### PR DESCRIPTION
1. Major number field is updated for Mi300 platform. If the Model number is 0x80 or 0x90 , then the major number field will display 2 for Program ID