### PR TITLE
Turin RAS implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,9 @@ set(DBUS_INTF_NAME "com.amd.crashdump")
 add_definitions(-DDBUS_OBJECT_NAME="/${DBUS_OBJECT_NAME}")
 add_definitions(-DDBUS_ENTRY_NAME="/${DBUS_ENTRY_NAME}")
 add_definitions(-DDBUS_INTF_NAME="${DBUS_INTF_NAME}")
-set(SRC_FILES src/main.cpp )
+set(SRC_FILES src/main.cpp 
+              src/runtime_errors.cpp )
+
 set ( SERVICE_FILES
     service_files/com.amd.crashdump.service )
 

--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -4,24 +4,35 @@
 #define CPER_SIG_SIZE               (4)
 #define CPER_SIG_RECORD             ("CPER")
 #define CPER_RECORD_REV             (0x0100)
-#define SECTION_COUNT               (2)
+#define FATAL_SECTION_COUNT         (2)
 #define CPER_SIG_END                (0xffffffff)
 #define CPER_SEV_FATAL              (1)
+#define SEV_NON_FATAL_UNCORRECTED   (0)
+#define SEV_NON_FATAL_CORRECTED     (2)  
 #define CTX_OOB_CRASH               (0x01)
-#define CPER_PRIMARY                (0)
+#define CPER_PRIMARY                (1)
 #define RSVD                        (0)
 #define GENOA_MCA_BANKS             (32)
 #define MCA_BANK_MAX_OFFSET         (128)
 #define SYS_MGMT_CTRL_ERR           (0x04)
 #define RESET_HANG_ERR              (0x02)
-#define DF_DUMP_RESERVED            (11571)
+#define DEUB_LOG_DUMP_REGION        (12160)
 #define MAX_ERROR_FILE              (10)
 #define LAST_TRANS_ADDR_OFFSET      (4)
-#define PCIE_DUMP_OFFSET            (49)
-#define MAX_PCIE_INSTANCES          (12)
 #define CCM_COUNT                   (8)
 #define BYTE_4                      (4)
 #define BYTE_2                      (2)
