### PR TITLE
Error threshold overflow feature enablement and SetRasOoobConfig command changes .

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -41,7 +41,7 @@
  * CPER section descriptor revision, used in revision field in struct
  * cper_section_descriptor
  */
-#define CPER_MINOR_REV (0x0004)
+#define CPER_MINOR_REV (0x0005)
 
 #define ADDC_GEN_NUMBER_1 (0x01)
 #define ADDC_GEN_NUMBER_2 (0x02)

--- a/inc/ras.hpp
+++ b/inc/ras.hpp
@@ -33,12 +33,18 @@ extern "C" {
 #define MCA_ERR (0)
 #define DRAM_CECC_ERR (1)
 #define PCIE_ERR (2)
+#define POLLING_MODE (0)
+#define INTERRUPT_MODE (1)
 #define ERROR_THRESHOLD_VAL (1)
 
 #define PCIE_ERROR_THRESHOLD (32)
 #define DRAM_CECC_ERROR_THRESHOLD (16)
 #define MCA_ERROR_THRESHOLD (8)
 #define FATAL_ERROR (1)
+#define MCA_ERR_OVERFLOW (8)
+#define DRAM_CECC_ERR_OVERFLOW (16)
+#define PCIE_ERR_OVERFLOW (32)
+
 #define APML_INIT_DONE_FILE ("/tmp/apml_init_complete")
 #define SBRMI_CONTROL_REGISTER (0x1)
 
@@ -87,6 +93,8 @@ extern "C" {
 
 void RunTimeErrorPolling();
 oob_status_t SetOobConfig();
+oob_status_t SetErrThreshold();
+void RunTimeErrorInfoCheck(uint8_t, uint8_t);
 void write_to_cper_file(std::string);
 void ErrorPollingHandler(uint8_t, uint16_t);
 void CreateDbusInterface();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -526,6 +526,7 @@ static void currentHostStateMonitor()
                 apmlInitialized = true;
                 clearSbrmiAlertMask();
                 SetOobConfig();
+                SetErrThreshold();
             }
         });
 }
@@ -569,11 +570,7 @@ bool PlatformInitialization()
     }
     if (plat_info->family == GENOA_FAMILY_ID)
     {
-       if ((plat_info->model != MI300A_MODEL_NUMBER) &&
-           (plat_info->model != MI300C_MODEL_NUMBER))
-       {
-           BlockId = {BLOCK_ID_33};
-       }
+        BlockId = {BLOCK_ID_33};
     }
     else if (plat_info->family == TURIN_FAMILY_ID)
     {

--- a/src/write_cper_data.cpp
+++ b/src/write_cper_data.cpp
@@ -482,12 +482,15 @@ void dump_proc_error_section(const std::shared_ptr<T>& data, uint8_t soc_num,
 
         if ((category == MCA_ERR) || (category == DRAM_CECC_ERR))
         {
-            if ((mca_status_register & (1ULL << INDEX_61)) == 0)
+            if (((mca_status_register & (1ULL << INDEX_61)) == 0) &&
+                ((mca_status_register & (1ULL << INDEX_44)) == 0))
             {
                 Severity[Section] = SEV_NON_FATAL_CORRECTED;
             }
-            else if (((mca_status_register & (1ULL << INDEX_61)) != 0) &&
-                     ((mca_status_register & (1ULL << INDEX_57)) == 0))
+            else if ((((mca_status_register & (1ULL << INDEX_61)) == 0) &&
+                      ((mca_status_register & (1ULL << INDEX_44)) != 0)) ||
+                     (((mca_status_register & (1ULL << INDEX_61)) != 0) &&
+                      ((mca_status_register & (1ULL << INDEX_57)) == 0)))
             {
                 Severity[Section] = SEV_NON_FATAL_UNCORRECTED;
             }


### PR DESCRIPTION
… enablement.

1. The input argument for SetRasOobConfig command is changed in thelatest PPR which has polling mode or interrupt mode as input argument.

2. Updated the input argument for SetRasOobConig command to integrate the apml library 3.3.0.

3. Added error threshold overflow feature for runtime errors. The error threshold overflow is supported for runtime MCA, DRAM CECC and PCIE errors.