### PR TITLE
Increase the Set Ras Oob Config retries

### DIFF
--- a/inc/ras.hpp
+++ b/inc/ras.hpp
@@ -73,6 +73,8 @@ extern "C" {
 #define RUNTIME_DRAM_ERR ("RUNTIME_DRAM_ERROR")
 #define FATAL_ERR ("FATAL")
 
+#define RETRY_45 (45)
+#define SLEEP_20 (20)
 #define WARM_RESET (0)
 #define COLD_RESET (1)
 #define NO_RESET (2)

--- a/src/runtime_errors.cpp
+++ b/src/runtime_errors.cpp
@@ -58,7 +58,7 @@ oob_status_t SetOobConfig()
         oob_config.pcie_err_reporting_en = ENABLE_BIT;
     }
 
-    uint16_t retryCount = 30;
+    uint16_t retryCount = RETRY_45;
 
     while (retryCount > 0)
     {
@@ -73,13 +73,13 @@ oob_status_t SetOobConfig()
             sd_journal_print(LOG_ERR, "Failed to set ras oob configuration for "
                                       "Processor P0. Retrying....\n");
         }
-        sleep(10);
+        sleep(SLEEP_20);
         retryCount--;
     }
 
     if (num_of_proc == TWO_SOCKET)
     {
-        retryCount = 30;
+        retryCount = RETRY_45;
         while (retryCount > 0)
         {
             ret = set_bmc_ras_oob_config(p1_info, oob_config);
@@ -93,7 +93,7 @@ oob_status_t SetOobConfig()
                 sd_journal_print(LOG_ERR, "Failed to set ras oob configuration "
                                           "for Processor P1. Retrying....\n");
             }
-            sleep(10);
+            sleep(SLEEP_20);
             retryCount--;
         }
     }


### PR DESCRIPTION
Increasing the SetRasOobConfig retries to 15 minutes as the 2P systems take more time to enable PCIE AER