+#define ENABLE_BIT                  (1)
+
+#define BLOCK_ID_1                      (1)
+#define BLOCK_ID_2                      (2)
+#define BLOCK_ID_3                      (3)
+#define BLOCK_ID_33                     (33)
+#define BLOCK_ID_36                     (36)
+#define BLOCK_ID_37                     (37)
+#define BLOCK_ID_38                     (38)
+#define BLOCK_ID_39                     (39)
+#define BLOCK_ID_40                     (40)
 
 /*
  * CPER section descriptor revision, used in revision field in struct
@@ -58,11 +69,12 @@
 #define FRU_TEXT_VALID                  (0x02)
 #define FOUR_BYTE_MASK                  (0xFFFFFFFF)
 #define TWO_BYTE_MASK                   (0xFFFF)
-#define INT_15                          (0x0F)
+#define INT_15                          (0xFF)
 #define INT_255                         (0xFF)
 #define SHIFT_4                         (4)
 #define SHIFT_23                        (23)
 #define SHIFT_25                        (25)
+#define SHIFT_32                        (32)
 #define INDEX_0                         (0)
 #define INDEX_1                         (1)
 #define INDEX_2                         (2)
@@ -70,8 +82,19 @@
 #define INDEX_4                         (4)
 #define INDEX_5                         (5)
 #define INDEX_6                         (6)
+#define INDEX_7                         (7)
 #define INDEX_8                         (8)
+#define INDEX_11                        (11)
+#define INDEX_12                        (12)
 #define INDEX_16                        (0x10)
+#define INDEX_19                        (19)
+#define INDEX_20                        (20)
+#define INDEX_23                        (23)
+#define INDEX_32                        (32)
+#define INDEX_44                        (44)
+#define INDEX_57                        (57)
+#define INDEX_61                        (61)
+#define INDEX_62                        (62)
 #define BASE_16                         (16)
 
 typedef struct {
@@ -89,12 +112,28 @@ typedef struct {
 #define CPER_NOTIFY_MCE                         \
     GUID_INIT(0xE8F56FFE, 0x919C, 0x4cc5, 0xBA, 0x88, 0x65, 0xAB,   \
           0xE1, 0x49, 0x13, 0xBB)
+#define CPER_NOTIFY_CMC                         \
+    GUID_INIT(0x2DCE8BB1, 0xBDD7, 0x450e, 0xB9, 0xAD, 0x9C, 0xF4,   \
+          0xEB, 0xD4, 0xF8, 0x90)
+#define CPER_NOTIFY_PCIE                        \
+    GUID_INIT(0xCF93C01F, 0x1A16, 0x4dfc, 0xB8, 0xBC, 0x9C, 0x4D,   \
+          0xAF, 0x67, 0xC1, 0x04)
 #define CPER_CREATOR_PSTORE                     \
     GUID_INIT(0x61fa3fac, 0xcb80, 0x4292, 0x8b, 0xfb, 0xd6, 0x43,   \
           0xb1, 0xde, 0x17, 0xf4)
-#define VENDOR_OOB_CRASHDUMP                    \
+#define AMD_OOB_CRASHDUMP                       \
     GUID_INIT(0x32AC0C78, 0x2623, 0x48F6, 0xB0, 0xD0, 0x73, 0x65,   \
           0x72, 0x5F, 0xD6, 0xAE)
+#define PROC_ERR_SECTION_TYPE                   \
+    GUID_INIT(0xDC3EA0B0, 0xA144, 0x4797, 0xB9, 0x5B, 0x53, 0xFA,   \
+          0x24, 0x2B, 0x6E, 0x1D)
+#define PCIE_ERR_SECTION_TYPE                   \
+    GUID_INIT(0xD995E954, 0xBBC1, 0x430F, 0xAD, 0x91, 0xB4, 0x4D,   \
+          0xCB, 0x3C, 0x6F, 0x35)
+
+#define MS_CHECK_GUID                           \
+    GUID_INIT(0x48AB7F57, 0xDC34, 0x4f6c, 0xA7, 0xD3, 0xB0, 0xB5,   \
+          0xB0, 0xA7, 0x43, 0x14)
 
 typedef struct {
   uint32_t mca_data[MCA_BANK_MAX_OFFSET];
@@ -103,10 +142,6 @@ typedef struct {
 typedef struct {
   uint32_t WdtData[LAST_TRANS_ADDR_OFFSET];
 } LAST_TRANS_ADDR;
-
-typedef struct {
-  uint32_t PcieData[PCIE_DUMP_OFFSET];
-} PCIE_DUMP;
 
 struct error_time_stamp {
   uint8_t    Seconds;
@@ -151,9 +186,9 @@ struct error_section_descriptor {
   uint8_t                            Reserved;
   uint32_t                           SectionFlags;
   GUID_T                             SectionType;
-  GUID_T                             FRUId;
+  uint64_t                           FRUId[INDEX_2];
   uint32_t                           Severity;
-  unsigned char                      FRUText[20];
+  char                               FRUText[20];
 } __attribute__((packed));
 
 typedef struct error_section_descriptor ERROR_SECTION_DESCRIPTOR;
@@ -174,15 +209,6 @@ struct df_dump {
 
 typedef struct df_dump DF_DUMP;
 
-struct pcie_dump {
-  uint8_t                            BlockID;
-  uint8_t                            ValidLogInstance;
-  uint16_t                           LogInstanceSize;
-  PCIE_DUMP                          PcieDump[MAX_PCIE_INSTANCES];
-}  __attribute__((packed));
-
-typedef struct pcie_dump PCIE_DUMP_DATA;
-
 struct context_info {
   uint16_t                           RegisterContextType;
   uint16_t                           RegisterArraySize;
@@ -191,8 +217,7 @@ struct context_info {
   CRASHDUMP_T                        CrashDumpData[GENOA_MCA_BANKS];
   DF_DUMP                            DfDumpData;
   uint32_t                           Reserved[96];
-  PCIE_DUMP_DATA                     PcieDumpData;
-  uint32_t                           reserved[DF_DUMP_RESERVED];
+  uint32_t                           DebugLogIdData[DEUB_LOG_DUMP_REGION];
 } __attribute__((packed));
 
 typedef struct context_info CONTEXT_INFO;

--- a/inc/cper_runtime.hpp
+++ b/inc/cper_runtime.hpp
@@ -1,0 +1,85 @@
+#ifndef CPER_RUNTIME_H
+#define CPER_RUNTIME_H
+
+#include "cper.hpp"
+
+#define RUNTIME_MCA_BANK_MAX_OFFSET          (32)
+
+struct proc_info_section {
+    uint64_t               ValidBits;
+    uint64_t               CPUAPICId;
+    uint32_t               CpuId[12];
+} __attribute__((packed));
+
+struct processor_error_info {
+    GUID_T                 ErrorType;
+    uint64_t               ValidationBits;
+    uint64_t               CheckInfo;
+    uint64_t               TargetId;
+    uint64_t               RequestorId;
+    uint64_t               ResponderId;
+    uint64_t               ip;
+} __attribute__((packed));
+
+struct proc_context_section {
+    uint16_t               RegContextType;
+    uint16_t               RegArraySize;
+    uint32_t               MSR_Addr;
+    uint64_t               MM_RegAddr;
+    uint32_t               DumpData[RUNTIME_MCA_BANK_MAX_OFFSET];
+} __attribute__((packed));
+
+struct proc_error_section {
+    proc_info_section      ProcInfoSection;
+    processor_error_info   ProcErrorInfo;
+    proc_context_section   ProcContextStruct;
+}__attribute__((packed));
+
+struct pcie_version {
+uint8_t            Minor;
+        uint8_t            Major;
+        uint8_t            Reserved[INDEX_2];
+}__attribute__((packed));
+
+struct device_id{
+        uint16_t           VendorId;
+        uint16_t           DeviceId;
+        uint8_t            ClassCode[INDEX_3];
+        uint8_t            Function;
+        uint8_t            Device;
+        uint16_t           Segment;
+        uint8_t            Bus;
+        uint8_t            SecondaryBus;
+        uint8_t            Reserved[INDEX_3];
+}__attribute__((packed));
+
+struct pcie_error_section {
+    uint64_t               ValidationBits;
+    uint32_t               PortType;
+    pcie_version           Version;
+    uint32_t               CommandStatus;
+    uint32_t               Reserved;
+    device_id              DeviceId;
+    uint64_t               DeviceSerialNumber;
+    uint32_t               BridgeControlStatus;
+    uint8_t                Capability[60];
+    uint32_t               AerInfo[24];
+}__attribute__((packed));
+
+struct proc_runtime_err_record {
+    common_error_record_header        Header;
+    error_section_descriptor          *SectionDescriptor;
+    proc_error_section                *ProcErrorSection;
+}  __attribute__((packed));
+
+typedef struct proc_runtime_err_record PROC_RUNTIME_ERR_RECORD;
+
+struct pcie_runtime_err_record {
+    common_error_record_header        Header;
+    error_section_descriptor          *SectionDescriptor;
+    pcie_error_section                *PcieErrorSection;
+}  __attribute__((packed));
+
+typedef struct pcie_runtime_err_record PCIE_RUNTIME_ERR_RECORD;
+
+#endif

--- a/inc/ras.hpp
+++ b/inc/ras.hpp
@@ -1,0 +1,117 @@
+#ifndef RAS_H
+#define RAS_H
+
+#include <array>
+#include <boost/asio.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/container/flat_map.hpp>
+#include <boost/container/flat_set.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <gpiod.hpp>
+#include <iostream>
+#include <mutex>  // std::mutex
+#include <phosphor-logging/log.hpp>
+#include <regex>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/asio/property.hpp>
+#include <shared_mutex>
+#include <string_view>
+#include <utility>
+#include <regex>
+#include <ctype.h>
+#include <nlohmann/json.hpp>
+#include <experimental/filesystem>
+
+extern "C" {
+#include <sys/stat.h>
+#include "linux/i2c-dev.h"
+#include "i2c/smbus.h"
+#include "apml.h"
+#include "esmi_cpuid_msr.h"
+#include "esmi_mailbox.h"
+#include "esmi_rmi.h"
+#include "esmi_mailbox_nda.h"
+}
+
+#define GENOA_FAMILY_ID               (0x19)
+#define TURIN_FAMILY_ID               (0x1A)
+#define MCA_POLLING_PERIOD            (3)
+#define DRAM_CECC_POLLING_PERIOD      (5)
+#define PCIE_AER_POLLING_PERIOD       (7)
+
+#define MCA_ERR                       (0)
+#define DRAM_CECC_ERR                 (1)
+#define PCIE_ERR                      (2)
+#define ERROR_THRESHOLD_VAL           (1)
+
+#define PCIE_ERROR_THRESHOLD          (32)
+#define DRAM_CECC_ERROR_THRESHOLD     (16)
+#define MCA_ERROR_THRESHOLD           (8)
+#define FATAL_ERROR                   (1)
+#define APML_INIT_DONE_FILE           ("/tmp/apml_init_complete")
+#define SBRMI_CONTROL_REGISTER        (0x1)
+
+#define COMMAND_NUM_OF_CPU  ("/sbin/fw_printenv -n num_of_cpu")
+#define COMMAND_LEN         (3)
+#define MAX_MCA_BANKS       (32)
+#define TWO_SOCKET          (2)
+#define SHIFT_24            (24)
+#define SHIFT_32            (32)
+#define CMD_BUFF_LEN        (256)
+#define BASE_16             (16)
+#define MAX_RETRIES         (10)
+#define RAS_STATUS_REGISTER (0x4C)
+#define index_file          ("/var/lib/amd-ras/current_index")
+#define config_file         ("/var/lib/amd-ras/config_file")
+#define COMMAND_BOARD_ID    ("/sbin/fw_printenv -n board_id")
+#define BAD_DATA            (0xBAADDA7A)
+#define PCIE_VENDOR_ID      (0x1022)
+#define RUNTIME_MCA_ERR     ("RUNTIME_MCA_ERROR")
+#define RUNTIME_PCIE_ERR    ("RUNTIME_PCIE_ERROR")
+#define RUNTIME_DRAM_ERR    ("RUNTIME_DRAM_ERROR")
+#define FATAL_ERR           ("FATAL")
+
+void RunTimeErrorPolling();
+void SetOobConfig();
+void write_to_cper_file(std::string);
+void ErrorPollingHandler(uint8_t, uint16_t);
+extern boost::asio::deadline_timer *McaErrorPollingEvent;
+extern boost::asio::deadline_timer *DramCeccErrorPollingEvent;
+extern boost::asio::deadline_timer *PcieAerErrorPollingEvent;
+
+extern uint8_t p0_info;
+extern uint8_t p1_info;
+extern int num_of_proc;
+extern bool TurinPlatform;
+extern bool GenoaPlatform;
+
+extern unsigned int board_id;
+extern uint64_t RecordId;
+extern uint16_t apmlRetryCount;
+extern bool McaPollingEn;
+extern bool PcieAerPollingEn;
+extern bool DramCeccPollingEn;
+
+extern uint16_t McaPollingPeriod;
+extern uint16_t DramCeccPollingPeriod;
+extern uint16_t PcieAerPollingPeriod;
+
+extern uint32_t p0_ucode;
+extern uint32_t p1_ucode;
+extern uint64_t p0_ppin;
+extern uint64_t p1_ppin;
+
+extern uint32_t p0_eax , p0_ebx , p0_ecx , p0_edx;
+extern uint32_t p1_eax , p1_ebx , p1_ecx , p1_edx;
+extern uint32_t err_count;
+
+constexpr std::string_view kRasDir = "/var/lib/amd-ras/";
+#endif

--- a/inc/write_cper_data.hpp
+++ b/inc/write_cper_data.hpp
@@ -1,0 +1,268 @@
+#include "ras.hpp"
+#include "cper.hpp"
+#include "cper_runtime.hpp"
+
+template<typename T>
+void calculate_time_stamp(const std::shared_ptr<T>& data)
+{
+    using namespace std;
+    using namespace std::chrono;
+    typedef duration<int, ratio_multiply<hours::period, ratio<24> >::type> days;
+
+    system_clock::time_point now = system_clock::now();
+    system_clock::duration tp = now.time_since_epoch();
+
+    days d = duration_cast<days>(tp);
+    tp -= d;
+    hours h = duration_cast<hours>(tp);
+    tp -= h;
+    minutes m = duration_cast<minutes>(tp);
+    tp -= m;
+    seconds s = duration_cast<seconds>(tp);
+    tp -= s;
+
+    time_t tt = system_clock::to_time_t(now);
+    tm utc_tm = *gmtime(&tt);
+
+    data->Header.TimeStamp.Seconds = utc_tm.tm_sec;
+    data->Header.TimeStamp.Minutes = utc_tm.tm_min;
+    data->Header.TimeStamp.Hours = utc_tm.tm_hour;
+    data->Header.TimeStamp.Flag = 1;
+    data->Header.TimeStamp.Day = utc_tm.tm_mday;
+    data->Header.TimeStamp.Month = utc_tm.tm_mon + 1;
+    data->Header.TimeStamp.Year = utc_tm.tm_year;
+    data->Header.TimeStamp.Century = 20 + utc_tm.tm_year/100;
+    data->Header.TimeStamp.Year = data->Header.TimeStamp.Year % 100;
+}
+
+template<typename T>
+void dump_error_descriptor_section(const std::shared_ptr<T>& data,uint16_t SectionCount,
+                std::string ErrorType,uint32_t *Severity)
+{
+    for(int i = 0 ; i < SectionCount ; i++)
+    {
+
+        if(ErrorType == FATAL_ERR)
+        {
+            data->SectionDescriptor[i].SectionOffset = sizeof(COMMON_ERROR_RECORD_HEADER) +
+                                   (INDEX_2 * sizeof(ERROR_SECTION_DESCRIPTOR));
+            data->SectionDescriptor[i].SectionLength = sizeof(ERROR_RECORD);
+            data->SectionDescriptor[i].SectionType = AMD_OOB_CRASHDUMP;
+            data->SectionDescriptor[i].Severity = CPER_SEV_FATAL;
+            data->SectionDescriptor[INDEX_0].FRUText[INDEX_0] = 'P';
+            data->SectionDescriptor[INDEX_0].FRUText[INDEX_1] = '0';
+            data->SectionDescriptor[INDEX_1].FRUText[INDEX_0] = 'P';
+            data->SectionDescriptor[INDEX_1].FRUText[INDEX_1] = '1';
+        }
+        else if((ErrorType == RUNTIME_MCA_ERR) || (ErrorType == RUNTIME_DRAM_ERR))
+        {
+            data->SectionDescriptor[i].SectionOffset =  sizeof(common_error_record_header) +
+                                                       (sizeof(error_section_descriptor) * SectionCount) +
+                                                       (sizeof(proc_error_section) * i);
+            data->SectionDescriptor[i].SectionLength = sizeof(proc_error_section);
+            data->SectionDescriptor[i].SectionType = PROC_ERR_SECTION_TYPE; 
+            data->SectionDescriptor[i].Severity = Severity[i];
+
+            if(ErrorType == RUNTIME_MCA_ERR)
+            {
+                std::strcpy(data->SectionDescriptor[i].FRUText,"ProcessorError");
+            }
+            if(ErrorType == RUNTIME_DRAM_ERR)
+            {
+                std::strcpy(data->SectionDescriptor[i].FRUText,"DramCeccError");
+            }
+        }
+        else if(ErrorType == RUNTIME_PCIE_ERR)
+        {
+            data->SectionDescriptor[i].SectionOffset = sizeof(common_error_record_header) + 
+                                                       (sizeof(error_section_descriptor) * SectionCount) +
+                                                       (i * sizeof(pcie_error_section));
+            data->SectionDescriptor[i].SectionLength = sizeof(pcie_error_section);
+            data->SectionDescriptor[i].SectionType = PCIE_ERR_SECTION_TYPE;
+            data->SectionDescriptor[i].Severity = Severity[i];
+            std::strcpy(data->SectionDescriptor[i].FRUText,"PcieError");
+        }
+
+        data->SectionDescriptor[i].RevisionMinor = CPER_MINOR_REV;
+
+        if(GenoaPlatform == true)
+        {
+            data->SectionDescriptor[i].RevisionMajor = ((ADDC_GEN_NUMBER_1 & INT_15) << SHIFT_4) | EPYC_PROG_SEG_ID;
+        } else if(TurinPlatform == true)
+        {
+            data->SectionDescriptor[i].RevisionMajor = ((ADDC_GEN_NUMBER_2 & INT_15) << SHIFT_4) | EPYC_PROG_SEG_ID;
+        }
+
+        data->SectionDescriptor[i].SecValidMask = FRU_ID_VALID | FRU_TEXT_VALID;
+        data->SectionDescriptor[i].SectionFlags = CPER_PRIMARY;
+    }
+}
+
+template<typename T>
+void dump_cper_header_section(const std::shared_ptr<T>& data, uint16_t SectionCount,
+                              uint32_t ErrorSeverity, std::string ErrorType)
+{
+    /*ASCII 4-character array “CPER” (0x43, 0x50, 0x45, 0x52) */
+    memcpy(data->Header.Signature, CPER_SIG_RECORD, CPER_SIG_SIZE);
+
+    data->Header.Revision = CPER_RECORD_REV; /*(0x100)*/
+
+    data->Header.SignatureEnd = CPER_SIG_END; /*(0xFFFFFFFF)*/
+
+    /*Number of valid sections associated with the record*/
+    data->Header.SectionCount = SectionCount;
+
+    /*0 - Non-fatal uncorrected ; 1 - Fatal ; 2 - Corrected*/
+    data->Header.ErrorSeverity = ErrorSeverity;
+
+    /*Bit 0 = 1 -> PlatformID field contains valid info
+      Bit 1 = 1 -> TimeStamp field contains valid info
+      Bit 2 = 1 -> PartitionID field contains valid info*/
+    data->Header.ValidationBits = (CPER_VALID_PLATFORM_ID | CPER_VALID_TIMESTAMP);
+
+    /*Size of whole CPER record*/
+    if((ErrorType == RUNTIME_MCA_ERR) || (ErrorType == RUNTIME_DRAM_ERR))
+    {
+        data->Header.RecordLength = sizeof(common_error_record_header) +
+                                    sizeof(error_section_descriptor) * SectionCount +
+                                    sizeof(proc_error_section) * SectionCount;
+    }
+    if(ErrorType == RUNTIME_PCIE_ERR)
+    {
+        data->Header.RecordLength = sizeof(common_error_record_header) +
+                                    (sizeof(error_section_descriptor) * SectionCount) +
+                                    (sizeof(pcie_error_section) * SectionCount);
+        sd_journal_print(LOG_INFO, "Size of pcie erorr section = %d\n",(sizeof(pcie_error_section)));
+    }
+    else if(ErrorType == FATAL_ERR)
+    {
+        data->Header.RecordLength = sizeof(CPER_RECORD);
+    }
+
+    /*TimeStamp when OOB controller received the event*/
+    calculate_time_stamp(data);
+
+    data->Header.PlatformId[INDEX_0] = board_id;
+
+    data->Header.CreatorId = CPER_CREATOR_PSTORE;
+
+    if(ErrorType == RUNTIME_PCIE_ERR)
+    {
+        data->Header.NotifyType = CPER_NOTIFY_PCIE;
+    }
+    else if((ErrorType == RUNTIME_MCA_ERR ) || (ErrorType == RUNTIME_DRAM_ERR))
+    {
+        if(ErrorSeverity == SEV_NON_FATAL_CORRECTED)
+        {
+            data->Header.NotifyType = CPER_NOTIFY_CMC;
+        }
+        else
+        {
+            data->Header.NotifyType = CPER_NOTIFY_MCE;
+        }
+    }
+
+    /*Starts at 1 and increments at each time when cper file is generated*/
+    data->Header.RecordId = RecordId++;
+}
+
+inline std::string getCperFilename(int num) {
+    return "ras-error" + std::to_string(num) + ".cper";
+}
+
+template<typename T>
+void write_to_cper_file(const std::shared_ptr<T>& data,std::string ErrorType,uint16_t SectionCount )
+{
+
+    std::string cperFileName;
+    FILE *file;
+
+    std::shared_ptr<PROC_RUNTIME_ERR_RECORD> ProcPtr;
+    std::shared_ptr<PCIE_RUNTIME_ERR_RECORD> PciePtr;
+    std::shared_ptr<CPER_RECORD> FatalPtr;
+  
+    if constexpr (std::is_same_v<T, PROC_RUNTIME_ERR_RECORD>) {
+        ProcPtr = std::static_pointer_cast<PROC_RUNTIME_ERR_RECORD>(data);
+    }
+    if constexpr (std::is_same_v<T, PCIE_RUNTIME_ERR_RECORD>) {
+        PciePtr = std::static_pointer_cast<PCIE_RUNTIME_ERR_RECORD>(data);
+    }
+    if constexpr (std::is_same_v<T, CPER_RECORD>) {
+        FatalPtr = std::static_pointer_cast<CPER_RECORD>(data);
+    }
+
+    cperFileName = getCperFilename(err_count);
+
+    for (const auto& entry : std::filesystem::directory_iterator(kRasDir))
+    {
+        std::string filename = entry.path().filename().string();
+        if(filename.size() >= cperFileName.size() &&
+                 filename.substr(filename.size() - cperFileName.size()) == cperFileName)
+        {
+            std::filesystem::remove(entry.path());
+        }
+    }
+
+    if(ErrorType == RUNTIME_MCA_ERR)
+    {
+        cperFileName = "mca-" + cperFileName;
+    }
+    else if(ErrorType == RUNTIME_DRAM_ERR)
+    {
+        cperFileName = "dram-" + cperFileName;
+    }
+    else if(ErrorType == RUNTIME_PCIE_ERR)
+    {
+        cperFileName = "pcie-" + cperFileName;
+    }
+
+    static std::mutex index_file_mtx;
+    std::unique_lock lock(index_file_mtx);
+
+    std::string cperFilePath = kRasDir.data() + cperFileName;
+    err_count++;
+
+    if(err_count >= MAX_ERROR_FILE)
+    {
+        /*The maximum number of error files supported is 10.
+          The counter will be rotated once it reaches max count*/
+          err_count = (err_count % MAX_ERROR_FILE);
+    }
+
+    file = fopen(index_file, "w");
+    if(file != NULL)
+    {
+        fprintf(file,"%d",err_count);
+        fclose(file);
+    }
+    lock.unlock();
+
+    file = fopen(cperFilePath.c_str(), "w");
+
+    if((ErrorType == RUNTIME_MCA_ERR) || (ErrorType == RUNTIME_DRAM_ERR)) 
+    {
+        if ((ProcPtr) && (file != NULL)) {
+            sd_journal_print(LOG_INFO, "Generating CPER file\n");
+
+            fwrite(&ProcPtr->Header,sizeof(common_error_record_header),1,file);
+
+            fwrite(ProcPtr->SectionDescriptor,sizeof(error_section_descriptor) * SectionCount,1,file);
+
+            fwrite(ProcPtr->ProcErrorSection,sizeof(proc_error_section) * SectionCount,1,file);
+        }
+    }else if(ErrorType == FATAL_ERR)
+    {
+        if ((FatalPtr) && (file != NULL)) {
+            sd_journal_print(LOG_DEBUG, "Generating CPER file\n");
+                fwrite(FatalPtr.get(), data->Header.RecordLength, 1, file);
+        }
+    }
+    else if(ErrorType == RUNTIME_PCIE_ERR)
+    {
+        fwrite(&PciePtr->Header,sizeof(common_error_record_header),1,file);
+        fwrite(PciePtr->SectionDescriptor,sizeof(error_section_descriptor) * SectionCount,1,file);
+        fwrite(PciePtr->PcieErrorSection,sizeof(pcie_error_section) * SectionCount,1,file);
+    }
+
+    fclose(file);
+}

