### PR TITLE
Change CPER section size

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -14,7 +14,7 @@
 #define MCA_BANK_MAX_OFFSET         (128)
 #define SYS_MGMT_CTRL_ERR           (0x04)
 #define RESET_HANG_ERR              (0x02)
-#define DF_DUMP_RESERVED            (11571)
+#define DF_DUMP_RESERVED            (11535)
 #define MAX_ERROR_FILE              (10)
 #define LAST_TRANS_ADDR_OFFSET      (4)
 #define PCIE_DUMP_OFFSET            (49)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@ extern "C" {
 }
 
 #define COMMAND_NUM_OF_CPU  ("/sbin/fw_printenv -n num_of_cpu")
+#define COMMAND_BOARD_ID    ("/sbin/fw_printenv -n board_id")
 #define COMMAND_LEN         (3)
 #define MAX_MCA_BANKS       (32)
 #define TWO_SOCKET          (2)
@@ -199,6 +200,30 @@ bool getNumberOfCpu()
     }
 
     return ret;
+}
+
+void getBoardID()
+{
+    FILE *pf;
+    char data[COMMAND_LEN];
+    std::stringstream ss;
+
+    // Setup pipe for reading and execute to get u-boot environment
+    // variable board_id.
+    pf = popen(COMMAND_BOARD_ID,"r");
+    // Error handling
+    if(pf)
+    {
+        // Get the data from the process execution
+        if (fgets(data, COMMAND_LEN, pf))
+        {
+            ss << std::hex << (std::string)data;
+            ss >> board_id;
+            sd_journal_print(LOG_DEBUG, "Board ID: 0x%x, Board ID String: %s\n", board_id, data);
+        }
+        // the data is now in 'data'
+        pclose(pf);
+    }
 }
 
 void getCpuID()
@@ -1391,6 +1416,7 @@ int main() {
     }
 
     getCpuID();
+    getBoardID();
 
     if (stat(kRasDir.data(), &buffer) != 0) {
         dir = mkdir(kRasDir.data(), 0777);


### PR DESCRIPTION
1. Changed Fatal error CPER section size to 65536b which was 65680b previously.
2. Added BoarID change which is removed as part of platform specific code