### PR TITLE
amd-ras: modify BlockID selection for MI300A/C to create CPER files

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -569,7 +569,11 @@ bool PlatformInitialization()
     }
     if (plat_info->family == GENOA_FAMILY_ID)
     {
-        BlockId = {BLOCK_ID_33};
+       if ((plat_info->model != MI300A_MODEL_NUMBER) &&
+           (plat_info->model != MI300C_MODEL_NUMBER))
+       {
+           BlockId = {BLOCK_ID_33};
+       }
     }
     else if (plat_info->family == TURIN_FAMILY_ID)
     {


### PR DESCRIPTION
To create proper CPER files, BlockID need to be selected based on based on platform type.