--- a/service_files/com.amd.crashdump.service
+++ b/service_files/com.amd.crashdump.service
@@ -7,6 +7,9 @@ ExecStart=/usr/bin/amd-ras
 SyslogIdentifier=amd-ras
 Type=dbus
 BusName=com.amd.crashdump
+Restart=always
+TimeoutStartSec=infinity
+ExecStartPre=/bin/sleep 5
 
 [Install]
 WantedBy=multi-user.target

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,75 +1,28 @@
-#include <array>
-#include <boost/asio.hpp>
-#include <boost/asio/error.hpp>
-#include <boost/asio/io_service.hpp>
-#include <boost/asio/posix/stream_descriptor.hpp>
-#include <boost/asio/spawn.hpp>
-#include <boost/asio/steady_timer.hpp>
-#include <boost/container/flat_map.hpp>
-#include <boost/container/flat_set.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <filesystem>
-#include <fstream>
-#include <future>
-#include <gpiod.hpp>
-#include <iostream>
-#include <mutex>  // std::mutex
-#include <phosphor-logging/log.hpp>
-#include <regex>
-#include <sdbusplus/asio/connection.hpp>
-#include <sdbusplus/asio/object_server.hpp>
-#include <sdbusplus/asio/property.hpp>
-#include <shared_mutex>
-#include <string_view>
-#include <utility>
-#include <regex>
-#include <ctype.h>
-#include <nlohmann/json.hpp>
-#include <experimental/filesystem>
+#include "ras.hpp"
 #include "cper.hpp"
-
-extern "C" {
-#include <sys/stat.h>
-#include "linux/i2c-dev.h"
-#include "i2c/smbus.h"
-#include "apml.h"
-#include "esmi_cpuid_msr.h"
-#include "esmi_mailbox.h"
-#include "esmi_rmi.h"
-#include "esmi_mailbox_nda.h"
-}
-
-#define COMMAND_NUM_OF_CPU  ("/sbin/fw_printenv -n num_of_cpu")
-#define COMMAND_LEN         (3)
-#define MAX_MCA_BANKS       (32)
-#define TWO_SOCKET          (2)
-#define SHIFT_24            (24)
-#define SHIFT_32            (32)
-#define CMD_BUFF_LEN        (256)
-#define BASE_16             (16)
+#include "write_cper_data.hpp"
+#include "cper_runtime.hpp"
 
 #define WARM_RESET          (0)
 #define COLD_RESET          (1)
 #define NO_RESET            (2)
-
-#define MAX_RETRIES 10
-#define RAS_STATUS_REGISTER (0x4C)
-#define index_file  ("/var/lib/amd-ras/current_index")
-#define config_file ("/var/lib/amd-ras/config_file")
-#define BAD_DATA    (0xBAADDA7A)
 
 #define HPM_FPGA_REGDUMP         "/usr/sbin/hpm-fpga-dump.sh"
 #define HPM_FPGA_REGDUMP_FILE    "/var/lib/amd-ras/fpga_dump.txt"
 //#undef LOG_DEBUG
 //#define LOG_DEBUG LOG_ERR
 
-static boost::asio::io_service io;
+boost::asio::io_service io;
 static std::shared_ptr<sdbusplus::asio::connection> conn;
 static std::shared_ptr<sdbusplus::asio::object_server> server;
 static std::array<
     std::pair<std::string, std::shared_ptr<sdbusplus::asio::dbus_interface>>,
     MAX_ERROR_FILE>
     crashdumpInterfaces;
+
+boost::asio::deadline_timer *McaErrorPollingEvent = nullptr;
+boost::asio::deadline_timer *DramCeccErrorPollingEvent = nullptr;
+boost::asio::deadline_timer *PcieAerErrorPollingEvent = nullptr;
 
 constexpr std::string_view crashdumpService = "com.amd.crashdump";
 constexpr std::string_view crashdumpPath = "/com/amd/crashdump";
@@ -95,11 +48,10 @@ std::string P0_InventoryPath = "/xyz/openbmc_project/inventory/system/processor/
 std::string P1_InventoryPath = "/xyz/openbmc_project/inventory/system/processor/P1";
 constexpr auto CpuInventoryInterface = "xyz.openbmc_project.Inventory.Item.Cpu";
 
-constexpr std::string_view kRasDir = "/var/lib/amd-ras/";
 constexpr int kCrashdumpTimeInSec = 300;
 
 static std::string BoardName;
-static uint32_t err_count = 0;
+uint32_t err_count = 0;
 
 static gpiod::line P0_apmlAlertLine;
 static boost::asio::posix::stream_descriptor P0_apmlAlertEvent(io);
@@ -125,7 +77,7 @@ static boost::asio::posix::stream_descriptor HPMFPGALockoutAlertEvent(io);
 uint8_t p0_info = 0;
 uint8_t p1_info = 1;
 
-static int num_of_proc = 0;
+int num_of_proc = 0;
 
 const static constexpr int resetPulseTimeMs = 100;
 
@@ -134,10 +86,10 @@ std::mutex harvest_in_progress_mtx;           // mutex for critical section
 static bool P0_AlertProcessed = false;
 static bool P1_AlertProcessed = false;
 
-static uint64_t RecordId = 1;
+uint64_t RecordId = 1;
 unsigned int board_id = 0;
-static uint32_t p0_eax , p0_ebx , p0_ecx , p0_edx;
-static uint32_t p1_eax , p1_ebx , p1_ecx , p1_edx;
+uint32_t p0_eax = 0, p0_ebx = 0, p0_ecx = 0, p0_edx = 0;
+uint32_t p1_eax = 0, p1_ebx = 0, p1_ecx = 0, p1_edx = 0;
 uint32_t p0_ucode = 0;
 uint32_t p1_ucode = 0;
 uint64_t p0_ppin = 0;
@@ -148,7 +100,8 @@ uint64_t p0_last_transact_addr = 0;
 uint64_t p1_last_transact_addr = 0;
 bool harvest_ras_errors(uint8_t info,std::string alert_name);
 
-uint16_t apmlRetryCount;
+uint16_t DebugLogIdOffset;
+uint16_t apmlRetryCount = 0;
 uint16_t systemRecovery;
 bool harvestuCodeVersionFlag = false;
 bool harvestPpinFlag = false;
@@ -169,8 +122,30 @@ int status_hi_offset = 0;
 
 bool ValidSignatureID = false;
 
-std::vector<std::string> sigIDOffset = {"0x30","0x34","0x28","0x2c","0x08","0x0c","null","null"};
+bool TurinPlatform = false;
+bool GenoaPlatform = false;
+bool McaPollingEn = false;
+bool DramCeccPollingEn = false;
+bool PcieAerPollingEn = false;
+bool McaThresholdEn = false;
+bool DramCeccThresholdEn = false;
+bool PcieAerThresholdEn = false;
 
+uint16_t McaPollingPeriod = 0;
+uint16_t DramCeccPollingPeriod = 0;
+uint16_t PcieAerPollingPeriod = 0;
+uint16_t McaErrCounter = 0;
+uint16_t DramCeccErrCounter = 0;
+uint16_t PcieAerErrCounter = 0;
+
+std::vector<std::string> sigIDOffset = {"0x30","0x34","0x28","0x2c","0x08","0x0c","null","null"};
+std::vector<uint8_t> BlockId;
+
+/**
+ * Check number of CPU's of the current platform.
+ *
+ * @return false if the number of CPU's is not found, otherwise true
+ */
 bool getNumberOfCpu()
 {
     FILE *pf;
@@ -235,6 +210,30 @@ void getCpuID()
 
     }
 
+}
+
+void getBoardID()
+{
+    FILE *pf;
+    char data[COMMAND_LEN];
+    std::stringstream ss;
+
+    // Setup pipe for reading and execute to get u-boot environment
+    // variable board_id.
+    pf = popen(COMMAND_BOARD_ID,"r");
+    // Error handling
+    if(pf)
+    {
+        // Get the data from the process execution
+        if (fgets(data, COMMAND_LEN, pf))
+        {
+            ss << std::hex << (std::string)data;
+            ss >> board_id;
+            sd_journal_print(LOG_DEBUG, "Board ID: 0x%x, Board ID String: %s\n", board_id, data);
+        }
+        // the data is now in 'data'
+        pclose(pf);
+    }
 }
 
 template <typename T> void updateConfigFile(std::string jsonField, T updateData)
@@ -379,87 +378,135 @@ void getLastTransAddr(uint8_t info)
     }
 }
 
