### PR TITLE
Add debug log ID 23 to crashdump flow

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -26,22 +26,11 @@
 #define BYTE_2 (2)
 #define ENABLE_BIT (1)
 
-#define BLOCK_ID_1 (1)
-#define BLOCK_ID_2 (2)
-#define BLOCK_ID_3 (3)
-#define BLOCK_ID_24 (24)
-#define BLOCK_ID_33 (33)
-#define BLOCK_ID_36 (36)
-#define BLOCK_ID_37 (37)
-#define BLOCK_ID_38 (38)
-#define BLOCK_ID_39 (39)
-#define BLOCK_ID_40 (40)
-
 /*
  * CPER section descriptor revision, used in revision field in struct
  * cper_section_descriptor
  */
-#define CPER_MINOR_REV (0x0006)
+#define CPER_MINOR_REV (0x0007)
 
 #define ADDC_GEN_NUMBER_1 (0x01)
 #define ADDC_GEN_NUMBER_2 (0x02)

--- a/inc/ras.hpp
+++ b/inc/ras.hpp
@@ -51,6 +51,7 @@ extern "C" {
 #define BLOCK_ID_1 (1)
 #define BLOCK_ID_2 (2)
 #define BLOCK_ID_3 (3)
+#define BLOCK_ID_23 (23)
 #define BLOCK_ID_24 (24)
 #define BLOCK_ID_33 (33)
 #define BLOCK_ID_36 (36)
@@ -96,7 +97,7 @@ extern "C" {
 
 void RunTimeErrorPolling();
 oob_status_t SetOobConfig();
-oob_status_t SetErrThreshold();
+oob_status_t ErrThresholdEnable();
 void RunTimeErrorInfoCheck(uint8_t, uint8_t);
 void write_to_cper_file(std::string);
 void ErrorPollingHandler(uint8_t, uint16_t);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -526,7 +526,7 @@ static void currentHostStateMonitor()
                 apmlInitialized = true;
                 clearSbrmiAlertMask();
                 SetOobConfig();
-                SetErrThreshold();
+                ErrThresholdEnable();
             }
         });
 }

--- a/src/write_cper_data.cpp
+++ b/src/write_cper_data.cpp
@@ -871,12 +871,17 @@ void write_to_cper_file(const std::shared_ptr<T>& data, std::string ErrorType,
     {
         if ((FatalPtr) && (file != NULL))
         {
-            sd_journal_print(LOG_INFO,
-                             "Generating CPER file for the fatal error\n");
-
             fwrite(FatalPtr.get(), FatalPtr->Header.RecordLength, 1, file);
 
             exportCrashdumpToDBus(err_count, FatalPtr->Header.TimeStamp);
+
+            std::string ras_err_msg =
+                "CPER file generated for fatal error";
+
+            sd_journal_send(
+                "MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i", LOG_ERR,
+                "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.AtScaleDebugConnected",
+                "REDFISH_MESSAGE_ARGS=%s", ras_err_msg.c_str(), NULL);
         }
     }
     else if (ErrorType == RUNTIME_PCIE_ERR)


### PR DESCRIPTION
Added DBG_LOG_ID = 23 in Turin ADDC Crashdump flow.
Add event log when a CPER file is generated for fatal errors.
Add retries if the BMC_RAS_SET_ERR_THRESH command failed.
Set PCI OOb error reporting enable bit via 0x61 command prior
to sending PCI error threshold enable command(0x63).

Signed-off-by: Abinaya Dhandapani <adhandap@amd.com>