### PR TITLE
Code cleanup

### DIFF
--- a/inc/ras.hpp
+++ b/inc/ras.hpp
@@ -155,8 +155,6 @@ extern boost::asio::deadline_timer *PcieAerErrorPollingEvent;
 extern uint8_t p0_info;
 extern uint8_t p1_info;
 extern int num_of_proc;
-extern bool TurinPlatform;
-extern bool GenoaPlatform;
 
 extern unsigned int board_id;
 extern uint64_t RecordId;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,9 +63,6 @@ uint64_t p1_ppin = 0;
 uint64_t p0_last_transact_addr = 0;
 uint64_t p1_last_transact_addr = 0;
 
-bool TurinPlatform = false;
-bool GenoaPlatform = false;
-
 std::vector<uint8_t> BlockId;
 uint8_t ProgId = 0;
 bool apmlInitialized = false;


### PR DESCRIPTION
The variables TurinPlatform, GenoaPlatform defined in the code but not used. Removing these codes for code cleanup