-void harvestPcieDump(uint8_t info)
+void harvestDebugLogDump(uint8_t info, uint8_t blk_id)
 {
-    oob_status_t ret;
-    uint8_t blk_id = BLOCK_ID_33;
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+    uint16_t retries = 0;
     uint16_t n = 0;
     uint16_t maxOffset32;
     uint32_t data;
     struct ras_df_err_chk err_chk;
     union ras_df_err_dump df_err = {0};
 
-    sd_journal_print(LOG_INFO, "Harvesting PCIE dump\n");
-
-    ret = read_ras_df_err_validity_check(info, blk_id, &err_chk);
-
-    if (ret)
+    while (ret != OOB_SUCCESS)
     {
-        sd_journal_print(LOG_ERR, "Failed to read Pcie dump validity check\n");
 
-        /*If 5Bh command fails ,0xBAADDA7A is written thrice in the PCIE dump region*/
-        if(info == p0_info)
+        retries++;
+
+        ret = read_ras_df_err_validity_check(info, blk_id, &err_chk);
+
+        if(ret == OOB_SUCCESS)
         {
-            rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.BlockID = (BAD_DATA & INT_255);
-            rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.ValidLogInstance = (BAD_DATA >> INDEX_8) & INT_255;
-            rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.LogInstanceSize = (BAD_DATA >> INDEX_16) & TWO_BYTE_MASK;
-            rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.PcieDump[INDEX_0].PcieData[INDEX_0] = BAD_DATA;
-            rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.PcieDump[INDEX_0].PcieData[INDEX_1] = BAD_DATA;
+            sd_journal_print(LOG_INFO, "Socket : %d , Debug Log ID : %d , Block Instance = %d, Err Log Length = %d\n",
+                             info,blk_id,err_chk.df_block_instances,err_chk.err_log_len);
+            break;
         }
-        else if(info == p1_info)
+
+        if (retries > apmlRetryCount)
         {
-            rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.BlockID = (BAD_DATA & INT_255);
-            rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.ValidLogInstance = (BAD_DATA >> INDEX_8) & INT_255;
-            rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.LogInstanceSize = (BAD_DATA >> INDEX_16) & TWO_BYTE_MASK;
-            rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.PcieDump[INDEX_0].PcieData[INDEX_0] = BAD_DATA;
-            rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.PcieDump[INDEX_0].PcieData[INDEX_1] = BAD_DATA;
-        }
-    }
-    else
-    {
-        if(err_chk.df_block_instances != 0)
-        {
+            sd_journal_print(LOG_ERR, "Socket %d: Failed to get valid debug log for Dbg Log ID %d . Error: %d\n", info,blk_id, ret);
+
+            /*If 5Bh command fails ,0xBAADDA7A is written thrice in the PCIE dump region*/
             if(info == p0_info)
             {
-                rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.BlockID = blk_id;
-                rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.ValidLogInstance =
-                                                         err_chk.df_block_instances;
-                rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.LogInstanceSize = err_chk.err_log_len;
+                rcd->P0_ErrorRecord.ContextInfo.DebugLogIdData[DebugLogIdOffset++] = blk_id;
+                rcd->P0_ErrorRecord.ContextInfo.DebugLogIdData[DebugLogIdOffset++] = BAD_DATA;
+                rcd->P0_ErrorRecord.ContextInfo.DebugLogIdData[DebugLogIdOffset++] = BAD_DATA;
+                rcd->P0_ErrorRecord.ContextInfo.DebugLogIdData[DebugLogIdOffset++] = BAD_DATA;
             }
             else if(info == p1_info)
             {
-                rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.BlockID = blk_id;
-                rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.ValidLogInstance =
-                                                             err_chk.df_block_instances;
-                rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.LogInstanceSize = err_chk.err_log_len;
+                rcd->P1_ErrorRecord.ContextInfo.DebugLogIdData[DebugLogIdOffset++] = blk_id;
+                rcd->P1_ErrorRecord.ContextInfo.DebugLogIdData[DebugLogIdOffset++] = BAD_DATA;
+                rcd->P1_ErrorRecord.ContextInfo.DebugLogIdData[DebugLogIdOffset++] = BAD_DATA;
+                rcd->P1_ErrorRecord.ContextInfo.DebugLogIdData[DebugLogIdOffset++] = BAD_DATA;
+            }
+            break;
+        }
+    }
+
+    if(ret == OOB_SUCCESS)
+    {
+        if(err_chk.df_block_instances != 0)
+        {
+
+            uint32_t DbgLogIdHeader = (static_cast<uint32_t>(err_chk.err_log_len) << INDEX_16) |
+                          (static_cast<uint32_t>(err_chk.df_block_instances) << INDEX_8) | static_cast<uint32_t>(blk_id);
+
+            if(info == p0_info)
+            {
+                rcd->P0_ErrorRecord.ContextInfo.DebugLogIdData[DebugLogIdOffset++] = DbgLogIdHeader;
+            }
+            else if(info == p1_info)
+            {
+                rcd->P1_ErrorRecord.ContextInfo.DebugLogIdData[DebugLogIdOffset++] = DbgLogIdHeader;
             }
 
             maxOffset32 = ((err_chk.err_log_len % BYTE_4) ? INDEX_1 : INDEX_0) + (err_chk.err_log_len >> BYTE_2);
 
             while(n < err_chk.df_block_instances)
             {
+                bool apmlHang = false;
+
                 for (int offset = 0; offset < maxOffset32; offset++)
                 {
-                    memset(&data, 0, sizeof(data));
-                    /* Offset */
-                    df_err.input[INDEX_0] = offset * BYTE_4;
-                    /* DF block ID */
-                    df_err.input[INDEX_1] = blk_id;
-                    /* DF block ID instance */
-                    df_err.input[INDEX_2] = n;
 
-                    ret = read_ras_df_err_dump(info, df_err, &data);
-
-                    if (ret != OOB_SUCCESS)
+                    if(apmlHang == false)
                     {
-                        sd_journal_print(LOG_ERR, "Failed to read Pcie dump data\n");
-                        data = BAD_DATA;
+                        memset(&data, 0, sizeof(data));
+                        memset(&df_err, 0, sizeof(df_err));
+
+                        /* Offset */
+                        df_err.input[INDEX_0] = offset * BYTE_4;
+                        /* DF block ID */
+                        df_err.input[INDEX_1] = blk_id;
+                        /* DF block ID instance */
+                        df_err.input[INDEX_2] = n;
+
+                        ret = read_ras_df_err_dump(info, df_err, &data);
+
+                        if (ret != OOB_SUCCESS)
+                        {
+                            // retry
+                            uint16_t retryCount = apmlRetryCount;
+                            while(retryCount > 0)
+                            {
+
+                                memset(&data, 0, sizeof(data));
+                                memset(&df_err, 0, sizeof(df_err));
+
+                                /* Offset */
+                                df_err.input[INDEX_0] = offset * BYTE_4;
+                                /* DF block ID */
+                                df_err.input[INDEX_1] = blk_id;
+                                /* DF block ID instance */
+                                df_err.input[INDEX_2] = n;
+
+                                ret = read_ras_df_err_dump(info, df_err, &data);
+
+                                if (ret == OOB_SUCCESS)
+                                {
+                                    break;
+                                }
+                                retryCount--;
+                                usleep(1000 * 1000);
+                            }
+
+                            if(ret != OOB_SUCCESS)
+                            {
+                                sd_journal_print(LOG_ERR, "Failed to read debug log dump for debug log ID : %d\n",blk_id);
+                                data = BAD_DATA;
+                                /*the Dump APML command fails in the middle of the iterative loop,
+                                  then write BAADDA7A for the remaining iterations in the for loop*/
+                                apmlHang = true;
+                            }
+                        }
                     }
 
                     if(info == p0_info) {
-                        rcd->P0_ErrorRecord.ContextInfo.PcieDumpData.PcieDump[n].PcieData[offset] = data;
+                        rcd->P0_ErrorRecord.ContextInfo.DebugLogIdData[DebugLogIdOffset++] = data;
                     } else if(info == p1_info) {
-                        rcd->P1_ErrorRecord.ContextInfo.PcieDumpData.PcieDump[n].PcieData[offset] = data;
+                        rcd->P1_ErrorRecord.ContextInfo.DebugLogIdData[DebugLogIdOffset++] = data;
                     }
                 }
                 n++;
@@ -488,10 +535,6 @@ void triggerColdReset()
         "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.State.Host", "RequestedHostTransition",
         std::variant<std::string>{command});
-}
-
-inline std::string getCperFilename(int num) {
-    return "ras-error" + std::to_string(num) + ".cper";
 }
 
 static bool requestGPIOEvents(
@@ -801,94 +844,6 @@ static void write_register(uint8_t info, uint32_t reg, uint32_t value)
     sd_journal_print(LOG_DEBUG, "Write to register 0x%x is successful\n", reg);
 }
 
-void calculate_time_stamp()
-{
-    using namespace std;
-    using namespace std::chrono;
-    typedef duration<int, ratio_multiply<hours::period, ratio<24> >::type> days;
-
-    system_clock::time_point now = system_clock::now();
-    system_clock::duration tp = now.time_since_epoch();
-
-    days d = duration_cast<days>(tp);
-    tp -= d;
-    hours h = duration_cast<hours>(tp);
-    tp -= h;
-    minutes m = duration_cast<minutes>(tp);
-    tp -= m;
-    seconds s = duration_cast<seconds>(tp);
-    tp -= s;
-
-    time_t tt = system_clock::to_time_t(now);
-    tm utc_tm = *gmtime(&tt);
-
-    rcd->Header.TimeStamp.Seconds = utc_tm.tm_sec;
-    rcd->Header.TimeStamp.Minutes = utc_tm.tm_min;
-    rcd->Header.TimeStamp.Hours = utc_tm.tm_hour;
-    rcd->Header.TimeStamp.Flag = 1;
-    rcd->Header.TimeStamp.Day = utc_tm.tm_mday;
-    rcd->Header.TimeStamp.Month = utc_tm.tm_mon + 1;
-    rcd->Header.TimeStamp.Year = utc_tm.tm_year;
-    rcd->Header.TimeStamp.Century = 20 + utc_tm.tm_year/100;
-    rcd->Header.TimeStamp.Year = rcd->Header.TimeStamp.Year % 100;
-}
-
-void dump_cper_header_section(uint16_t numbanks, uint16_t bytespermca)
-{
-    memcpy(rcd->Header.Signature, CPER_SIG_RECORD, CPER_SIG_SIZE);
-    rcd->Header.Revision = CPER_RECORD_REV;
-    rcd->Header.SignatureEnd = CPER_SIG_END;
-    rcd->Header.SectionCount = SECTION_COUNT;
-    rcd->Header.ErrorSeverity = CPER_SEV_FATAL;
-
-    /*Bit 0 = 1 -> PlatformID field contains valid info
-      Bit 1 = 1 -> TimeStamp field contains valid info
-      Bit 2 = 1 -> PartitionID field contains valid info*/
-
-    rcd->Header.ValidationBits = (CPER_VALID_PLATFORM_ID | CPER_VALID_TIMESTAMP);
-
-    rcd->Header.RecordLength = sizeof(CPER_RECORD);
-
-    calculate_time_stamp();
-
-    rcd->Header.PlatformId[INDEX_0] = board_id;
-
-    rcd->Header.CreatorId = CPER_CREATOR_PSTORE;
-    rcd->Header.NotifyType = CPER_NOTIFY_MCE;
-
-    if(rcd->Header.RecordId != RSVD)
-        rcd->Header.RecordId = RecordId++;
-}
-
-void dump_error_descriptor_section(uint16_t numbanks, uint16_t bytespermca,uint8_t info)
-{
-
-    rcd->SectionDescriptor[INDEX_0].SectionOffset = sizeof(COMMON_ERROR_RECORD_HEADER) +
-                              (INDEX_2 * sizeof(ERROR_SECTION_DESCRIPTOR));
-    rcd->SectionDescriptor[INDEX_0].SectionLength = sizeof(ERROR_RECORD);
-    rcd->SectionDescriptor[INDEX_0].RevisionMinor = CPER_MINOR_REV;
-    rcd->SectionDescriptor[INDEX_0].RevisionMajor = ((ADDC_GEN_NUMBER_1 & INT_15) << SHIFT_4) | EPYC_PROG_SEG_ID;
-    rcd->SectionDescriptor[INDEX_0].SecValidMask = FRU_ID_VALID | FRU_TEXT_VALID;
-    rcd->SectionDescriptor[INDEX_0].SectionFlags = CPER_PRIMARY;
-    rcd->SectionDescriptor[INDEX_0].SectionType = VENDOR_OOB_CRASHDUMP;
-    rcd->SectionDescriptor[INDEX_0].Severity = CPER_SEV_FATAL;
-    rcd->SectionDescriptor[INDEX_0].FRUText[INDEX_0] = 'P';
-    rcd->SectionDescriptor[INDEX_0].FRUText[INDEX_1] = '0';
-
-
-    rcd->SectionDescriptor[INDEX_1].SectionOffset = sizeof(COMMON_ERROR_RECORD_HEADER) +
-                             (INDEX_2 * sizeof(ERROR_SECTION_DESCRIPTOR)) + sizeof(ERROR_RECORD);
-    rcd->SectionDescriptor[INDEX_1].SectionLength = sizeof(ERROR_RECORD);
-    rcd->SectionDescriptor[INDEX_1].RevisionMinor = CPER_MINOR_REV;
-    rcd->SectionDescriptor[INDEX_1].RevisionMajor = ((ADDC_GEN_NUMBER_1 & INT_15) << SHIFT_4) | EPYC_PROG_SEG_ID;
-    rcd->SectionDescriptor[INDEX_1].SecValidMask = FRU_ID_VALID | FRU_TEXT_VALID;
-    rcd->SectionDescriptor[INDEX_1].SectionFlags = CPER_PRIMARY;
-    rcd->SectionDescriptor[INDEX_1].SectionType = VENDOR_OOB_CRASHDUMP;
-    rcd->SectionDescriptor[INDEX_1].Severity = CPER_SEV_FATAL;
-    rcd->SectionDescriptor[INDEX_1].FRUText[INDEX_0] = 'P';
-    rcd->SectionDescriptor[INDEX_1].FRUText[INDEX_1] = '1';
-}
-
 void dump_processor_error_section(uint8_t info)
 {
 
@@ -921,13 +876,28 @@ void dump_processor_error_section(uint8_t info)
 
 void dump_context_info(uint16_t numbanks,uint16_t bytespermca,uint8_t info)
 {
+
     getLastTransAddr(p0_info);
-    harvestPcieDump(p0_info);
+
+    uint8_t blk_id;
+
+    DebugLogIdOffset = 0;
+
+    for(blk_id = 0 ; blk_id < BlockId.size() ; blk_id++)
+    {
+        harvestDebugLogDump(p0_info,BlockId[blk_id]);
+    }
 
     if(num_of_proc == TWO_SOCKET)
     {
         getLastTransAddr(p1_info);
-        harvestPcieDump(p1_info);
+
+        DebugLogIdOffset = 0;
+
+        for(blk_id = 0 ; blk_id < BlockId.size() ; blk_id++)
+        {
+            harvestDebugLogDump(p1_info,BlockId[blk_id]);
+        }
     }
 
     if(info == p0_info)
@@ -959,10 +929,11 @@ static bool harvest_mca_data_banks(uint8_t info, uint16_t numbanks, uint16_t byt
     uint32_t buffer;
     struct mca_bank mca_dump;
     oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+    uint32_t Severity;
 
-    dump_cper_header_section(numbanks,bytespermca);
+    dump_cper_header_section(rcd,FATAL_SECTION_COUNT,CPER_SEV_FATAL,FATAL_ERR);
 
-    dump_error_descriptor_section(numbanks,bytespermca,info);
+    dump_error_descriptor_section(rcd,INDEX_2,FATAL_ERR,&Severity);
 
     dump_processor_error_section(info);
 
@@ -1147,6 +1118,71 @@ static bool harvest_mca_validity_check(uint8_t info, uint16_t *numbanks, uint16_
     return mac_validity_check;
 }
 
+void SystemRecovery(uint8_t buf)
+{
+
+    oob_status_t ret;
+    uint32_t ack_resp = 0;
+
+    if(systemRecovery == WARM_RESET)
+    {
+        if ((buf & SYS_MGMT_CTRL_ERR))
+        {
+            triggerColdReset();
+            sd_journal_print(LOG_INFO, "COLD RESET triggered\n");
+
+        } else {
+            /* In a 2P config, it is recommended to only send this command to P0
+            Hence, sending the Signal only to socket 0*/
+            ret = reset_on_sync_flood(p0_info, &ack_resp);
+            if(ret)
+            {
+                sd_journal_print(LOG_ERR, "Failed to request reset after sync flood\n");
+            } else {
+                sd_journal_print(LOG_ERR, "WARM RESET triggered\n");
+            }
+        }
+    }
+    else if(systemRecovery == COLD_RESET)
+    {
+        triggerColdReset();
+        sd_journal_print(LOG_INFO, "COLD RESET triggered\n");
+
+    }
+    else if(systemRecovery == NO_RESET)
+    {
+        sd_journal_print(LOG_INFO, "NO RESET triggered\n");
+    }
+    else
+    {
+        sd_journal_print(LOG_ERR, "CdumpResetPolicy is not valid\n");
+    }
+}
+
+void harvest_pcie_errors()
+{
+
+}
+
+void harvest_dram_cecc_errors()
+{
+
+}
+
+void harvest_mca_errors()
+{
+
+}
+
+void harvest_fatal_errors(uint8_t info, uint16_t numbanks, uint16_t bytespermca)
+{
+    // RAS MCA Validity Check
+    if ( true == harvest_mca_validity_check(info, &numbanks, &bytespermca) )
+    {
+        harvest_mca_data_banks(info, numbanks, bytespermca);
+    }
+}
+
 bool harvest_ras_errors(uint8_t info,std::string alert_name)
 {
     std::unique_lock lock(harvest_in_progress_mtx);
@@ -1176,6 +1212,7 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
             {
                 /*if RasStatus[reset_ctrl_err] is set in any of the processors,
                   proceed to cold reset, regardless of the status of the other P */
+
                 std::string ras_err_msg = "Fatal error detected in the control fabric. "
                                           "BMC may trigger a reset based on policy set. ";
 
@@ -1188,7 +1225,8 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
                 P1_AlertProcessed = true;
                 ControlFabricError = true;
 
-            } else if(buf & RESET_HANG_ERR)
+            }
+            else if(buf & RESET_HANG_ERR)
             {
                 std::string ras_err_msg = "System hang while resetting in syncflood."
                                           "Suggested next step is to do an additional manual immediate reset";
@@ -1200,7 +1238,40 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
 
                 FchHangError = true;
             }
-            else
+            else if(buf & PCIE_ERROR_THRESHOLD)
+            {
+                std::string ras_err_msg = "PCIE error threshold overflow detected in the system";
+
+                sd_journal_send("MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i",
+                    LOG_ERR, "REDFISH_MESSAGE_ID=%s",
+                    "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
+                    ras_err_msg.c_str(), NULL);
+
+                harvest_pcie_errors();
+            }
+            else if(buf & DRAM_CECC_ERROR_THRESHOLD)
+            {
+                std::string ras_err_msg = "DRAM Correctable error counter threshold overflow detected in the system";
+
+                sd_journal_send("MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i",
+                    LOG_ERR, "REDFISH_MESSAGE_ID=%s",
+                    "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
+                    ras_err_msg.c_str(), NULL);
+
+                harvest_dram_cecc_errors();
+            }
+            else if(buf & MCA_ERROR_THRESHOLD)
+            {
+                std::string ras_err_msg = "MCA error counter threshold overflow detected in the system";
+
+                sd_journal_send("MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i",
+                    LOG_ERR, "REDFISH_MESSAGE_ID=%s",
+                    "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
+                    ras_err_msg.c_str(), NULL);
+
+                harvest_mca_errors();
+            }
+            else if(buf & FATAL_ERROR)
             {
                 std::string ras_err_msg = "RAS FATAL Error detected. "
                                           "System may reset after harvesting MCA data based on policy set. ";
@@ -1210,27 +1281,19 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
                     "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
                     ras_err_msg.c_str(), NULL);
 
-                if(alert_name.compare("P0_ALERT") == 0 )
-                {
-                    P0_AlertProcessed = true;
-
-                }
-
-                if(alert_name.compare("P1_ALERT") == 0 )
-                {
-                    P1_AlertProcessed = true;
-
-                }
+                harvest_fatal_errors(info, numbanks, bytespermca);
             }
 
-            //Do not harvest MCA banks in case of control fabric errors
-            if((ControlFabricError == false) && (FchHangError == false))
+            if(alert_name.compare("P0_ALERT") == 0 )
             {
-                // RAS MCA Validity Check
-                if ( true == harvest_mca_validity_check(info, &numbanks, &bytespermca) )
-                {
-                    harvest_mca_data_banks(info, numbanks, bytespermca);
-                }
+                P0_AlertProcessed = true;
+
+            }
+
+            if(alert_name.compare("P1_ALERT") == 0 )
+            {
+                P1_AlertProcessed = true;
+
             }
 
             // Clear RAS status register
@@ -1261,68 +1324,12 @@ bool harvest_ras_errors(uint8_t info,std::string alert_name)
 
                 if(ControlFabricError == false)
                 {
-                    std::string cperFilePath =
-                        kRasDir.data() + getCperFilename(err_count);
-                    err_count++;
-
-                    if(err_count >= MAX_ERROR_FILE)
-                    {
-                        /*The maximum number of error files supported is 10.
-                          The counter will be rotated once it reaches max count*/
-                        err_count = (err_count % MAX_ERROR_FILE);
-                    }
-
-                    file = fopen(index_file, "w");
-
-                    if(file != NULL)
-                    {
-                        fprintf(file,"%d",err_count);
-                        fclose(file);
-                    }
-
-                    file = fopen(cperFilePath.c_str(), "w");
-                    if ((rcd != nullptr) && (file != NULL)) {
-                        sd_journal_print(LOG_DEBUG, "Generating CPER file\n");
-                        fwrite(rcd.get(), sizeof(CPER_RECORD), 1, file);
-                        fclose(file);
-                    }
+                    write_to_cper_file(rcd, FATAL_ERR, INDEX_2);
                 }
 
                 rcd = nullptr;
 
-                if(systemRecovery == WARM_RESET)
-                {
-                    if ((buf & SYS_MGMT_CTRL_ERR))
-                    {
-                        triggerColdReset();
-                        sd_journal_print(LOG_INFO, "COLD RESET triggered\n");
-
-                    } else {
-                        /* In a 2P config, it is recommended to only send this command to P0
-                           Hence, sending the Signal only to socket 0*/
-                        ret = reset_on_sync_flood(p0_info, &ack_resp);
-                        if(ret)
-                        {
-                            sd_journal_print(LOG_ERR, "Failed to request reset after sync flood\n");
-                        } else {
-                            sd_journal_print(LOG_ERR, "WARM RESET triggered\n");
-                        }
-                    }
-                }
-                else if(systemRecovery == COLD_RESET)
-                {
-                    triggerColdReset();
-                    sd_journal_print(LOG_INFO, "COLD RESET triggered\n");
-
-                }
-                else if(systemRecovery == NO_RESET)
-                {
-                    sd_journal_print(LOG_INFO, "NO RESET triggered\n");
-                }
-                else
-                {
-                    sd_journal_print(LOG_ERR, "CdumpResetPolicy is not valid\n");
-                }
+                SystemRecovery(buf);
 
                 P0_AlertProcessed = false;
                 P1_AlertProcessed = false;
@@ -1378,19 +1385,105 @@ void exportCrashdumpToDBus(int num) {
     crashdumpInterfaces[num] = {filename, iface};
 }
 
-int main() {
+void dump_run_time_error_info(uint8_t soc_num, uint16_t number_of_inst, uint16_t number_of_bytes,uint8_t error_type)
+{
 
+    uint16_t n = 0;
+    uint16_t maxOffset32;
+    struct run_time_err_d_in err_d_in;
+    oob_status_t ret;
+    uint32_t buffer;
+
+    maxOffset32 = ((number_of_bytes % BYTE_4) ? INDEX_1 : INDEX_0) + (number_of_bytes >> BYTE_2);
+    sd_journal_print(LOG_INFO, "Number of Valid error instances :%d\n", number_of_inst);
+    sd_journal_print(LOG_INFO, "Number of 32 Bit Words:%d\n", maxOffset32);
+
+    while(n < number_of_inst)
+    {
+        for (int offset = 0; offset < maxOffset32; offset++)
+        {
+            memset(&buffer, 0, sizeof(buffer));
+            memset(&err_d_in, 0, sizeof(err_d_in));
+            err_d_in.valid_inst_index = n;
+            err_d_in.offset = offset * BYTE_4;
+            err_d_in.category = error_type;
+
+            ret = get_bmc_ras_run_time_error_info(soc_num, err_d_in, &buffer);
+
+            if (ret != OOB_SUCCESS)
+            {
+                // retry
+                uint16_t retryCount = apmlRetryCount;
+                while(retryCount > 0)
+                {
+                    memset(&buffer, 0, sizeof(buffer));
+                    memset(&err_d_in, 0, sizeof(err_d_in));
+                    err_d_in.valid_inst_index  = n;
+                    err_d_in.offset = offset * BYTE_4;
+                    err_d_in.category = error_type;
+
+                    ret = get_bmc_ras_run_time_error_info(soc_num, err_d_in, &buffer);
+
+                    if (ret == OOB_SUCCESS)
+                    {
+                        break;
+                    }
+                    retryCount--;
+                }
+                if (ret != OOB_SUCCESS)
+                {
+                    sd_journal_print(LOG_ERR, "Socket %d : Failed to get run time error from Bank:%d, Offset:0x%x\n", soc_num, n, offset);
+                    /*if(info == p0_info) {
+                        rcd->P0_ErrorRecord.ContextInfo.CrashDumpData[n].mca_data[offset] = BAD_DATA;
+                    } else if(info == p1_info) {
+                       rcd->P1_ErrorRecord.ContextInfo.CrashDumpData[n].mca_data[offset] = BAD_DATA;
+                    }*/
+                    continue;
+                }
+            } // if (ret != OOB_SUCCESS)
+
+            /*if(info == p0_info) {
+                rcd->P0_ErrorRecord.ContextInfo.CrashDumpData[n].mca_data[offset] = buffer;
+            } else if(info == p1_info) {
+                rcd->P1_ErrorRecord.ContextInfo.CrashDumpData[n].mca_data[offset] = buffer;
+            }*/
+        } // for loop
+        n++;
+    }
+}
+
+void SetErrorThreshold(struct run_time_threshold th)
+{
+    oob_status_t ret;
+
+    ret = set_bmc_ras_err_threshold(p0_info, th);
+    if (ret)
+    {
+        sd_journal_print(LOG_ERR,"Failed to set bmc ras error threshold for P0\n");
+    }
+    sd_journal_print(LOG_INFO, "BMC RAS error threshold set successfully for P0\n");
+
+    if(num_of_proc == TWO_SOCKET)
+    {
+
+        ret = set_bmc_ras_err_threshold(p0_info, th);
+        if (ret)
+        {
+            sd_journal_print(LOG_ERR, "Failed to set bmc ras error threshold for P1\n");
+        }
+        sd_journal_print(LOG_INFO, "BMC RAS error threshold set successfully for P1\n");
+    }
+}
+
+/**
+ * Create Index file in /var/lib/amd-ras location
+ * to store the index of the CPER file
+ */
+void CreateIndexFile()
+{
     int dir;
     struct stat buffer;
     FILE* file;
-
-    if(getNumberOfCpu() == false)
-    {
-        sd_journal_print(LOG_ERR, "Could not find number of CPU's of the platform\n");
-        return false;
-    }
-
-    getCpuID();
 
     if (stat(kRasDir.data(), &buffer) != 0) {
         dir = mkdir(kRasDir.data(), 0777);
@@ -1420,6 +1513,12 @@ int main() {
             fclose(file);
         }
     }
+}
+
+void CreateConfigFile()
+{
+
+    struct stat buffer;
 
     /*Create Cdump Config file to store the system recovery*/
     if (stat(config_file, &buffer) != 0)
@@ -1432,6 +1531,24 @@ int main() {
         };
 
         jsonConfig["sigIDOffset"] = sigIDOffset;
+
+        if(TurinPlatform == true)
+        {
+            jsonConfig["McaPollingEn"] = true;
+            jsonConfig["McaPollingPeriod"] = 3;
+            jsonConfig["DramCeccPollingEn"] = true;
+            jsonConfig["DramCeccPollingPeriod"] = DRAM_CECC_POLLING_PERIOD;
+            jsonConfig["PcieAerPollingEn"] = true;
+            jsonConfig["PcieAerPollingPeriod"] = PCIE_AER_POLLING_PERIOD;
+
+            jsonConfig["McaThresholdEn"] = false;
+            jsonConfig["McaErrCounter"] = ERROR_THRESHOLD_VAL;
+            jsonConfig["DramCeccThresholdEn"] = false;
+            jsonConfig["DramCeccErrCounter"] = ERROR_THRESHOLD_VAL;
+            jsonConfig["PcieAerThresholdEn"] = false;
+            jsonConfig["PcieAerErrCounter"] = ERROR_THRESHOLD_VAL;
+
+        }
 
         std::ofstream jsonWrite(config_file);
         jsonWrite << jsonConfig;
@@ -1447,16 +1564,29 @@ int main() {
     harvestPpinFlag = data["harvestPpin"];
     sigIDOffset = data.at("sigIDOffset").get<std::vector<std::string>>();
 
-    jsonRead.close();
+    if(TurinPlatform == true)
+    {
+        McaPollingEn = data["McaPollingEn"];
+        McaPollingPeriod = data["McaPollingPeriod"];
+        DramCeccPollingEn= data["DramCeccPollingEn"];
+        DramCeccPollingPeriod = data["DramCeccPollingPeriod"];
+        PcieAerPollingEn = data["PcieAerPollingEn"];
+        PcieAerPollingPeriod = data["PcieAerPollingPeriod"];
 
-    if(harvestuCodeVersionFlag == true)
-    {
-        getMicrocodeRev();
+        McaThresholdEn = data["McaThresholdEn"];
+        McaErrCounter = data["McaErrCounter"];
+        DramCeccThresholdEn = data["DramCeccThresholdEn"];
+        DramCeccErrCounter = data["DramCeccErrCounter"];
+        PcieAerThresholdEn = data["PcieAerThresholdEn"];
+        PcieAerErrCounter = data["PcieAerErrCounter"];
+
     }
-    if(harvestPpinFlag == true)
-    {
-        getPpinFuse();
-    }
+
+    jsonRead.close();
+}
+
+void CreateDbusInterface()
+{
 
     rcd = std::make_shared<CPER_RECORD>();
 
@@ -1513,7 +1643,6 @@ int main() {
             updateConfigFile("apmlRetries",apmlRetryCount);
             return 1;
         });
-
     configIface->register_property("systemRecovery", systemRecovery,
         [](const uint16_t& requested, uint16_t& resp)
         {
@@ -1550,6 +1679,110 @@ int main() {
             updateConfigFile("sigIDOffset",sigIDOffset);
             return 1;
         });
+
+    if(TurinPlatform == true)
+    {
+        configIface->register_property("McaPollingEn", McaPollingEn,
+        [](const bool& requested, bool& resp)
+            {
+                resp = requested;
+                McaPollingEn = resp;
+                updateConfigFile("McaPollingEn",McaPollingEn);
+                return 1;
+            });
+
+        configIface->register_property("DramCeccPollingEn", DramCeccPollingEn,
+            [](const bool& requested, bool& resp)
+            {
+                resp = requested;
+                DramCeccPollingEn = resp;
+                updateConfigFile("DramCeccPollingEn",DramCeccPollingEn);
+                return 1;
+            });
+
+        configIface->register_property("PcieAerPollingEn", PcieAerPollingEn,
+            [](const bool& requested, bool& resp)
+            {
+                resp = requested;
+                PcieAerPollingEn = resp;
+                updateConfigFile("PcieAerPollingEn",PcieAerPollingEn);
+                return 1;
+            });
+
+        configIface->register_property("McaThresholdEn", McaThresholdEn,
+            [](const bool& requested, bool& resp)
+            {
+                resp = requested;
+                McaThresholdEn = resp;
+                updateConfigFile("McaThresholdEn",McaThresholdEn);
+                return 1;
+            });
+
+        configIface->register_property("DramCeccThresholdEn", DramCeccThresholdEn,
+            [](const bool& requested, bool& resp)
+            {
+                resp = requested;
+                DramCeccThresholdEn = resp;
+                updateConfigFile("DramCeccThresholdEn",DramCeccThresholdEn);
+                return 1;
+            });
+        configIface->register_property("PcieAerThresholdEn", PcieAerThresholdEn,
+            [](const bool& requested, bool& resp)
+            {
+                resp = requested;
+                PcieAerThresholdEn = resp;
+                updateConfigFile("PcieAerThresholdEn",PcieAerThresholdEn);
+                return 1;
+            });
+        configIface->register_property("McaPollingPeriod", McaPollingPeriod,
+            [](const uint16_t& requested, uint16_t& resp)
+            {
+                resp = requested;
+                McaPollingPeriod = resp;
+                updateConfigFile("McaPollingPeriod",McaPollingPeriod);
+                return 1;
+            });
+        configIface->register_property("DramCeccPollingPeriod", DramCeccPollingPeriod,
+            [](const uint16_t& requested, uint16_t& resp)
+            {
+                resp = requested;
+                DramCeccPollingPeriod = resp;
+                updateConfigFile("DramCeccPollingPeriod",DramCeccPollingPeriod);
+                return 1;
+            });
+        configIface->register_property("PcieAerPollingPeriod", PcieAerPollingPeriod,
+            [](const uint16_t& requested, uint16_t& resp)
+            {
+                resp = requested;
+                PcieAerPollingPeriod = resp;
+                updateConfigFile("PcieAerPollingPeriod",PcieAerPollingPeriod);
+                return 1;
+            });
+        configIface->register_property("McaErrCounter", McaErrCounter,
+            [](const uint16_t& requested, uint16_t& resp)
+            {
+                resp = requested;
+                McaErrCounter = resp;
+                updateConfigFile("McaErrCounter",McaErrCounter);
+                return 1;
+            });
+        configIface->register_property("DramCeccErrCounter", DramCeccErrCounter,
+            [](const uint16_t& requested, uint16_t& resp)
+            {
+                resp = requested;
+                DramCeccErrCounter = resp;
+                updateConfigFile("DramCeccErrCounter",DramCeccErrCounter);
+                return 1;
+            });
+        configIface->register_property("PcieAerErrCounter", PcieAerErrCounter,
+            [](const uint16_t& requested, uint16_t& resp)
+            {
+                resp = requested;
+                PcieAerErrCounter = resp;
+                updateConfigFile("PcieAerErrCounter",PcieAerErrCounter);
+                return 1;
+            });
+    }
 
     configIface->initialize();
 
@@ -1612,6 +1845,280 @@ int main() {
             exportCrashdumpToDBus(kNum);
         }
     }
+}
+
+void EnableErrorThreshold()
+{
+    if(TurinPlatform == true)
+    {
+        struct run_time_threshold th;
+
+        if(McaThresholdEn == true)
+        {
+            memset(&th, 0, sizeof(th));
+
+            sd_journal_print(LOG_INFO, "Setting error threshold for MCA error type."
+                            "Error Count threshold = %d\n",McaErrCounter); 
+
+            th.err_type = MCA_ERR;
+            th.err_count_th = McaErrCounter;
+            th.max_intrupt_rate = 0;
+
+            SetErrorThreshold(th);
+        }
+        if(DramCeccThresholdEn == true)
+        {
+            memset(&th, 0, sizeof(th));
+
+            sd_journal_print(LOG_INFO, "Setting error threshold for DRAM CECC error type."
+                            "Error Count threshold = %d\n",DramCeccErrCounter);
+
+            th.err_type = DRAM_CECC_ERR;
+            th.err_count_th = DramCeccErrCounter;
+            th.max_intrupt_rate = 0;
+
+            SetErrorThreshold(th);
+        }
+        if(PcieAerThresholdEn == true)
+        {
+            //memset(&th, 0, sizeof(th));
+
+            //th.err_type = PCIE_UE;
+            th.err_count_th = PcieAerErrCounter;
+            th.max_intrupt_rate = 0;
+
+            sd_journal_print(LOG_INFO, "Setting error threshold for PCIE UE error type."
+                            "Error Count threshold = %d\n", PcieAerErrCounter);
+
+            SetErrorThreshold(th);
+
+            memset(&th, 0, sizeof(th));
+
+            //th.err_type = PCIE_CE;
+            th.err_count_th = PcieAerErrCounter;
+            th.max_intrupt_rate = 0;
+
+            sd_journal_print(LOG_INFO, "Setting error threshold for PCIE CE error type."
+                            "Error Count threshold = %d\n", PcieAerErrCounter);
+
+            SetErrorThreshold(th);
+        }
+    }
+}
+
+oob_status_t read_register(uint8_t info,uint32_t reg,uint8_t *value)
+{
+    oob_status_t ret;
+    uint16_t retryCount = 10;
+
+    while(retryCount > 0)
+    {
+        ret = esmi_oob_read_byte(info, reg, SBRMI, value);
+        if (ret == OOB_SUCCESS) {
+            break;
+        }
+        sd_journal_print(LOG_ERR, "Failed to read register:0x%x Retrying\n", reg); 
+        usleep(1000 * 1000);
+        retryCount--;
+    }
+    if (ret != OOB_SUCCESS) {
+        sd_journal_print(LOG_ERR, "Failed to read register: 0x%x\n", reg);
+    }
+
+    return ret;
+
+}
+
+void clearSbrmiAlertMask()
+{
+
+    oob_status_t ret;
+
+    sd_journal_print(LOG_ERR, "Clear Alert Mask bit of SBRMI Control register \n");
+    uint8_t buffer;
+
+    ret = read_register(p0_info,SBRMI_CONTROL_REGISTER,&buffer);
+
+    if(ret == OOB_SUCCESS)
+    {
+        buffer = buffer & 0xFE;
+        write_register(p0_info, SBRMI_CONTROL_REGISTER, static_cast<uint32_t>(buffer));
+    }
+
+    if (num_of_proc == TWO_SOCKET)
+    {
+        buffer = 0;
+        ret = read_register(p1_info,SBRMI_CONTROL_REGISTER,&buffer);
+        if(ret == OOB_SUCCESS)
+        {
+            buffer = buffer & 0xFE;
+            write_register(p1_info, SBRMI_CONTROL_REGISTER, static_cast<uint32_t>(buffer));
+        }
+    }
+}
+
+static void currentHostStateMonitor()
+{
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+    boost::system::error_code ec;
+    auto conn = std::make_shared<sdbusplus::asio::connection>(io);
+
+    static auto match = sdbusplus::bus::match::match(
+        *conn,
+        "type='signal',member='PropertiesChanged', "
+        "interface='org.freedesktop.DBus.Properties', "
+        "arg0='xyz.openbmc_project.State.Host'",
+        [](sdbusplus::message::message& message) {
+            std::string intfName;
+            std::map<std::string, std::variant<std::string>> properties;
+
+            try
+            {
+                message.read(intfName, properties);
+            }
+            catch (std::exception& e)
+            {
+                sd_journal_print(LOG_ERR,"Unable to read host state\n");
+                return;
+            }
+            if (properties.empty())
+            {
+                sd_journal_print(LOG_ERR,"ERROR: Empty PropertiesChanged signal received\n");
+                return;
+            }
+
+            // We only want to check for CurrentHostState
+            if (properties.begin()->first != "CurrentHostState")
+            {
+                return;
+            }
+            std::string* currentHostState =
+                std::get_if<std::string>(&(properties.begin()->second));
+            if (currentHostState == nullptr)
+            {
+                sd_journal_print(LOG_ERR,"property invalid\n");
+                return;
+            }
+
+            if (*currentHostState !=
+                "xyz.openbmc_project.State.Host.HostState.Off")
+            {
+                struct stat buffer;
+
+                while(INDEX_1)
+                {
+                    if (stat(APML_INIT_DONE_FILE, &buffer) == 0)
+                    {
+                        sd_journal_print(LOG_INFO, "APML initialization done \n");
+                        break;
+                    }
+                }
+                clearSbrmiAlertMask();
+                SetOobConfig();
+            }
+
+        });
+}
+
+ /* Check if the ADDC feature is supported for the platform
+ * Supported platform = Stones , Breithorn , MI300
+ * @return true if the module is supported, false otherwise.
+ */
+bool validatePlatformSupport()
+{
+    oob_status_t ret;
+    uint8_t soc_num = 0;
+
+    struct processor_info plat_info[INDEX_1];
+    struct stat buffer;
+    uint16_t retryCount = 10;
+
+    while(INDEX_1)
+    {
+        if (stat(APML_INIT_DONE_FILE, &buffer) == 0)
+        {
+            sd_journal_print(LOG_INFO, "APML initialization done\n");
+            break;
+        }
+    }
+
+    sd_journal_print(LOG_INFO, "Validating platform support \n");
+
+    while(retryCount > 0)
+    {
+        ret = esmi_get_processor_info(soc_num, plat_info);
+
+        if(ret == OOB_SUCCESS)
+        {
+            break;
+        }
+        usleep(1000 * 1000);
+        retryCount--;
+        sd_journal_print(LOG_INFO, "Reading family ID failed. Retry count = %d \n", retryCount);
+
+    }
+    if (plat_info->family == GENOA_FAMILY_ID)
+    {
+        GenoaPlatform = true;
+
+        BlockId = {BLOCK_ID_33};
+    }
+    else if (plat_info->family == TURIN_FAMILY_ID)
+    {
+        TurinPlatform = true;
+
+        clearSbrmiAlertMask();
+
+        currentHostStateMonitor();
+
+        BlockId = {BLOCK_ID_1, BLOCK_ID_2, BLOCK_ID_3, BLOCK_ID_33, BLOCK_ID_36, BLOCK_ID_37,
+                    BLOCK_ID_38,BLOCK_ID_40};
+    }
+    else {
+        sd_journal_print(LOG_ERR, "ADDC is not supported for this platform\n");
+        return false;
+    }
+    return true;
+}
+
+int main()
+{
+
+    struct stat buffer;
+    if(validatePlatformSupport() == false)
+    {
+        return false;
+    }
+
+    TurinPlatform = true;
+    if(getNumberOfCpu() == false)
+    {
+        sd_journal_print(LOG_ERR, "Could not find number of CPU's of the platform\n");
+        return false;
+    }
+
+    getCpuID();
+
+    getBoardID();
+
+    CreateIndexFile();
+
+    CreateConfigFile();
+
+    if(harvestuCodeVersionFlag == true)
+    {
+        getMicrocodeRev();
+    }
+    if(harvestPpinFlag == true)
+    {
+        getPpinFuse();
+    }
+
+    CreateDbusInterface();
+
+    RunTimeErrorPolling();
+
+//    EnableErrorThreshold();
 
     requestGPIOEvents("P0_I3C_APML_ALERT_L", P0AlertEventHandler, P0_apmlAlertLine, P0_apmlAlertEvent);
     requestGPIOEvents("P0_DIMM_AF_ERROR", P0PmicAfEventHandler, P0_pmicAfAlertLine, P0_pmicAfAlertEvent);
@@ -1626,6 +2133,15 @@ int main() {
     }
 
     io.run();
+
+    if(McaErrorPollingEvent != nullptr)
+        delete McaErrorPollingEvent;
+
+    if(DramCeccErrorPollingEvent != nullptr)
+        delete DramCeccErrorPollingEvent;
+
+        if(PcieAerErrorPollingEvent != nullptr)
+            delete PcieAerErrorPollingEvent;
 
     return 0;
 }

--- a/src/runtime_errors.cpp
+++ b/src/runtime_errors.cpp
@@ -1,0 +1,626 @@
+#include "ras.hpp"
+#include "cper.hpp"
+#include "cper_runtime.hpp"
+#include "write_cper_data.hpp"
+
+extern boost::asio::io_service io;
+
+std::shared_ptr<PROC_RUNTIME_ERR_RECORD> mca_ptr = nullptr;
+std::shared_ptr<PROC_RUNTIME_ERR_RECORD> dram_ptr = nullptr;
+std::shared_ptr<PCIE_RUNTIME_ERR_RECORD> pcie_ptr = nullptr;
+
+std::mutex mca_error_harvest_mtx;
+std::mutex dram_error_harvest_mtx;
+std::mutex pcie_error_harvest_mtx;
+
+oob_status_t RunTimeErrValidityCheck(uint8_t soc_num,uint32_t rt_err_category,struct ras_rt_valid_err_inst *inst)
+{
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+
+    ret = get_bmc_ras_run_time_err_validity_ck(soc_num, rt_err_category,
+                           inst);
+    if (ret) {
+        sd_journal_print(LOG_DEBUG,"Failed to get bmc ras runtime error validity check\n");
+    }
+
+    return ret;
+}
+
+void SetOobConfig()
+{
+    oob_status_t ret;
+    struct oob_config_d_in oob_config;
+
+    memset(&oob_config, 0, sizeof(oob_config));
+
+    if(McaPollingEn == true)
+    {
+        /* Core MCA OOB Error Reporting Enable */
+        oob_config.core_mca_err_reporting_en = ENABLE_BIT;
+    }
+
+    if(DramCeccPollingEn == true)
+    {
+        /* DRAM CECC OOB Error Counter Mode */
+        oob_config.core_mca_err_reporting_en = ENABLE_BIT;
+        oob_config.dram_cecc_oob_ec_mode = ENABLE_BIT; /*Enabled in No leak mode*/
+    }
+
+    if(PcieAerPollingEn == true)
+    {
+        /* PCIe OOB Error Reporting Enable */
+        oob_config.pcie_err_reporting_en = ENABLE_BIT;
+    }
+
+    ret = set_bmc_ras_oob_config(p0_info, oob_config);
+
+    if (ret) {
+        sd_journal_print(LOG_ERR, "Failed to set ras oob configuration\n");
+    }
+
+    if(num_of_proc == TWO_SOCKET)
+    {
+        ret = set_bmc_ras_oob_config(p1_info, oob_config);
+
+        if (ret) {
+            sd_journal_print(LOG_ERR, "Failed to set ras oob configuration\n");
+        }
+    }
+
+    sd_journal_print(LOG_INFO, "BMC RAS oob configuration set successfully\n");
+}
+
+template<typename T>
+void dump_proc_error_section(const std::shared_ptr<T>& data,uint8_t soc_num,
+            struct ras_rt_valid_err_inst inst,uint8_t category,uint16_t Section,uint32_t *Severity,uint64_t *CheckInfo)
+{
+    uint16_t maxOffset32;
+    uint16_t n = 0;
+    struct run_time_err_d_in d_in;
+    uint32_t d_out;
+    uint64_t mca_status_register = 0;
+    uint32_t root_err_status = 0;
+    uint32_t offset = 0;
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+
+    sd_journal_print(LOG_INFO, "Harvesting errors for category %d\n",category);
+    std::shared_ptr<PROC_RUNTIME_ERR_RECORD> ProcPtr;
+    std::shared_ptr<PCIE_RUNTIME_ERR_RECORD> PciePtr;
+
+    if constexpr (std::is_same_v<T, PROC_RUNTIME_ERR_RECORD>) {
+        ProcPtr = std::static_pointer_cast<PROC_RUNTIME_ERR_RECORD>(data);
+    }
+    if constexpr (std::is_same_v<T, PCIE_RUNTIME_ERR_RECORD>) {
+        PciePtr = std::static_pointer_cast<PCIE_RUNTIME_ERR_RECORD>(data);
+    }
+
+    while(n < inst.number_of_inst)
+    {
+        if(category == DRAM_CECC_ERR)
+        {
+            offset = INDEX_4;
+        }
+        else {
+            offset = 0;
+        }
+
+        int DumpIndex = 0;
+
+        for (; offset < inst.number_bytes; offset = offset+INDEX_4)
+        {
+            memset(&d_in,0,sizeof(d_in));
+            memset(&d_out,0,sizeof(d_out));
+            d_in.offset = offset;
+            d_in.category = category;
+            d_in.valid_inst_index = n;
+
+            ret = get_bmc_ras_run_time_error_info(soc_num, d_in, &d_out);
+
+            if (ret != OOB_SUCCESS)
+            {
+                // retry
+                uint16_t retryCount = apmlRetryCount;
+                while(retryCount > 0)
+                {
+                    memset(&d_in,0,sizeof(d_in));
+                    memset(&d_out,0,sizeof(d_out));
+                    d_in.offset = offset;
+                    d_in.category = category;
+                    d_in.valid_inst_index = n;
+
+                    ret = get_bmc_ras_run_time_error_info(soc_num, d_in, &d_out);
+
+                    if (ret == OOB_SUCCESS)
+                    {
+                        break;
+                    }
+                    retryCount--;
+                    usleep(1000 * 1000);
+                }
+
+            }
+            if (ret != OOB_SUCCESS)
+            {
+                sd_journal_print(LOG_ERR, "Socket %d : Failed to get runtime error info for instance :%d, Offset:0x%x\n", soc_num, n, offset);
+                if(ProcPtr) {
+                    ProcPtr->ProcErrorSection[Section].ProcContextStruct.DumpData[DumpIndex] = BAD_DATA; 
+                } else if(PciePtr) {
+                    PciePtr->PcieErrorSection[Section].AerInfo[DumpIndex] = BAD_DATA;
+                }
+                continue;
+            }
+
+            if(ProcPtr)
+            {
+                ProcPtr->ProcErrorSection[Section].ProcContextStruct.DumpData[DumpIndex] = d_out;
+
+                if(d_in.offset == INDEX_8)
+                {
+                    mca_status_register = mca_status_register | ((uint64_t) d_out);
+                }
+                else if(d_in.offset == INDEX_12)
+                {
+                    mca_status_register = ((uint64_t)d_out << INDEX_32) | mca_status_register;
+                }
+            } else if(PciePtr)
+            {
+                PciePtr->PcieErrorSection[Section].AerInfo[DumpIndex] = d_out;
+
+                if(d_in.offset == INDEX_44)
+                {
+                    root_err_status = d_out;
+                }
+            }
+            DumpIndex++;
+
+        } // for loop
+
+        if((category == MCA_ERR) || (category = DRAM_CECC_ERR))
+        { 
+            if ((mca_status_register & (1ULL << INDEX_61)) == 0) {
+                Severity[n] = SEV_NON_FATAL_CORRECTED;
+            }
+            else if((mca_status_register & (1ULL << INDEX_61) == 1) && 
+                   ((mca_status_register & (1ULL << INDEX_57)) == 0)) {
+                Severity[n] = SEV_NON_FATAL_UNCORRECTED;
+            }
+        }
+        else if(category = PCIE_ERR)
+        {
+
+            if (root_err_status & (INDEX_1 << INDEX_6))
+            {
+                Severity[Section] = CPER_SEV_FATAL;
+            }
+            else if (root_err_status & (INDEX_1 << INDEX_5))
+            {
+                Severity[Section] = SEV_NON_FATAL_UNCORRECTED;
+            }
+            else if (root_err_status & INDEX_1)
+            {
+                Severity[Section] = SEV_NON_FATAL_CORRECTED;
+            }
+        } 
+
+        if((category == MCA_ERR) || (category = DRAM_CECC_ERR))
+        {
+            CheckInfo[Section] = 0;
+            CheckInfo[Section] |= ((mca_status_register >> INDEX_57) & 1ULL) << INDEX_19;
+            CheckInfo[Section] |= ((mca_status_register >> INDEX_61) & 1ULL) << INDEX_20;
+            CheckInfo[Section] |= ((mca_status_register >> INDEX_62) & 1ULL) << INDEX_23;
+            CheckInfo[Section] |= (5ULL << INDEX_16);
+        }
+
+        n++;
+        Section++;
+    }
+}
+
+template<typename T>
+void dump_pcie_error_info_section(const std::shared_ptr<T>& data,
+                uint16_t SectionStart,uint16_t SectionCount)
+{
+
+    for(int i = SectionStart ; i < SectionCount ; i++)
+    {
+        data->PcieErrorSection[i].ValidationBits |= 1ULL | (1ULL << INDEX_1) 
+                                                    | (1ULL << INDEX_3) | (1ULL << INDEX_7); 
+        data->PcieErrorSection[i].PortType = INDEX_4; //Root Port
+        data->PcieErrorSection[i].Version.Major = INDEX_2;
+        data->PcieErrorSection[i].DeviceId.VendorId = PCIE_VENDOR_ID;
+    }
+}
+
+template<typename T>
+void dump_proc_error_info_section(const std::shared_ptr<T>& ProcPtr, uint8_t soc_num,uint16_t SectionCount,
+                                 uint64_t *CheckInfo,uint32_t SectionStart)
+{
+
+    for(uint32_t i = SectionStart ; i < SectionCount ; i++)
+    {
+        ProcPtr->ProcErrorSection[i].ProcInfoSection.ValidBits =  0b11 | (SectionCount << INDEX_2) | (SectionCount << INDEX_8);
+
+        if(soc_num == p0_info)
+        {
+            ProcPtr->ProcErrorSection[i].ProcInfoSection.CpuId[INDEX_0] = p0_eax;
+            ProcPtr->ProcErrorSection[i].ProcInfoSection.CpuId[INDEX_2] = p0_ebx;
+            ProcPtr->ProcErrorSection[i].ProcInfoSection.CpuId[INDEX_4] = p0_ecx;
+            ProcPtr->ProcErrorSection[i].ProcInfoSection.CpuId[INDEX_6] = p0_edx;
+            ProcPtr->ProcErrorSection[i].ProcInfoSection.CPUAPICId = ((p0_ebx >> SHIFT_24) & INT_255);
+        }
+        if(soc_num == p1_info)
+        {
+            ProcPtr->ProcErrorSection[i].ProcInfoSection.CpuId[INDEX_0] = p1_eax;
+            ProcPtr->ProcErrorSection[i].ProcInfoSection.CpuId[INDEX_2] = p1_ebx;
+            ProcPtr->ProcErrorSection[i].ProcInfoSection.CpuId[INDEX_4] = p1_ecx;
+            ProcPtr->ProcErrorSection[i].ProcInfoSection.CpuId[INDEX_6] = p1_edx;
+            ProcPtr->ProcErrorSection[i].ProcInfoSection.CPUAPICId = ((p1_ebx >> SHIFT_24) & INT_255);
+        }
+
+        ProcPtr->ProcErrorSection[i].ProcErrorInfo.ErrorType = MS_CHECK_GUID;
+        ProcPtr->ProcErrorSection[i].ProcErrorInfo.ValidationBits = ENABLE_BIT;
+        ProcPtr->ProcErrorSection[i].ProcErrorInfo.CheckInfo = CheckInfo[i];
+        ProcPtr->ProcErrorSection[i].ProcContextStruct.RegContextType = ENABLE_BIT;
+        ProcPtr->ProcErrorSection[i].ProcContextStruct.RegArraySize = MCA_BANK_MAX_OFFSET;
+         
+    }
+
+}
+
+/*The function returns the highest severity out of all Section Severity for CPER header
+  Severity Order = Fatal > non-fatal uncorrected > corrected*/ 
+bool calculate_highest_severity(uint32_t* Severity,uint16_t SectionCount,uint32_t* HighestSeverity,std::string ErrorType)
+{
+    bool rc = true;
+    *HighestSeverity = SEV_NON_FATAL_CORRECTED;
+
+    for(int i = 0 ; i < SectionCount; i++)
+    {
+        if(Severity[i] == CPER_SEV_FATAL)
+        {
+            if(ErrorType == RUNTIME_PCIE_ERR)
+            {
+                *HighestSeverity = CPER_SEV_FATAL;
+                 break;
+            }
+            else
+            {
+                sd_journal_print(LOG_ERR, "Error Severity is fatal. This must be captured in Crashdump CPER, not runtime CPER\n");
+                rc = false; 
+            }
+        }
+        else if(Severity[i] == SEV_NON_FATAL_UNCORRECTED)
+        {
+            *HighestSeverity = SEV_NON_FATAL_UNCORRECTED;
+             break;
+        }
+    }
+    return rc;
+}
+
+void harvest_runtime_errors(uint8_t ErrorPollingType, struct ras_rt_valid_err_inst p0_inst,struct ras_rt_valid_err_inst p1_inst)
+{
+
+    uint8_t category;
+    uint32_t *Severity = nullptr;
+    uint64_t *CheckInfo = nullptr;
+    uint32_t HighestSeverity;
+    uint32_t SectionDesSize = 0;
+    uint32_t SectionSize = 0;
+
+    uint16_t SectionCount = p0_inst.number_of_inst + p1_inst.number_of_inst;
+
+    Severity = new uint32_t[SectionCount];
+    CheckInfo = new uint64_t[SectionCount];
+
+    if(ErrorPollingType == MCA_ERR)
+    {
+        std::unique_lock lock(mca_error_harvest_mtx);
+
+        mca_ptr->SectionDescriptor = new error_section_descriptor[SectionCount];
+        SectionDesSize = sizeof(error_section_descriptor) * SectionCount;
+        memset(mca_ptr->SectionDescriptor, 0 , SectionDesSize);
+
+        mca_ptr->ProcErrorSection = new proc_error_section[SectionCount];
+        SectionSize = sizeof(proc_error_section) * SectionCount;
+        memset(mca_ptr->ProcErrorSection, 0 , SectionSize);
+
+        uint16_t SectionStart = 0;
+
+        if(p0_inst.number_of_inst != 0)
+        {
+            dump_proc_error_section(mca_ptr,p0_info,p0_inst,MCA_ERR,SectionStart,Severity,CheckInfo);
+
+            dump_proc_error_info_section(mca_ptr,p0_info,p0_inst.number_of_inst,CheckInfo,SectionStart);
+        }
+        if(p1_inst.number_of_inst != 0)
+        {
+            SectionStart = SectionCount - p1_inst.number_of_inst;
+
+            dump_proc_error_section(mca_ptr,p1_info,p1_inst,MCA_ERR,SectionStart,Severity,CheckInfo);
+
+            dump_proc_error_info_section(mca_ptr,p1_info,SectionCount,CheckInfo,SectionStart);
+        }
+
+        calculate_highest_severity(Severity,SectionCount,&HighestSeverity,RUNTIME_MCA_ERR);
+
+        dump_cper_header_section(mca_ptr, SectionCount, HighestSeverity, RUNTIME_MCA_ERR);
+
+        dump_error_descriptor_section(mca_ptr, SectionCount,RUNTIME_MCA_ERR,Severity);
+
+        write_to_cper_file(mca_ptr,RUNTIME_MCA_ERR,SectionCount);
+
+        if(mca_ptr->SectionDescriptor != nullptr) {
+            delete[] mca_ptr->SectionDescriptor;
+            mca_ptr->SectionDescriptor = nullptr;
+        }
+
+        if(mca_ptr->ProcErrorSection != nullptr) {
+            delete[] mca_ptr->ProcErrorSection;
+            mca_ptr->ProcErrorSection = nullptr;
+        }
+    }
+    else if(ErrorPollingType == DRAM_CECC_ERR)
+    {
+        std::unique_lock lock(dram_error_harvest_mtx);
+
+        dram_ptr->SectionDescriptor = new error_section_descriptor[SectionCount];
+        SectionDesSize = sizeof(error_section_descriptor) * SectionCount;
+        memset(dram_ptr->SectionDescriptor, 0 , SectionDesSize);
+
+        dram_ptr->ProcErrorSection = new proc_error_section[SectionCount];
+        SectionSize = sizeof(proc_error_section) * SectionCount;
+        memset(dram_ptr->ProcErrorSection, 0 , SectionSize);
+
+        uint16_t SectionStart = 0;
+
+        if(p0_inst.number_of_inst != 0)
+        {
+            dump_proc_error_section(dram_ptr,p0_info,p0_inst,DRAM_CECC_ERR,SectionStart,Severity,CheckInfo);
+
+            dump_proc_error_info_section(dram_ptr,p0_info,p0_inst.number_of_inst,CheckInfo,SectionStart);
+        }
+        if(p1_inst.number_of_inst != 0)
+        {
+            SectionStart = SectionCount - p1_inst.number_of_inst;
+
+            dump_proc_error_section(dram_ptr,p1_info,p1_inst,DRAM_CECC_ERR,SectionStart,Severity,CheckInfo);
+
+            dump_proc_error_info_section(dram_ptr,p1_info,SectionCount,CheckInfo,SectionStart);
+        }
+
+        calculate_highest_severity(Severity,SectionCount,&HighestSeverity,RUNTIME_DRAM_ERR);
+
+        dump_cper_header_section(dram_ptr, SectionCount, HighestSeverity, RUNTIME_DRAM_ERR);
+
+        dump_error_descriptor_section(dram_ptr, SectionCount,RUNTIME_DRAM_ERR,Severity);
+
+        write_to_cper_file(dram_ptr,RUNTIME_DRAM_ERR,SectionCount);
+
+        if(dram_ptr->SectionDescriptor != nullptr) {
+            delete[] dram_ptr->SectionDescriptor;
+            dram_ptr->SectionDescriptor = nullptr;
+        }
+
+        if(dram_ptr->ProcErrorSection != nullptr) {
+            delete[] dram_ptr->ProcErrorSection;
+            dram_ptr->ProcErrorSection = nullptr;
+        }
+
+    }
+    else if(ErrorPollingType == PCIE_ERR)
+    {
+
+        std::unique_lock lock(pcie_error_harvest_mtx);
+
+        pcie_ptr->SectionDescriptor = new error_section_descriptor[SectionCount];
+        SectionDesSize = sizeof(error_section_descriptor) * SectionCount;
+        memset(pcie_ptr->SectionDescriptor, 0 , SectionDesSize);
+
+        pcie_ptr->PcieErrorSection = new pcie_error_section[SectionCount];
+        SectionSize = sizeof(pcie_error_section) * SectionCount;
+        memset(pcie_ptr->PcieErrorSection, 0 , SectionSize);
+
+        uint16_t SectionStart = 0;
+
+        if(p0_inst.number_of_inst != 0)
+        {
+            dump_proc_error_section(pcie_ptr,p0_info,p0_inst,PCIE_ERR,SectionStart,Severity,CheckInfo);
+            dump_pcie_error_info_section(pcie_ptr,SectionStart,p0_inst.number_of_inst);
+        }
+        if(p1_inst.number_of_inst != 0)
+        {
+            SectionStart = SectionCount - p1_inst.number_of_inst;
+
+            dump_proc_error_section(pcie_ptr,p1_info,p1_inst,PCIE_ERR,SectionStart,Severity,CheckInfo);
+            dump_pcie_error_info_section(pcie_ptr,SectionStart,SectionCount);
+        }
+
+        calculate_highest_severity(Severity,SectionCount,&HighestSeverity,RUNTIME_PCIE_ERR);
+
+        dump_cper_header_section(pcie_ptr, SectionCount, HighestSeverity, RUNTIME_PCIE_ERR);
+
+        dump_error_descriptor_section(pcie_ptr, SectionCount,RUNTIME_PCIE_ERR,Severity);
+
+        write_to_cper_file(pcie_ptr,RUNTIME_PCIE_ERR,SectionCount);
+
+        if(pcie_ptr->SectionDescriptor != nullptr) {
+            delete[] pcie_ptr->SectionDescriptor;
+            pcie_ptr->SectionDescriptor = nullptr;
+        }
+
+        if(pcie_ptr->PcieErrorSection != nullptr) {
+            delete[] pcie_ptr->PcieErrorSection;
+            pcie_ptr->PcieErrorSection = nullptr;
+        }
+
+    }
+
+    if(CheckInfo != nullptr) {
+        delete[] CheckInfo;
+        CheckInfo = nullptr;
+    }
+
+    if(Severity != nullptr) {
+        delete[] Severity;
+        Severity = nullptr;
+    }
+}
+
+void McaErrorPollingHandler(uint16_t PollingPeriod)
+{
+    struct ras_rt_valid_err_inst p0_inst,p1_inst;
+    uint32_t rt_err_category;
+    oob_status_t p0_ret = OOB_MAILBOX_CMD_UNKNOWN ,p1_ret = OOB_MAILBOX_CMD_UNKNOWN;
+
+    rt_err_category = 0 ; /*00 = MCA*/
+    memset(&p0_inst, 0, sizeof(p0_inst));
+    memset(&p1_inst, 0, sizeof(p1_inst));
+
+    p0_ret =  RunTimeErrValidityCheck(p0_info,rt_err_category,&p0_inst);
+
+    if(num_of_proc == TWO_SOCKET)
+    {
+        
+        p1_ret = RunTimeErrValidityCheck(p1_info,rt_err_category,&p1_inst);
+    }
+
+    if(((p0_ret == OOB_SUCCESS) && (p0_inst.number_of_inst > 0)) ||
+            ((p1_ret == OOB_SUCCESS) && (p1_inst.number_of_inst > 0)))
+    {
+
+        if (mca_ptr == nullptr)
+        {
+            mca_ptr = std::make_shared<PROC_RUNTIME_ERR_RECORD>();
+        }
+
+        harvest_runtime_errors(MCA_ERR,p0_inst,p1_inst);
+    }
+
+    if(McaErrorPollingEvent != nullptr)
+        delete McaErrorPollingEvent;
+
+    McaErrorPollingEvent = new boost::asio::deadline_timer(io,boost::posix_time::seconds(PollingPeriod));
+
+    McaErrorPollingEvent->async_wait(
+        [PollingPeriod](const boost::system::error_code ec) {
+            if (ec)
+            {
+                sd_journal_print(LOG_ERR, "fd handler error failed: %s \n", ec.message().c_str());
+                return;
+            }
+            McaErrorPollingHandler(PollingPeriod);
+        });
+}
+
+void DramCeccErrorPollingHandler(uint16_t PollingPeriod)
+{
+    struct ras_rt_valid_err_inst p0_inst,p1_inst;
+    uint32_t rt_err_category;
+    oob_status_t p0_ret = OOB_MAILBOX_CMD_UNKNOWN ,p1_ret = OOB_MAILBOX_CMD_UNKNOWN;
+
+    rt_err_category = ENABLE_BIT ; /*01 = DRAM CECC*/
+    memset(&p0_inst, 0, sizeof(p0_inst));
+    memset(&p1_inst, 0, sizeof(p1_inst));
+
+    p0_ret = RunTimeErrValidityCheck(p0_info,rt_err_category,&p0_inst);
+
+    if(num_of_proc == TWO_SOCKET)
+    {
+        p1_ret = RunTimeErrValidityCheck(p1_info,rt_err_category,&p1_inst);
+    }
+
+    if(((p0_ret == OOB_SUCCESS) && (p0_inst.number_of_inst > 0)) ||
+            ((p1_ret == OOB_SUCCESS) && (p1_inst.number_of_inst > 0)))
+    {
+        if (dram_ptr == nullptr) {
+            dram_ptr = std::make_shared<PROC_RUNTIME_ERR_RECORD>();
+        }
+        harvest_runtime_errors(DRAM_CECC_ERR,p0_inst,p1_inst);
+    }
+
+    if(DramCeccErrorPollingEvent != nullptr)
+        delete DramCeccErrorPollingEvent;
+
+    DramCeccErrorPollingEvent = new boost::asio::deadline_timer(io,boost::posix_time::seconds(PollingPeriod));
+
+    DramCeccErrorPollingEvent->async_wait(
+        [PollingPeriod](const boost::system::error_code ec) {
+            if (ec)
+            {
+                sd_journal_print(LOG_ERR, "fd handler error failed: %s \n", ec.message().c_str());
+                return;
+            }
+            DramCeccErrorPollingHandler(PollingPeriod);
+        });
+}
+
+void PcieErrorPollingHandler(uint16_t PollingPeriod)
+{
+
+    struct ras_rt_valid_err_inst p0_inst,p1_inst;
+    uint32_t rt_err_category;
+    oob_status_t p0_ret = OOB_MAILBOX_CMD_UNKNOWN ,p1_ret = OOB_MAILBOX_CMD_UNKNOWN;
+
+    rt_err_category = BYTE_2 ; /*10 = PCIe*/
+    memset(&p0_inst, 0, sizeof(p0_inst));
+    memset(&p1_inst, 0, sizeof(p1_inst));
+
+    p0_ret = RunTimeErrValidityCheck(p0_info,rt_err_category,&p0_inst);
+
+    if(num_of_proc == TWO_SOCKET)
+    {
+        p1_ret = RunTimeErrValidityCheck(p1_info,rt_err_category,&p1_inst);
+
+        if(p1_ret != OOB_SUCCESS)
+        {
+            memset(&p1_inst, 0, sizeof(p1_inst));
+        } 
+    }
+
+    if(((p0_ret == OOB_SUCCESS) && (p0_inst.number_of_inst > 0)) ||
+            ((p1_ret == OOB_SUCCESS) && (p1_inst.number_of_inst > 0)))
+    {
+        if (pcie_ptr == nullptr) {
+            pcie_ptr = std::make_shared<PCIE_RUNTIME_ERR_RECORD>();
+        }
+        harvest_runtime_errors(PCIE_ERR,p0_inst,p1_inst);
+
+    }
+
+    if(PcieAerErrorPollingEvent != nullptr)
+        delete PcieAerErrorPollingEvent;
+
+    PcieAerErrorPollingEvent = new boost::asio::deadline_timer(io,boost::posix_time::seconds(PollingPeriod));
+
+    PcieAerErrorPollingEvent->async_wait(
+        [PollingPeriod](const boost::system::error_code ec) {
+            if (ec)
+            {
+                sd_journal_print(LOG_ERR, "fd handler error failed: %s \n", ec.message().c_str());
+                return;
+            }
+            PcieErrorPollingHandler(PollingPeriod);
+        });
+}
+
+void RunTimeErrorPolling()
+{
+    if(TurinPlatform == true)
+    {
+        SetOobConfig();
+
+        if(McaPollingEn == true)
+        {
+            McaErrorPollingHandler(McaPollingPeriod);
+        }
+        if(DramCeccPollingEn == true)
+        {
+            DramCeccErrorPollingHandler(DramCeccPollingPeriod);
+        }
+        if(PcieAerPollingEn == true)
+        {
+            PcieErrorPollingHandler(PcieAerPollingPeriod);
+        }
+    }
+}


### PR DESCRIPTION
1. Support Runtime error polling for MCA , DRAM CECC and PCIE errors.
2. Add redfish implementation to enable MCA , DRAM CECC and PCIE error polling and set the polling period for all these errors.
3. Clear Alert Mask bit of sbrmi control register
4. Support error harvesting of additional debug log ID's in Turin
