### PR TITLE
Fix typo in HPM dump script invocation

### DIFF
--- a/src/fatal_error.cpp
+++ b/src/fatal_error.cpp
@@ -1031,7 +1031,7 @@ void HPMFPGALockoutEventHandler()
                         LOG_ERR, "REDFISH_MESSAGE_ID=%s",
                         "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
                         ras_err_msg.c_str(), NULL);
-        int ret = system("HPM_FPGA_REGDUMP > " HPM_FPGA_REGDUMP_FILE " 2>&1 &");
+        int ret = system(HPM_FPGA_REGDUMP " > " HPM_FPGA_REGDUMP_FILE " 2>&1 &");
 
         if (ret == -1)
         {


### PR DESCRIPTION
Fixed typo in system call to register dump script

Fixes: FWDEV-65553