### PR TITLE
Implementation of fatal error handling

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Full Description:
+Different components of meta-amd are under different licenses (a mix
+of MIT and Apache-2.0). Please see:
+
+COPYING.Apache-2.0
+COPYING.MIT (MIT)
+
+All metadata is MIT licensed unless otherwise stated. Source code
+included in tree for individual recipes is under the LICENSE stated in
+the associated recipe (.bb file) unless otherwise stated.
+
+License information for any other files is either explicitly stated
+or defaults to Apache-2.0.

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,41 @@
+# OWNERS
+# ------
+#
+# The OWNERS file maintains the list of individuals responsible for various
+# parts of this repository, including code review and approval.  We use the
+# Gerrit 'owners' plugin, which consumes this file, along with some extra
+# keywords for our own purposes and tooling.
+#
+# For details on the configuration used by 'owners' see:
+#  https://gerrit.googlesource.com/plugins/owners/+/refs/heads/master/owners/src/main/resources/Documentation/config.md
+#
+# An OWNERS file must be in the root of a repository but may also be present
+# in any subdirectory.  The contents of the subdirectory OWNERS file are
+# combined with parent directories unless 'inherit: false' is set.
+#
+# The owners file is YAML and has [up to] 4 top-level keywords.
+#   * owners: A list of individuals who have approval authority on the
+#     repository.
+#
+#   * reviewers: A list of individuals who have requested review notification
+#     on the repository.
+#
+#   * matches: A list of specific file/path matches for granular 'owners' and
+#     'reviewers'.  See 'owners' plugin documentation.
+#
+#   * openbmc: A list of openbmc-specific meta-data about owners and reviewers.
+#     - name: preferred name of the individual.
+#     - email: preferred email address of the individual.
+#     - discord: Discord nickname of the individual.
+#
+# It is expected that these 4 sections will be listed in the order above and
+# data within them will be kept sorted.
+
+owners:
+
+reviewers:
+
+matches:
+
+openbmc:
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+#AMD BMC RAS
+
+The amd-bmc-ras service is intended to discover, configure and exercise OOB
+RAS capabilities supported by the processors. The application creates error
+records from RAS telemetry extracted from the processor over APML.

--- a/config/ras-config.json
+++ b/config/ras-config.json
@@ -1,0 +1,39 @@
+{
+    "Configuration": [
+        {
+            "apmlRetries": {
+                "Description": "Number of APML retry count",
+                "Value": 10,
+                "MaxBoundLimit": "50"
+            }
+        },
+        {
+            "SystemRecovery": {
+                "Description": "System recovery mode",
+                "Value": "NO_RESET",
+                "MaxBoundLimit": "No specific limit"
+            }
+        },
+        {
+            "HarvestMicrocode": {
+                "Description": "Harvest microcode version",
+                "Value": true,
+                "MaxBoundLimit": ""
+            }
+        },
+        {
+            "HarvestPPIN": {
+                "Description": "Harvest PPIN",
+                "Value": true,
+                "MaxBoundLimit": ""
+            }
+        },
+        {
+            "Reset Signal": {
+                "Description": "Reset Signal Type",
+                "Value": "SYS_RST",
+                "MaxBoundLimit": ""
+            }
+        }
+    ]
+}

--- a/host-transport-extensions/default/apml_interface.cpp
+++ b/host-transport-extensions/default/apml_interface.cpp
@@ -1,0 +1,1174 @@
+#include "cper_generator.hpp"
+#include "interface_manager.hpp"
+
+void InterfaceManager::getNumberOfCpu()
+{
+    FILE* pf;
+    char data[COMMAND_LEN];
+    std::stringstream ss;
+
+    pf = popen(COMMAND_NUM_OF_CPU.data(), "r");
+    if (pf)
+    {
+        if (fgets(data, COMMAND_LEN, pf))
+        {
+            ss << std::hex << (std::string)data;
+            ss >> numOfCpu;
+
+            lg2::debug("Number of Cpu {CPU}", "CPU", numOfCpu);
+            cpuId = new CpuId[numOfCpu];
+
+            uCode = new uint32_t[numOfCpu];
+            std::memset(uCode, 0, numOfCpu * sizeof(uint32_t));
+
+            ppin = new uint64_t[numOfCpu];
+            std::memset(ppin, 0, numOfCpu * sizeof(uint64_t));
+
+            inventoryPath = new std::string[numOfCpu];
+
+            for (int i = 0; i < numOfCpu; i++)
+            {
+                inventoryPath[i] =
+                    "/xyz/openbmc_project/inventory/system/processor/P" +
+                    std::to_string(i);
+            }
+        }
+        else
+        {
+            throw std::runtime_error("Error reading data from the process.");
+        }
+        pclose(pf);
+    }
+    else
+    {
+        throw std::runtime_error("Error opening the process.");
+    }
+}
+
+void InterfaceManager::p0AlertEventHandler()
+{
+    gpiod::line_event gpioLineEvent = p0_apmlAlertLine.event_read();
+
+    if (gpioLineEvent.event_type == gpiod::line_event::FALLING_EDGE)
+    {
+        lg2::debug("Falling Edge: P0 APML Alert received");
+
+        if (rcd == nullptr)
+        {
+            rcd = std::make_shared<CperRecord>();
+        }
+
+        harvestFatalError(SOCKET_0);
+    }
+    else if (gpioLineEvent.event_type == gpiod::line_event::RISING_EDGE)
+    {
+        lg2::debug("Rising Edge: P0 APML Alert cancelled");
+    }
+
+    p0_apmlAlertEvent.async_wait(
+        boost::asio::posix::stream_descriptor::wait_read,
+        [this](const boost::system::error_code ec) {
+            if (ec)
+            {
+
+                lg2::error("P0 APML alert handler error: {ERROR}", "ERROR",
+                           ec.message().c_str());
+                return;
+            }
+            p0AlertEventHandler();
+        });
+}
+
+bool InterfaceManager::harvestMcaValidityCheck(uint8_t info, uint16_t* numbanks,
+                                               uint16_t* bytespermca)
+{
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+    uint16_t retries = 0;
+    bool mcaValidityCheck = true;
+
+    AttributeValue apmlRetry = getAttribute("apmlRetries");
+    int64_t* apmlRetryCount = std::get_if<int64_t>(&apmlRetry);
+
+    while (ret != OOB_SUCCESS)
+    {
+        retries++;
+
+        ret = read_bmc_ras_mca_validity_check(info, bytespermca, numbanks);
+
+        if (retries > *apmlRetryCount)
+        {
+            lg2::error(
+                "Socket {SOCK}: Failed to get MCA banks with valid status",
+                "SOCK", info);
+            break;
+        }
+
+        if ((*numbanks == 0) || (*numbanks > MAX_MCA_BANKS))
+        {
+            lg2::error("Socket {SOCKET}: Invalid MCA bank validity status. "
+                       "Retry Count: {RETRY_COUNT}",
+                       "SOCKET", info, "RETRY_COUNT", retries);
+            ret = OOB_MAILBOX_CMD_UNKNOWN;
+            usleep(1000 * 1000);
+            continue;
+        }
+    }
+
+    if ((*numbanks <= 0) || (*numbanks > MAX_MCA_BANKS))
+    {
+        mcaValidityCheck = false;
+    }
+
+    return mcaValidityCheck;
+}
+
+template <typename T>
+void InterfaceManager::harvestMcaDataBanks(uint8_t info, uint16_t numbanks,
+                                           uint16_t bytespermca,
+                                           CperGenerator<T>& cperGenerator)
+{
+    uint16_t n = 0;
+    uint16_t maxOffset32;
+    uint32_t buffer;
+    struct mca_bank mca_dump;
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+    uint32_t Severity;
+    bool ValidSignatureID = false;
+
+    int syndOffsetLo = 0;
+    int syndOffsetHi = 0;
+    int ipidOffsetLo = 0;
+    int ipidOffsetHi = 0;
+    int statusOffsetLo = 0;
+    int statusOffsetHi = 0;
+
+    uint32_t mcaStatusLo = 0;
+    uint32_t mcaStatusHi = 0;
+    uint32_t mcaIpidLo = 0;
+    uint32_t mcaIpidHi = 0;
+    uint32_t mcaSyndLo = 0;
+    uint32_t mcaSyndHi = 0;
+
+    AttributeValue sigIdOffsetVal = getAttribute("SigIDOffset");
+    std::vector<std::string>* sigIDOffset =
+        std::get_if<std::vector<std::string>>(&sigIdOffsetVal);
+
+    AttributeValue apmlRetry = getAttribute("apmlRetries");
+    int64_t* apmlRetryCount = std::get_if<int64_t>(&apmlRetry);
+
+    cperGenerator.dumpCperHeaderSection(rcd, FATAL_SECTION_COUNT,
+                                        CPER_SEV_FATAL, FATAL_ERR);
+
+    rcd->sectionDescriptor = new ErrorSectionDescriptor[FATAL_SECTION_COUNT];
+    std::memset(rcd->sectionDescriptor, 0,
+                FATAL_SECTION_COUNT * sizeof(ErrorSectionDescriptor));
+
+    rcd->errorRecord = new ErrorRecord[FATAL_SECTION_COUNT];
+    std::memset(rcd->errorRecord, 0, FATAL_SECTION_COUNT * sizeof(ErrorRecord));
+
+    cperGenerator.dumpErrorDescriptorSection(rcd, FATAL_SECTION_COUNT,
+                                             FATAL_ERR, &Severity);
+
+    cperGenerator.dumpProcessorErrorSection(rcd, info, FATAL_SECTION_COUNT,
+                                            cpuId);
+
+    cperGenerator.dumpContextInfo(rcd, numbanks, bytespermca, info,
+                                  FATAL_SECTION_COUNT, blockId, ppin, uCode,
+                                  apmlRetryCount);
+
+    syndOffsetLo = std::stoul((*sigIDOffset)[INDEX_0], nullptr, BASE_16);
+    syndOffsetHi = std::stoul((*sigIDOffset)[INDEX_1], nullptr, BASE_16);
+    ipidOffsetLo = std::stoul((*sigIDOffset)[INDEX_2], nullptr, BASE_16);
+    ipidOffsetHi = std::stoul((*sigIDOffset)[INDEX_3], nullptr, BASE_16);
+    statusOffsetLo = std::stoul((*sigIDOffset)[INDEX_4], nullptr, BASE_16);
+    statusOffsetHi = std::stoul((*sigIDOffset)[INDEX_5], nullptr, BASE_16);
+
+    maxOffset32 =
+        ((bytespermca % BYTE_4) ? INDEX_1 : INDEX_0) + (bytespermca >> BYTE_2);
+    lg2::info("Number of Valid MCA bank: {NUMBANKS}", "NUMBANKS", numbanks);
+    lg2::info("Number of 32 Bit Words:{MAX_OFFSET}", "MAX_OFFSET", maxOffset32);
+
+    while (n < numbanks)
+    {
+        for (int offset = 0; offset < maxOffset32; offset++)
+        {
+            memset(&buffer, 0, sizeof(buffer));
+            memset(&mca_dump, 0, sizeof(mca_dump));
+            mca_dump.index = n;
+            mca_dump.offset = offset * BYTE_4;
+
+            ret = read_bmc_ras_mca_msr_dump(info, mca_dump, &buffer);
+
+            if (ret != OOB_SUCCESS)
+            {
+                while (*apmlRetryCount > 0)
+                {
+                    memset(&buffer, 0, sizeof(buffer));
+                    memset(&mca_dump, 0, sizeof(mca_dump));
+                    mca_dump.index = n;
+                    mca_dump.offset = offset * BYTE_4;
+
+                    ret = read_bmc_ras_mca_msr_dump(info, mca_dump, &buffer);
+
+                    if (ret == OOB_SUCCESS)
+                    {
+                        break;
+                    }
+                    (*apmlRetryCount)--;
+                    usleep(1000 * 1000);
+                }
+                if (ret != OOB_SUCCESS)
+                {
+                    lg2::error("Socket {SOCKET} : Failed to get MCA bank data "
+                               "from Bank:{N}, Offset:{OFFSET}",
+                               "SOCKET", info, "N", n, "OFFSET", lg2::hex,
+                               offset);
+                    rcd->errorRecord[info]
+                        .contextInfo.crashDumpData[n]
+                        .mcaData[offset] = BAD_DATA;
+                    continue;
+                }
+
+            } // if (ret != OOB_SUCCESS)
+
+            rcd->errorRecord[info]
+                .contextInfo.crashDumpData[n]
+                .mcaData[offset] = buffer;
+
+            if (mca_dump.offset == statusOffsetLo)
+            {
+                mcaStatusLo = buffer;
+            }
+            if (mca_dump.offset == statusOffsetHi)
+            {
+                mcaStatusHi = buffer;
+
+                /*Bit 23 and bit 25 of MCA_STATUS_HI
+                  should be set for a valid signature ID*/
+                if ((mcaStatusHi & (INDEX_1 << SHIFT_25)) &&
+                    (mcaStatusHi & (INDEX_1 << SHIFT_23)))
+                {
+                    ValidSignatureID = true;
+                }
+            }
+            if (mca_dump.offset == ipidOffsetLo)
+            {
+                mcaIpidLo = buffer;
+            }
+            if (mca_dump.offset == ipidOffsetHi)
+            {
+                mcaIpidHi = buffer;
+            }
+            if (mca_dump.offset == syndOffsetLo)
+            {
+                mcaSyndLo = buffer;
+            }
+            if (mca_dump.offset == syndOffsetHi)
+            {
+                mcaSyndHi = buffer;
+            }
+
+        } // for loop
+
+        if (ValidSignatureID == true)
+        {
+            rcd->errorRecord[info].procError.signatureID[INDEX_0] = mcaSyndLo;
+            rcd->errorRecord[info].procError.signatureID[INDEX_1] = mcaSyndHi;
+            rcd->errorRecord[info].procError.signatureID[INDEX_2] = mcaIpidLo;
+            rcd->errorRecord[info].procError.signatureID[INDEX_3] = mcaIpidHi;
+            rcd->errorRecord[info].procError.signatureID[INDEX_4] = mcaStatusLo;
+            rcd->errorRecord[info].procError.signatureID[INDEX_5] = mcaStatusHi;
+
+            rcd->errorRecord[info].procError.validBits =
+                rcd->errorRecord[info].procError.validBits |
+                FAILURE_SIGNATURE_ID;
+
+            ValidSignatureID = false;
+        }
+        else
+        {
+            mcaSyndLo = 0;
+            mcaSyndHi = 0;
+            mcaIpidLo = 0;
+            mcaIpidHi = 0;
+            mcaStatusLo = 0;
+            mcaStatusHi = 0;
+        }
+        n++;
+    }
+}
+
+void InterfaceManager::harvestFatalError(uint8_t info)
+{
+    std::unique_lock lock(harvest_in_progress_mtx);
+
+    uint16_t bytespermca = 0;
+    uint16_t numbanks = 0;
+    bool controlFabricError = false;
+    bool fchHangError = false;
+    uint8_t buf;
+    bool resetReady = false;
+
+    CperGenerator<CperRecord> cperGenerator(numOfCpu, progId, familyId,
+                                            errCount);
+
+    // Check if APML ALERT is because of RAS
+    if (read_sbrmi_ras_status(info, &buf) == OOB_SUCCESS)
+    {
+        lg2::debug("Read RAS status register. Value: {BUF}", "BUF", buf);
+
+        // check RAS Status Register
+        if (buf & INT_15)
+        {
+            lg2::error("The alert signaled is due to a RAS fatal error");
+
+            if (buf & SYS_MGMT_CTRL_ERR)
+            {
+                /*if RasStatus[reset_ctrl_err] is set in any of the processors,
+                  proceed to cold reset, regardless of the status of the other P
+                */
+
+                std::string ras_err_msg =
+                    "Fatal error detected in the control fabric. "
+                    "BMC may trigger a reset based on policy set. ";
+
+                sd_journal_send(
+                    "MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i", LOG_ERR,
+                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
+                    "REDFISH_MESSAGE_ARGS=%s", ras_err_msg.c_str(), NULL);
+
+                p0AlertProcessed = true;
+                p1AlertProcessed = true;
+                controlFabricError = true;
+            }
+            else if (buf & RESET_HANG_ERR)
+            {
+                std::string ras_err_msg =
+                    "System hang while resetting in syncflood."
+                    "Suggested next step is to do an additional manual "
+                    "immediate reset";
+
+                sd_journal_send(
+                    "MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i", LOG_ERR,
+                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
+                    "REDFISH_MESSAGE_ARGS=%s", ras_err_msg.c_str(), NULL);
+
+                fchHangError = true;
+            }
+            else if (buf & FATAL_ERROR)
+            {
+                std::string ras_err_msg = "RAS FATAL Error detected. "
+                                          "System may reset after harvesting "
+                                          "MCA data based on policy set. ";
+
+                sd_journal_send(
+                    "MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i", LOG_ERR,
+                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
+                    "REDFISH_MESSAGE_ARGS=%s", ras_err_msg.c_str(), NULL);
+
+                if (true ==
+                    harvestMcaValidityCheck(info, &numbanks, &bytespermca))
+                {
+                    harvestMcaDataBanks(info, numbanks, bytespermca,
+                                        cperGenerator);
+                }
+            }
+
+            if (info == SOCKET_0)
+            {
+                p0AlertProcessed = true;
+            }
+
+            if (info == SOCKET_1)
+            {
+                p1AlertProcessed = true;
+            }
+
+            // Clear RAS status register
+            // 0x4c is a SB-RMI register acting as write to clear
+            // check PPR to determine whether potential bug in PPR or in
+            // implementation of SMU?
+
+            writeRegister(info, RAS_STATUS_REGISTER, buf);
+
+            if (fchHangError == true)
+            {
+                // return true;
+            }
+
+            if (numOfCpu == TWO_SOCKET)
+            {
+                if ((p0AlertProcessed == true) && (p1AlertProcessed == true))
+                {
+                    resetReady = true;
+                }
+            }
+            else
+            {
+                resetReady = true;
+            }
+
+            if (resetReady == true)
+            {
+
+                if (controlFabricError == false)
+                {
+                    cperGenerator.cperFileWrite(rcd, FATAL_ERR,
+                                                FATAL_SECTION_COUNT);
+                }
+
+                if (rcd->sectionDescriptor != nullptr)
+                {
+                    delete[] rcd->sectionDescriptor;
+                    rcd->sectionDescriptor = nullptr;
+                }
+                if (rcd->errorRecord != nullptr)
+                {
+                    delete[] rcd->errorRecord;
+                    rcd->errorRecord = nullptr;
+                }
+
+                rcd = nullptr;
+
+                rasRecoveryAction(buf);
+
+                p0AlertProcessed = false;
+                p1AlertProcessed = false;
+            }
+        }
+    }
+    else
+    {
+        lg2::debug("Nothing to Harvest. Not RAS Error");
+    }
+}
+
+void InterfaceManager::p1AlertEventHandler()
+{
+    gpiod::line_event gpioLineEvent = p1_apmlAlertLine.event_read();
+
+    if (gpioLineEvent.event_type == gpiod::line_event::FALLING_EDGE)
+    {
+        lg2::debug("Falling Edge: P1 APML Alert received");
+
+        if (rcd == nullptr)
+        {
+            rcd = std::make_shared<CperRecord>();
+        }
+        harvestFatalError(SOCKET_1);
+    }
+    else if (gpioLineEvent.event_type == gpiod::line_event::RISING_EDGE)
+    {
+        lg2::debug("Rising Edge: P1 APML Alert cancelled");
+    }
+
+    p1_apmlAlertEvent.async_wait(
+        boost::asio::posix::stream_descriptor::wait_read,
+        [this](const boost::system::error_code ec) {
+            if (ec)
+            {
+                lg2::error("P1 APML alert handler error {ERR}", "ERR",
+                           ec.message().c_str());
+
+                return;
+            }
+            p1AlertEventHandler();
+        });
+}
+
+void InterfaceManager::clearSbrmiAlertMask(uint8_t socNum)
+{
+
+    oob_status_t ret;
+
+    lg2::info("Clear Alert Mask bit of SBRMI Control register");
+
+    uint8_t buffer;
+
+    ret = readRegister(socNum, SBRMI_CONTROL_REGISTER, &buffer);
+
+    if (ret == OOB_SUCCESS)
+    {
+        buffer = buffer & 0xFE;
+        writeRegister(socNum, SBRMI_CONTROL_REGISTER,
+                      static_cast<uint32_t>(buffer));
+    }
+}
+
+void InterfaceManager::writeRegister(uint8_t info, uint32_t reg, uint32_t value)
+{
+    oob_status_t ret;
+
+    ret = esmi_oob_write_byte(info, reg, SBRMI, value);
+    if (ret != OOB_SUCCESS)
+    {
+        lg2::error("Failed to write register: {REG}", "REG", lg2::hex, reg);
+        return;
+    }
+    lg2::debug("Write to register {REGISTER} is successful", "REGISTER", reg);
+}
+
+oob_status_t InterfaceManager::readRegister(uint8_t info, uint32_t reg,
+                                            uint8_t* value)
+{
+    oob_status_t ret;
+    uint16_t retryCount = 10;
+
+    while (retryCount > 0)
+    {
+        ret = esmi_oob_read_byte(info, reg, SBRMI, value);
+        if (ret == OOB_SUCCESS)
+        {
+            break;
+        }
+
+        lg2::error("Failed to read register: {REGISTER} Retrying\n", "REGISTER",
+                   lg2::hex, reg);
+
+        usleep(1000 * 1000);
+        retryCount--;
+    }
+    if (ret != OOB_SUCCESS)
+    {
+        lg2::error("Failed to read register: {REGISTER}\n", "REGISTER",
+                   lg2::hex, reg);
+    }
+
+    return ret;
+}
+
+void InterfaceManager::requestHostTransition(std::string command)
+{
+
+    boost::system::error_code ec;
+    boost::asio::io_context io;
+    auto conn = std::make_shared<sdbusplus::asio::connection>(io);
+
+    conn->async_method_call(
+        [](boost::system::error_code ec) {
+            if (ec)
+            {
+                sd_journal_print(
+                    LOG_ERR, "Failed to trigger cold reset of the system\n");
+            }
+        },
+        "xyz.openbmc_project.State.Host", "/xyz/openbmc_project/state/host0",
+        "org.freedesktop.DBus.Properties", "Set",
+        "xyz.openbmc_project.State.Host", "RequestedHostTransition",
+        std::variant<std::string>{command});
+}
+
+void InterfaceManager::triggerColdReset()
+{
+    AttributeValue ResetSignalVal = getAttribute("ResetSignal");
+    std::string* ResetSignal = std::get_if<std::string>(&ResetSignalVal);
+
+    if (*ResetSignal == "SYS_RST")
+    {
+        std::string command =
+            "xyz.openbmc_project.State.Host.Transition.Reboot";
+
+        requestHostTransition(command);
+    }
+    else if (*ResetSignal == "RSMRST")
+    {
+        boost::system::error_code ec;
+        boost::asio::io_context io;
+        auto conn = std::make_shared<sdbusplus::asio::connection>(io);
+
+        conn->async_method_call(
+            [](boost::system::error_code ec) {
+                if (ec)
+                {
+                    sd_journal_print(
+                        LOG_ERR,
+                        "Failed to trigger cold reset of the system\n");
+                }
+            },
+            "xyz.openbmc_project.State.Host",
+            "/xyz/openbmc_project/control/host0/SOCReset",
+            "xyz.openbmc_project.Control.Host.SOCReset", "SOCReset");
+
+        sleep(1);
+        sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+        std::string CurrentHostState = getProperty<std::string>(
+            bus, "xyz.openbmc_project.State.Host",
+            "/xyz/openbmc_project/state/host0",
+            "xyz.openbmc_project.State.Host", "CurrentHostState");
+
+        if (CurrentHostState.compare(
+                "xyz.openbmc_project.State.Host.HostState.Off") == 0)
+        {
+
+            std::string command =
+                "xyz.openbmc_project.State.Host.Transition.On";
+
+            requestHostTransition(command);
+        }
+    }
+}
+
+void InterfaceManager::apmlInitializeCheck()
+{
+    oob_status_t ret;
+    uint8_t socNum = 0;
+
+    struct processor_info plat_info[INDEX_1];
+    uint16_t retryCount = 10;
+    struct stat buffer;
+
+    while (INDEX_1)
+    {
+        if (stat(APML_INIT_DONE_FILE.data(), &buffer) == 0)
+        {
+            lg2::info("APML initialization done");
+            break;
+        }
+    }
+
+    while (retryCount > 0)
+    {
+        ret = esmi_get_processor_info(socNum, plat_info);
+
+        if (ret == OOB_SUCCESS)
+        {
+            familyId = plat_info->family;
+            break;
+        }
+        usleep(1000 * 1000);
+        retryCount--;
+
+        lg2::info("Reading family ID failed. Retry count = {RETRY_COUNT}",
+                  "RETRY_COUNT", retryCount);
+    }
+    if (plat_info->family == GENOA_FAMILY_ID)
+    {
+        if ((plat_info->model != MI300A_MODEL_NUMBER) &&
+            (plat_info->model != MI300C_MODEL_NUMBER))
+        {
+            blockId = {BLOCK_ID_33};
+        }
+    }
+    else if (plat_info->family == TURIN_FAMILY_ID)
+    {
+
+        apmlInitialized = true;
+
+        for (uint8_t i = 0; i < numOfCpu; i++)
+        {
+            clearSbrmiAlertMask(i);
+        }
+
+        currentHostStateMonitor();
+
+        blockId = {BLOCK_ID_1,  BLOCK_ID_2,  BLOCK_ID_3,
+                   BLOCK_ID_24, BLOCK_ID_33, BLOCK_ID_36,
+                   BLOCK_ID_37, BLOCK_ID_38, BLOCK_ID_40};
+    }
+    else
+    {
+        throw std::runtime_error("ADDC is not supported for this platform");
+    }
+}
+
+void InterfaceManager::currentHostStateMonitor()
+{
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+    boost::system::error_code ec;
+    auto conn = std::make_shared<sdbusplus::asio::connection>(io);
+
+    static auto match = sdbusplus::bus::match::match(
+        *conn,
+        "type='signal',member='PropertiesChanged', "
+        "interface='org.freedesktop.DBus.Properties', "
+        "arg0='xyz.openbmc_project.State.Host'",
+        [this](sdbusplus::message::message& message) {
+            std::string intfName;
+            std::map<std::string, std::variant<std::string>> properties;
+
+            try
+            {
+                message.read(intfName, properties);
+            }
+            catch (std::exception& e)
+            {
+                lg2::error("Unable to read host state");
+                return;
+            }
+            if (properties.empty())
+            {
+                lg2::error("ERROR: Empty PropertiesChanged signal received");
+                return;
+            }
+
+            if (properties.begin()->first != "CurrentHostState")
+            {
+                return;
+            }
+            std::string* currentHostState =
+                std::get_if<std::string>(&(properties.begin()->second));
+            if (currentHostState == nullptr)
+            {
+                lg2::error("property invalid");
+                return;
+            }
+
+            if (*currentHostState !=
+                "xyz.openbmc_project.State.Host.HostState.Off")
+            {
+
+                apmlInitialized = false;
+                struct stat buffer;
+
+                while (INDEX_1)
+                {
+                    if (stat(APML_INIT_DONE_FILE.data(), &buffer) == 0)
+                    {
+                        lg2::info("APML initialization done");
+                        break;
+                    }
+                }
+
+                sleep(180);
+                apmlInitialized = true;
+
+                for (uint8_t i = 0; i < numOfCpu; i++)
+                {
+                    clearSbrmiAlertMask(i);
+                }
+            }
+        });
+}
+
+void InterfaceManager::getCpuId()
+{
+    for (int i = 0; i < numOfCpu; i++)
+    {
+        uint32_t core_id = 0;
+        oob_status_t ret;
+        cpuId[i].eax = 1;
+        cpuId[i].ebx = 0;
+        cpuId[i].ecx = 0;
+        cpuId[i].edx = 0;
+
+        ret = esmi_oob_cpuid(i, core_id, &cpuId[i].eax, &cpuId[i].ebx,
+                             &cpuId[i].ecx, &cpuId[i].edx);
+
+        if (ret)
+        {
+            lg2::error("Failed to get the CPUID for socket {CPU}", "CPU", i);
+        }
+    }
+}
+
+void InterfaceManager::getBoardId()
+{
+    FILE* pf;
+    char data[COMMAND_LEN];
+    std::stringstream ss;
+
+    // Setup pipe for reading and execute to get u-boot environment
+    // variable board_id.
+    pf = popen(COMMAND_BOARD_ID.data(), "r");
+    // Error handling
+    if (pf)
+    {
+        // Get the data from the process execution
+        if (fgets(data, COMMAND_LEN, pf))
+        {
+            ss << std::hex << (std::string)data;
+            ss >> boardId;
+
+            lg2::debug("Board ID: {BOARD_ID}", "BOARD_ID", boardId);
+        }
+        // the data is now in 'data'
+        pclose(pf);
+    }
+}
+
+void InterfaceManager::findProgramId()
+{
+    oob_status_t ret;
+    uint8_t socNum = 0;
+
+    struct processor_info platInfo[INDEX_1];
+
+    ret = esmi_get_processor_info(socNum, platInfo);
+
+    if (ret == OOB_SUCCESS)
+    {
+        if ((platInfo->model == MI300A_MODEL_NUMBER) ||
+            (platInfo->model == MI300C_MODEL_NUMBER))
+        {
+            progId = MI_PROG_SEG_ID;
+        }
+        else
+        {
+            progId = EPYC_PROG_SEG_ID;
+        }
+    }
+}
+
+void InterfaceManager::init()
+{
+
+    getNumberOfCpu();
+
+    apmlInitializeCheck();
+
+    getCpuId();
+
+    getBoardId();
+
+    findProgramId();
+}
+
+void InterfaceManager::createIndexFile()
+{
+    try
+    {
+        struct stat buffer;
+
+        // Create the RAS directory if it doesn't exist
+        if (stat(RAS_DIR.data(), &buffer) != 0)
+        {
+            if (mkdir(RAS_DIR.data(), 0777) != 0)
+            {
+                throw std::runtime_error(
+                    "Failed to create ras-error-logging directory");
+            }
+        }
+
+        memset(&buffer, 0, sizeof(buffer));
+
+        // Create or read the index file
+        if (stat(INDEX_FILE.data(), &buffer) != 0)
+        {
+            std::ofstream file(INDEX_FILE.data());
+            if (file.is_open())
+            {
+                file << "0";
+                file.close();
+            }
+            else
+            {
+                throw std::runtime_error("Failed to create index file");
+            }
+        }
+        else
+        {
+            std::ifstream file(INDEX_FILE);
+            if (file.is_open())
+            {
+                if (!(file >> errCount) || errCount < INDEX_0)
+                {
+                    throw std::runtime_error(
+                        "Failed to read CPER index number");
+                }
+                file.close();
+            }
+            else
+            {
+                throw std::runtime_error("Failed to read from index file");
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Exception: {ERROR}", "ERROR", e.what());
+    }
+}
+
+void InterfaceManager::createConfigFile()
+{
+
+    struct stat buffer;
+
+    /*Create Cdump Config file to store the system recovery*/
+    if (stat(CONFIG_FILE.data(), &buffer) != 0)
+    {
+        std::string copyCommand =
+            std::string("cp ") + SRC_CONFIG_FILE + " " + CONFIG_FILE;
+
+        int result = system(copyCommand.c_str());
+        if (result != 0)
+        {
+            lg2::error("Error copying RAS config file.");
+        }
+    }
+
+    std::ifstream jsonRead(CONFIG_FILE);
+    nlohmann::json data = nlohmann::json::parse(jsonRead);
+
+    ConfigTable configMap;
+
+    for (const auto& item : data["Configuration"])
+    {
+        AttributeType attributeType;
+        std::string key;
+        std::string description;
+        std::variant<bool, std::string, int64_t, std::vector<std::string>,
+                     std::map<std::string, std::string>>
+            value;
+        int64_t maxBoundValue = 0;
+
+        if (item.is_object() && item.size() == 1)
+        {
+            key = item.begin().key();
+
+            const auto& obj = item[key];
+            description = obj["Description"];
+
+            if (value.index() == 0)
+            {
+                attributeType = sdbusplus::common::com::amd::ras::
+                    Configuration::AttributeType::Boolean;
+            }
+            else if (value.index() == 1)
+            {
+                attributeType = sdbusplus::common::com::amd::ras::
+                    Configuration::AttributeType::String;
+            }
+            else if (value.index() == 2)
+            {
+                attributeType = sdbusplus::common::com::amd::ras::
+                    Configuration::AttributeType::Integer;
+            }
+            else if (value.index() == 3)
+            {
+                attributeType = sdbusplus::common::com::amd::ras::
+                    Configuration::AttributeType::ArrayOfStrings;
+            }
+            else if (value.index() == 4)
+            {
+                attributeType = sdbusplus::common::com::amd::ras::
+                    Configuration::AttributeType::KeyValueMap;
+            }
+
+            // Determine the type of the value and construct the std::variant
+            // accordingly
+            if (obj["Value"].is_boolean())
+            {
+                value = obj["Value"].get<bool>();
+            }
+            else if (obj["Value"].is_string())
+            {
+                value = obj["Value"].get<std::string>();
+            }
+            else if (obj["Value"].is_number_integer())
+            {
+                value = obj["Value"].get<int64_t>();
+            }
+            else if (obj["Value"].is_array())
+            {
+                value = obj["Value"].get<std::vector<std::string>>();
+            }
+            else if (obj["Value"].is_object())
+            {
+                value = obj["Value"].get<std::map<std::string, std::string>>();
+            }
+        }
+
+        configMap[key] =
+            std::make_tuple(attributeType, description, value, maxBoundValue);
+    }
+
+    rasConfigTable(configMap);
+
+    jsonRead.close();
+}
+
+template <typename T>
+T InterfaceManager::getProperty(sdbusplus::bus::bus& bus, const char* service,
+                                const char* path, const char* interface,
+                                const char* propertyName)
+{
+    auto method = bus.new_method_call(service, path,
+                                      "org.freedesktop.DBus.Properties", "Get");
+    method.append(interface, propertyName);
+    std::variant<T> value{};
+    try
+    {
+        auto reply = bus.call(method);
+        reply.read(value);
+    }
+    catch (const sdbusplus::exception::SdBusError& ex)
+    {
+        lg2::info("GetProperty call failed");
+    }
+    return std::get<T>(value);
+}
+
+void InterfaceManager::getMicrocodeRev()
+{
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+
+    for (int i = 0; i < numOfCpu; i++)
+    {
+        std::string microCode = getProperty<std::string>(
+            bus, INVENTORY_SERVICE.data(), inventoryPath[i].c_str(),
+            CPU_INVENTORY_INTERFACE.data(), "Microcode");
+
+        if (microCode.empty())
+        {
+            lg2::error("Failed to read ucode revision");
+        }
+        else
+        {
+            uCode[i] = std::stoul(microCode, nullptr, BASE_16);
+        }
+    }
+}
+
+void InterfaceManager::getPpinFuse()
+{
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+
+    for (int i = 0; i < numOfCpu; i++)
+    {
+        std::string microCode = getProperty<std::string>(
+            bus, INVENTORY_SERVICE.data(), inventoryPath[i].c_str(),
+            CPU_INVENTORY_INTERFACE.data(), "PPIN");
+
+        if (microCode.empty())
+        {
+            lg2::error("Failed to read ppin");
+        }
+        else
+        {
+            ppin[i] = std::stoul(microCode, nullptr, BASE_16);
+        }
+    }
+}
+
+void InterfaceManager::configure()
+{
+    createIndexFile();
+
+    createConfigFile();
+
+    AttributeValue uCodeVersion = getAttribute("HarvestMicrocode");
+    bool* uCodeVersionFlag = std::get_if<bool>(&uCodeVersion);
+
+    AttributeValue harvestPpin = getAttribute("HarvestPPIN");
+    bool* harvestPpinFlag = std::get_if<bool>(&harvestPpin);
+
+    if (*uCodeVersionFlag == true)
+    {
+        getMicrocodeRev();
+    }
+    if (*harvestPpinFlag == true)
+    {
+        getPpinFuse();
+    }
+}
+
+void InterfaceManager::requestGPIOEvents(
+    const std::string& name, const std::function<void()>& handler,
+    gpiod::line& gpioLine,
+    boost::asio::posix::stream_descriptor& gpioEventDescriptor)
+{
+    try
+    {
+        // Find the GPIO line
+        gpioLine = gpiod::find_line(name);
+        if (!gpioLine)
+        {
+            throw std::runtime_error("Failed to find GPIO line: " + name);
+        }
+
+        // Request events for the GPIO line
+        gpioLine.request(
+            {"RAS", gpiod::line_request::EVENT_BOTH_EDGES, INDEX_0});
+
+        // Get the GPIO line file descriptor
+        int gpioLineFd = gpioLine.event_get_fd();
+        if (gpioLineFd < 0)
+        {
+            throw std::runtime_error(
+                "Failed to get GPIO line file descriptor: " + name);
+        }
+
+        // Assign the file descriptor to gpioEventDescriptor
+        gpioEventDescriptor.assign(gpioLineFd);
+
+        // Set up asynchronous wait for events
+        gpioEventDescriptor.async_wait(
+            boost::asio::posix::stream_descriptor::wait_read,
+            [&name, handler](const boost::system::error_code ec) {
+                if (ec)
+                {
+                    throw std::runtime_error("Error in fd handler: " +
+                                             ec.message());
+                }
+                handler();
+            });
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Exception: {ERROR}", "ERROR", e.what());
+    }
+}
+
+void InterfaceManager::harvestDumps(ErrorType errorType)
+{
+
+    if (errorType == ERROR_TYPE_FATAL)
+    {
+        requestGPIOEvents(
+            "P0_I3C_APML_ALERT_L",
+            std::bind(&InterfaceManager::p0AlertEventHandler, this),
+            p0_apmlAlertLine, p0_apmlAlertEvent);
+
+        if (numOfCpu == TWO_SOCKET)
+        {
+            requestGPIOEvents(
+                "P1_I3C_APML_ALERT_L",
+                std::bind(&InterfaceManager::p1AlertEventHandler, this),
+                p1_apmlAlertLine, p1_apmlAlertEvent);
+        }
+    }
+}
+
+void InterfaceManager::rasRecoveryAction(uint8_t buf)
+{
+    oob_status_t ret;
+    uint32_t ack_resp = 0;
+
+    AttributeValue SystemRecoveryVal = getAttribute("SystemRecovery");
+    std::string* SystemRecovery = std::get_if<std::string>(&SystemRecoveryVal);
+
+    if (*SystemRecovery == "WARM_RESET")
+    {
+        if ((buf & SYS_MGMT_CTRL_ERR))
+        {
+            triggerColdReset();
+        }
+        else
+        {
+            /* In a 2P config, it is recommended to only send this command to P0
+            Hence, sending the Signal only to socket 0*/
+            ret = reset_on_sync_flood(INDEX_0, &ack_resp);
+            if (ret)
+            {
+                lg2::error("Failed to request reset after sync flood");
+            }
+            else
+            {
+                lg2::info("Warm reset triggered");
+            }
+        }
+    }
+    else if (*SystemRecovery == "COLD_RESET")
+    {
+        triggerColdReset();
+    }
+    else if (*SystemRecovery == "NO_RESET")
+    {
+        lg2::info("NO RESET triggered");
+    }
+    else
+    {
+        lg2::error("CdumpResetPolicy is not valid");
+    }
+}

--- a/host-transport-extensions/default/config_manager.cpp
+++ b/host-transport-extensions/default/config_manager.cpp
@@ -1,0 +1,87 @@
+#include "config_manager.hpp"
+
+#include "ras.hpp"
+
+void RasConfiguration::setAttribute(AttributeName attribute,
+                                    AttributeValue value)
+{
+    nlohmann::json j;
+
+    auto configMap = rasConfigTable();
+
+    try
+    {
+        std::ifstream jsonFile(CONFIG_FILE);
+        if (!jsonFile.is_open())
+        {
+            throw std::runtime_error("Could not open JSON file");
+        }
+
+        jsonFile >> j;
+        jsonFile.close();
+
+        bool attributeFound = false;
+        for (auto& configItem : j["Configuration"])
+        {
+            auto it = configItem.find(attribute);
+            if (it != configItem.end())
+            {
+                std::visit([&](auto&& arg) { it.value()["Value"] = arg; },
+                           value);
+                attributeFound = true;
+                break;
+            }
+        }
+        if (attributeFound)
+        {
+            for (auto& [key, tuple] : configMap)
+            {
+                if (key == attribute)
+                {
+                    std::get<2>(tuple) = value;
+                    break;
+                }
+            }
+            lg2::info("Attribute updated successfully");
+        }
+        else
+        {
+            lg2::error("Attribute not found");
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Error : {ERROR}", "ERROR", e.what());
+    }
+
+    rasConfigTable(configMap);
+
+    std::ofstream jsonFileOut(CONFIG_FILE);
+    jsonFileOut << j.dump(4);
+    jsonFileOut.close();
+}
+
+AttributeValue RasConfiguration::getAttribute(AttributeName attribute)
+{
+    auto configMap = rasConfigTable();
+    auto it = configMap.find(attribute);
+    AttributeValue value;
+
+    for (auto& [key, tuple] : configMap)
+    {
+        if (key == attribute)
+        {
+            value = std::get<2>(tuple);
+            break;
+        }
+    }
+    return value;
+}
+
+RasConfiguration::RasConfiguration(
+    sdbusplus::asio::object_server& objectServer,
+    std::shared_ptr<sdbusplus::asio::connection>& systemBus) :
+    sdbusplus::com::amd::RAS::server::Configuration(*systemBus, objectPath),
+    objServer(objectServer), systemBus(systemBus)
+{
+}

--- a/host-transport-extensions/default/cper_generator.cpp
+++ b/host-transport-extensions/default/cper_generator.cpp
@@ -1,0 +1,520 @@
+#include "cper_generator.hpp"
+
+#include "interface_manager.hpp"
+
+template <typename T>
+GUID_T CperGenerator<T>::initializeGUID(unsigned int a, unsigned short b,
+                                        unsigned short c, unsigned char d0,
+                                        unsigned char d1, unsigned char d2,
+                                        unsigned char d3, unsigned char d4,
+                                        unsigned char d5, unsigned char d6,
+                                        unsigned char d7)
+{
+    GUID_T temp;
+    temp.b[0] = (a)&0xff;
+    temp.b[1] = ((a) >> 8) & 0xff;
+    temp.b[2] = ((a) >> 16) & 0xff;
+    temp.b[3] = ((a) >> 24) & 0xff;
+    temp.b[4] = (b)&0xff;
+    temp.b[5] = ((b) >> 8) & 0xff;
+    temp.b[6] = (c)&0xff;
+    temp.b[7] = ((c) >> 8) & 0xff;
+    temp.b[8] = (d0);
+    temp.b[9] = (d1);
+    temp.b[10] = (d2);
+    temp.b[11] = (d3);
+    temp.b[12] = (d4);
+    temp.b[13] = (d5);
+    temp.b[14] = (d6);
+    temp.b[15] = (d7);
+    return temp;
+}
+
+template <typename T>
+void CperGenerator<T>::calculateTimeStamp(const std::shared_ptr<T>& data)
+{
+    using namespace std;
+    using namespace std::chrono;
+    typedef duration<int, ratio_multiply<hours::period, ratio<24>>::type> days;
+
+    system_clock::time_point now = system_clock::now();
+    system_clock::duration tp = now.time_since_epoch();
+
+    days d = duration_cast<days>(tp);
+    tp -= d;
+    hours h = duration_cast<hours>(tp);
+    tp -= h;
+    minutes m = duration_cast<minutes>(tp);
+    tp -= m;
+    seconds s = duration_cast<seconds>(tp);
+    tp -= s;
+
+    time_t tt = system_clock::to_time_t(now);
+    tm utc_tm = *gmtime(&tt);
+
+    data->header.timeStamp.seconds = utc_tm.tm_sec;
+    data->header.timeStamp.minutes = utc_tm.tm_min;
+    data->header.timeStamp.hours = utc_tm.tm_hour;
+    data->header.timeStamp.flag = 1;
+    data->header.timeStamp.day = utc_tm.tm_mday;
+    data->header.timeStamp.month = utc_tm.tm_mon + 1;
+    data->header.timeStamp.year = utc_tm.tm_year;
+    data->header.timeStamp.century = 20 + utc_tm.tm_year / 100;
+    data->header.timeStamp.year = data->header.timeStamp.year % 100;
+}
+
+template <typename T>
+void CperGenerator<T>::dumpCperHeaderSection(const std::shared_ptr<T>& data,
+                                             uint16_t sectionCount,
+                                             uint32_t errorSeverity,
+                                             std::string errorType)
+{
+
+    /*ASCII 4-character array “CPER” (0x43, 0x50, 0x45, 0x52) */
+    memcpy(data->header.signature, CPER_SIG_RECORD.data(), CPER_SIG_SIZE);
+
+    data->header.revision = CPER_RECORD_REV; /*(0x100)*/
+
+    data->header.signatureEnd = CPER_SIG_END; /*(0xFFFFFFFF)*/
+
+    /*Number of valid sections associated with the record*/
+    data->header.sectionCount = sectionCount;
+
+    /*0 - Non-fatal uncorrected ; 1 - Fatal ; 2 - Corrected*/
+    data->header.errorSeverity = errorSeverity;
+
+    /*Bit 0 = 1 -> PlatformID field contains valid info
+      Bit 1 = 1 -> TimeStamp field contains valid info
+      Bit 2 = 1 -> PartitionID field contains valid info*/
+    data->header.validationBits =
+        (CPER_VALID_PLATFORM_ID | CPER_VALID_TIMESTAMP);
+
+    /*Size of whole CPER record*/
+    if ((errorType == RUNTIME_MCA_ERR) || (errorType == RUNTIME_DRAM_ERR))
+    {
+        data->header.recordLength =
+            sizeof(ErrorRecordHeader) +
+            sizeof(ErrorSectionDescriptor) * sectionCount +
+            sizeof(ProcErrorSection) * sectionCount;
+    }
+    if (errorType == RUNTIME_PCIE_ERR)
+    {
+        data->header.recordLength =
+            sizeof(ErrorRecordHeader) +
+            (sizeof(ErrorSectionDescriptor) * sectionCount) +
+            (sizeof(PcieErrorSection) * sectionCount);
+    }
+    else if (errorType == FATAL_ERR)
+    {
+        data->header.recordLength =
+            sizeof(ErrorRecordHeader) +
+            (sizeof(ErrorSectionDescriptor) * sectionCount) +
+            (sizeof(ErrorRecord) * sectionCount);
+    }
+
+    /*TimeStamp when OOB controller received the event*/
+    calculateTimeStamp(data);
+
+    data->header.platformId[INDEX_0] = boardId;
+
+    data->header.creatorId =
+        initializeGUID(0x61fa3fac, 0xcb80, 0x4292, 0x8b, 0xfb, 0xd6, 0x43, 0xb1,
+                       0xde, 0x17, 0xf4);
+
+    if (errorType == RUNTIME_PCIE_ERR)
+    {
+        data->header.notifyType =
+            initializeGUID(0xCF93C01F, 0x1A16, 0x4dfc, 0xB8, 0xBC, 0x9C, 0x4D,
+                           0xAF, 0x67, 0xC1, 0x04);
+    }
+    else if ((errorType == RUNTIME_MCA_ERR) || (errorType == RUNTIME_DRAM_ERR))
+    {
+        if (errorSeverity == SEV_NON_FATAL_CORRECTED)
+        {
+            data->header.notifyType =
+                initializeGUID(0x2DCE8BB1, 0xBDD7, 0x450e, 0xB9, 0xAD, 0x9C,
+                               0xF4, 0xEB, 0xD4, 0xF8, 0x90);
+        }
+        else
+        {
+            data->header.notifyType =
+                initializeGUID(0xE8F56FFE, 0x919C, 0x4cc5, 0xBA, 0x88, 0x65,
+                               0xAB, 0xE1, 0x49, 0x13, 0xBB);
+        }
+    }
+
+    /*Starts at 1 and increments at each time when cper file is generated*/
+    data->header.recordId = recordId++;
+}
+
+template <typename T>
+void CperGenerator<T>::dumpErrorDescriptorSection(
+    const std::shared_ptr<T>& data, uint16_t sectionCount,
+    std::string errorType, uint32_t* severity)
+{
+    for (int i = 0; i < sectionCount; i++)
+    {
+
+        if (errorType == FATAL_ERR)
+        {
+            data->sectionDescriptor[i].sectionOffset =
+                sizeof(ErrorRecordHeader) +
+                (INDEX_2 * sizeof(ErrorSectionDescriptor)) +
+                (i * sizeof(ErrorRecord));
+
+            data->sectionDescriptor[i].sectionLength = sizeof(ErrorRecord);
+
+            data->sectionDescriptor[i].sectionType =
+                initializeGUID(0x32AC0C78, 0x2623, 0x48F6, 0xB0, 0xD0, 0x73,
+                               0x65, 0x72, 0x5F, 0xD6, 0xAE);
+
+            data->sectionDescriptor[i].severity = CPER_SEV_FATAL;
+
+            data->sectionDescriptor[i].fruText[INDEX_0] = 'P';
+            data->sectionDescriptor[i].fruText[INDEX_1] = '0' + i;
+        }
+
+        data->sectionDescriptor[i].revisionMinor = CPER_MINOR_REV;
+
+        if (familyId == TURIN_FAMILY_ID)
+        {
+            data->sectionDescriptor[i].revisionMajor =
+                ((ADDC_GEN_NUMBER_2 & INT_15) << SHIFT_4) | progId;
+        }
+        else if (familyId == GENOA_FAMILY_ID)
+        {
+            data->sectionDescriptor[i].revisionMajor =
+                ((ADDC_GEN_NUMBER_1 & INT_15) << SHIFT_4) | progId;
+        }
+
+        data->sectionDescriptor[i].secValidMask = FRU_ID_VALID | FRU_TEXT_VALID;
+        data->sectionDescriptor[i].sectionFlags = CPER_PRIMARY;
+    }
+}
+
+template <typename T>
+void CperGenerator<T>::dumpProcessorErrorSection(
+    const std::shared_ptr<CperRecord>& fatalPtr, uint8_t info,
+    uint16_t sectionCount, CpuId* cpuId)
+{
+    for (int i = 0; i < numOfCpu; i++)
+    {
+        fatalPtr->errorRecord[i].procError.validBits =
+            CPU_ID_VALID | LOCAL_APIC_ID_VALID;
+        fatalPtr->errorRecord[i].procError.cpuId[INDEX_0] = cpuId[i].eax;
+        fatalPtr->errorRecord[i].procError.cpuId[INDEX_2] = cpuId[i].ebx;
+        fatalPtr->errorRecord[i].procError.cpuId[INDEX_4] = cpuId[i].ecx;
+        fatalPtr->errorRecord[i].procError.cpuId[INDEX_6] = cpuId[i].edx;
+        fatalPtr->errorRecord[i].procError.cpuApicId =
+            ((cpuId[i].ebx >> SHIFT_24) & INT_15);
+
+        if (i == info)
+        {
+            fatalPtr->errorRecord[i].procError.validBits |=
+                PROC_CONTEXT_STRUCT_VALID;
+        }
+    }
+}
+
+template <typename T>
+void CperGenerator<T>::getLastTransAddr(
+    const std::shared_ptr<CperRecord>& fatalPtr, uint8_t info)
+{
+    oob_status_t ret;
+    uint8_t blk_id = 0;
+    uint16_t n = 0;
+    uint16_t maxOffset32;
+    uint32_t data;
+    struct ras_df_err_chk err_chk;
+    union ras_df_err_dump df_err = {0};
+
+    ret = read_ras_df_err_validity_check(info, blk_id, &err_chk);
+
+    if (ret)
+    {
+        lg2::error("Failed to read RAS DF validity check");
+    }
+    else
+    {
+        if (err_chk.df_block_instances != 0)
+        {
+            lg2::info("Harvesting last transaction address");
+
+            maxOffset32 = ((err_chk.err_log_len % BYTE_4) ? INDEX_1 : INDEX_0) +
+                          (err_chk.err_log_len >> BYTE_2);
+            while (n < err_chk.df_block_instances)
+            {
+                for (int offset = 0; offset < maxOffset32; offset++)
+                {
+                    memset(&data, 0, sizeof(data));
+                    /* Offset */
+                    df_err.input[INDEX_0] = offset * BYTE_4;
+                    /* DF block ID */
+                    df_err.input[INDEX_1] = blk_id;
+                    /* DF block ID instance */
+                    df_err.input[INDEX_2] = n;
+
+                    ret = read_ras_df_err_dump(info, df_err, &data);
+
+                    fatalPtr->errorRecord[info]
+                        .contextInfo.dfDumpData.lastTransAddr[n]
+                        .wdtData[offset] = data;
+                }
+                n++;
+            }
+        }
+    }
+}
+
+template <typename T>
+void CperGenerator<T>::harvestDebugLogDump(
+    const std::shared_ptr<CperRecord>& fatalPtr, uint8_t info, uint8_t blk_id,
+    int64_t* apmlRetryCount, uint16_t& debugLogIdOffset)
+{
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+    uint16_t retries = 0;
+    uint16_t n = 0;
+    uint16_t maxOffset32;
+    uint32_t data;
+    struct ras_df_err_chk err_chk;
+    union ras_df_err_dump df_err = {0};
+
+    while (ret != OOB_SUCCESS)
+    {
+
+        retries++;
+
+        ret = read_ras_df_err_validity_check(info, blk_id, &err_chk);
+
+        if (ret == OOB_SUCCESS)
+        {
+            lg2::info(
+                "Socket: {SOCKET},Debug Log ID : {DBG_ID} read successful",
+                "SOCKET", info, "DBG_ID", blk_id);
+            break;
+        }
+
+        if (retries > *apmlRetryCount)
+        {
+            lg2::error("Socket: {SOCKET},Debug Log ID : {DBG_ID} read failed",
+                       "SOCKET", info, "DBG_ID", blk_id);
+
+            /*If 5Bh command fails ,0xBAADDA7A is written thrice in the PCIE
+             * dump region*/
+            fatalPtr->errorRecord[info]
+                .contextInfo.debugLogIdData[debugLogIdOffset++] = blk_id;
+            fatalPtr->errorRecord[info]
+                .contextInfo.debugLogIdData[debugLogIdOffset++] = BAD_DATA;
+            fatalPtr->errorRecord[info]
+                .contextInfo.debugLogIdData[debugLogIdOffset++] = BAD_DATA;
+            fatalPtr->errorRecord[info]
+                .contextInfo.debugLogIdData[debugLogIdOffset++] = BAD_DATA;
+
+            break;
+        }
+    }
+
+    if (ret == OOB_SUCCESS)
+    {
+        if (err_chk.df_block_instances != 0)
+        {
+
+            uint32_t DbgLogIdHeader =
+                (static_cast<uint32_t>(err_chk.err_log_len) << INDEX_16) |
+                (static_cast<uint32_t>(err_chk.df_block_instances) << INDEX_8) |
+                static_cast<uint32_t>(blk_id);
+
+            fatalPtr->errorRecord[info]
+                .contextInfo.debugLogIdData[debugLogIdOffset++] =
+                DbgLogIdHeader;
+
+            maxOffset32 = ((err_chk.err_log_len % BYTE_4) ? INDEX_1 : INDEX_0) +
+                          (err_chk.err_log_len >> BYTE_2);
+
+            while (n < err_chk.df_block_instances)
+            {
+                bool apmlHang = false;
+
+                for (int offset = 0; offset < maxOffset32; offset++)
+                {
+
+                    lg2::info("Harvtesing debug log ID dumps");
+
+                    if (apmlHang == false)
+                    {
+                        memset(&data, 0, sizeof(data));
+                        memset(&df_err, 0, sizeof(df_err));
+
+                        /* Offset */
+                        df_err.input[INDEX_0] = offset * BYTE_4;
+                        /* DF block ID */
+                        df_err.input[INDEX_1] = blk_id;
+                        /* DF block ID instance */
+                        df_err.input[INDEX_2] = n;
+
+                        ret = read_ras_df_err_dump(info, df_err, &data);
+
+                        if (ret != OOB_SUCCESS)
+                        {
+                            // retry
+                            uint16_t retryCount = *apmlRetryCount;
+
+                            while (retryCount > 0)
+                            {
+
+                                memset(&data, 0, sizeof(data));
+                                memset(&df_err, 0, sizeof(df_err));
+
+                                /* Offset */
+                                df_err.input[INDEX_0] = offset * BYTE_4;
+                                /* DF block ID */
+                                df_err.input[INDEX_1] = blk_id;
+                                /* DF block ID instance */
+                                df_err.input[INDEX_2] = n;
+
+                                ret = read_ras_df_err_dump(info, df_err, &data);
+
+                                if (ret == OOB_SUCCESS)
+                                {
+                                    break;
+                                }
+                                retryCount--;
+                                usleep(1000 * 1000);
+                            }
+
+                            if (ret != OOB_SUCCESS)
+                            {
+                                lg2::error("Failed to read debug log dump for "
+                                           "debug log ID : {BLK_ID}",
+                                           "BLK_ID", blk_id);
+                                data = BAD_DATA;
+                                /*the Dump APML command fails in the middle of
+                                  the iterative loop, then write BAADDA7A for
+                                  the remaining iterations in the for loop*/
+                                apmlHang = true;
+                            }
+                        }
+                    }
+
+                    fatalPtr->errorRecord[info]
+                        .contextInfo.debugLogIdData[debugLogIdOffset++] = data;
+                }
+                n++;
+            }
+        }
+    }
+}
+
+template <typename T>
+void CperGenerator<T>::dumpContextInfo(
+    const std::shared_ptr<CperRecord>& fatalPtr, uint16_t numbanks,
+    uint16_t bytespermca, uint8_t info, uint16_t sectionCount,
+    std::vector<uint8_t> blockId, uint64_t* ppin, uint32_t* uCode,
+    int64_t* apmlRetryCount)
+{
+    for (int i = 0; i < numOfCpu; i++)
+    {
+        uint8_t blk_id;
+
+        getLastTransAddr(fatalPtr, i);
+
+        uint16_t debugLogIdOffset = 0;
+
+        for (blk_id = 0; blk_id < blockId.size(); blk_id++)
+        {
+            harvestDebugLogDump(fatalPtr, i, blockId[blk_id], apmlRetryCount,
+                                debugLogIdOffset);
+        }
+
+        fatalPtr->errorRecord[i].contextInfo.ppin = ppin[i];
+
+        if (i == info)
+        {
+            fatalPtr->errorRecord[i].contextInfo.registerContextType =
+                CTX_OOB_CRASH;
+            fatalPtr->errorRecord[i].contextInfo.registerArraySize =
+                numbanks * bytespermca;
+        }
+    }
+}
+
+template <typename T>
+std::string CperGenerator<T>::getCperFilename(int num)
+{
+    return "ras-error" + std::to_string(num) + ".cper";
+}
+
+template <typename T>
+void CperGenerator<T>::cperFileWrite(const std::shared_ptr<T>& data,
+                                     std::string errorType,
+                                     uint16_t sectionCount)
+{
+
+    static std::mutex index_file_mtx;
+    std::unique_lock lock(index_file_mtx);
+
+    std::string cperFileName;
+    FILE* file;
+
+    std::shared_ptr<CperRecord> fatalPtr;
+
+    if constexpr (std::is_same_v<T, CperRecord>)
+    {
+        fatalPtr = std::static_pointer_cast<CperRecord>(data);
+    }
+
+    cperFileName = getCperFilename(errCount);
+
+    for (const auto& entry : std::filesystem::directory_iterator(RAS_DIR))
+    {
+        std::string filename = entry.path().filename().string();
+        if (filename.size() >= cperFileName.size() &&
+            filename.substr(filename.size() - cperFileName.size()) ==
+                cperFileName)
+        {
+            std::filesystem::remove(entry.path());
+        }
+    }
+
+    std::string cperFilePath = RAS_DIR + cperFileName;
+
+    file = fopen(cperFilePath.c_str(), "w");
+
+    if (errorType == FATAL_ERR)
+    {
+        if ((fatalPtr) && (file != NULL))
+        {
+            lg2::info("Generating CPER file for the fatal error");
+
+            fwrite(&fatalPtr->header, sizeof(ErrorRecordHeader), 1, file);
+            fwrite(fatalPtr->sectionDescriptor,
+                   sizeof(ErrorSectionDescriptor) * sectionCount, 1, file);
+            fwrite(fatalPtr->errorRecord, sizeof(ErrorRecord) * sectionCount, 1,
+                   file);
+        }
+    }
+
+    fclose(file);
+
+    errCount++;
+
+    if (errCount >= MAX_ERROR_FILE)
+    {
+        /*The maximum number of error files supported is 10.
+          The counter will be rotated once it reaches max count*/
+        errCount = (errCount % MAX_ERROR_FILE);
+    }
+
+    file = fopen(INDEX_FILE.data(), "w");
+    if (file != NULL)
+    {
+        fprintf(file, "%d", errCount);
+        fclose(file);
+    }
+
+    lock.unlock();
+}
+
+template class CperGenerator<CperRecord>;
+template class CperGenerator<ProcRuntimeErrRecord>;
+template class CperGenerator<PcieRuntimeErrRecord>;

--- a/host-transport-extensions/default/inc/config_manager.hpp
+++ b/host-transport-extensions/default/inc/config_manager.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <com/amd/RAS/Configuration/common.hpp>
+#include <com/amd/RAS/Configuration/server.hpp>
+#include <filesystem>
+#include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/server.hpp>
+#include <string>
+
+static constexpr auto objectPath = "/com/amd/RAS/Configuration";
+
+using AttributeType =
+    sdbusplus::common::com::amd::ras::Configuration::AttributeType;
+using Base = sdbusplus::com::amd::RAS::server::Configuration;
+
+using AttributeName = std::string;
+using AttributeValue =
+    std::variant<bool, std::string, int64_t, std::vector<std::string>,
+                 std::map<std::string, std::string>>;
+using ConfigTable =
+    std::map<std::string,
+             std::tuple<AttributeType, std::string,
+                        std::variant<bool, std::string, int64_t,
+                                     std::vector<std::string>,
+                                     std::map<std::string, std::string>>,
+                        int64_t>>;
+
+struct EventDeleter
+{
+    void operator()(sd_event* event) const
+    {
+        event = sd_event_unref(event);
+    }
+};
+using EventPtr = std::unique_ptr<sd_event, EventDeleter>;
+
+/**
+ * @brief Definition of the RasConfiguration class.
+ *
+ * @tparam AttributeName The type for attribute names (usually std::string).
+ * @tparam AttributeValue The variant type for attribute values.
+ * @tparam ConfigTable The map type for storing attribute information.
+ */
+
+class RasConfiguration : public Base
+{
+  public:
+    /**
+     * Constructor for Configuration.
+     *
+     * @param objectServer Reference to the object server.
+     * @param systemBus Reference to the system D-Bus connection.
+     */
+    RasConfiguration(sdbusplus::asio::object_server& objectServer,
+                     std::shared_ptr<sdbusplus::asio::connection>& systemBus);
+
+    /**
+     * Set the value of an attribute.
+     *
+     * @param attribute The name of the attribute.
+     * @param value The value to set.
+     */
+    void setAttribute(AttributeName attribute, AttributeValue value) override;
+
+    /**
+     * Get the value of an attribute.
+     *
+     * @param attribute The name of the attribute.
+     * @return The value of the attribute.
+     */
+    AttributeValue getAttribute(AttributeName attribute) override;
+
+  private:
+    sdbusplus::asio::object_server& objServer;
+    std::shared_ptr<sdbusplus::asio::connection>& systemBus;
+};

--- a/host-transport-extensions/default/inc/cper.hpp
+++ b/host-transport-extensions/default/inc/cper.hpp
@@ -1,0 +1,186 @@
+#pragma once
+
+#include "ras.hpp"
+
+typedef struct
+{
+    unsigned char b[INDEX_16];
+} GUID_T;
+
+typedef struct
+{
+    uint32_t mcaData[MCA_BANK_MAX_OFFSET] = {0};
+} CRASHDUMP_T;
+
+typedef struct
+{
+    uint32_t wdtData[LAST_TRANS_ADDR_OFFSET] = {0};
+} LAST_TRANS_ADDR;
+
+struct TimeStamp
+{
+    uint8_t seconds;
+    uint8_t minutes;
+    uint8_t hours;
+    uint8_t flag;
+    uint8_t day;
+    uint8_t month;
+    uint8_t year;
+    uint8_t century;
+} __attribute__((packed));
+
+struct ErrorRecordHeader
+{
+    unsigned char signature[CPER_SIG_SIZE];
+    uint16_t revision;
+    uint32_t signatureEnd;
+    uint16_t sectionCount;
+    uint32_t errorSeverity;
+    uint32_t validationBits;
+    uint32_t recordLength;
+    TimeStamp timeStamp;
+    uint64_t platformId[INDEX_2];
+    GUID_T partitionId;
+    GUID_T creatorId;
+    GUID_T notifyType;
+    uint64_t recordId;
+    uint32_t flags;
+    uint64_t persistenceInfo;
+    uint8_t reserved[INDEX_12];
+} __attribute__((packed));
+
+struct ErrorSectionDescriptor
+{
+    uint32_t sectionOffset;
+    uint32_t sectionLength;
+    uint8_t revisionMinor;
+    uint8_t revisionMajor;
+    uint8_t secValidMask;
+    uint8_t reserved;
+    uint32_t sectionFlags;
+    GUID_T sectionType;
+    uint64_t fruId[INDEX_2];
+    uint32_t severity;
+    char fruText[INDEX_20];
+} __attribute__((packed));
+
+struct ProcessorErrorSection
+{
+    uint64_t validBits;
+    uint64_t cpuApicId;
+    uint32_t cpuId[INDEX_12];
+    uint32_t signatureID[INDEX_8];
+    uint32_t reserved[INDEX_8];
+} __attribute__((packed));
+
+struct DfDump
+{
+    LAST_TRANS_ADDR lastTransAddr[CCM_COUNT] = {0};
+} __attribute__((packed));
+
+struct ContextInfo
+{
+    uint16_t registerContextType;
+    uint16_t registerArraySize;
+    uint32_t microcodeVersion;
+    uint64_t ppin;
+    CRASHDUMP_T crashDumpData[GENOA_MCA_BANKS] = {0};
+    DfDump dfDumpData;
+    uint32_t reserved[RESERVE_96] = {0};
+    uint32_t debugLogIdData[DEUB_LOG_DUMP_REGION] = {0};
+} __attribute__((packed));
+
+struct ErrorRecord
+{
+    ProcessorErrorSection procError;
+    ContextInfo contextInfo;
+} __attribute__((packed));
+
+struct CperRecord
+{
+    ErrorRecordHeader header;
+    ErrorSectionDescriptor* sectionDescriptor;
+    ErrorRecord* errorRecord;
+} __attribute__((packed));
+
+struct ProcInfoSection
+{
+    uint64_t validBits;
+    uint64_t cpuApicId;
+    uint32_t cpuId[INDEX_12];
+} __attribute__((packed));
+
+struct ProcessorErrorInfo
+{
+    GUID_T errorType;
+    uint64_t validationBits;
+    uint64_t checkInfo;
+    uint64_t targetId;
+    uint64_t requestorId;
+    uint64_t responderId;
+    uint64_t ip;
+} __attribute__((packed));
+
+struct ProcContextSection
+{
+    uint16_t regContextType;
+    uint16_t regArraySize;
+    uint32_t msrAddr;
+    uint64_t mmRegAddr;
+    uint32_t dumpData[RUNTIME_MCA_BANK_MAX_OFFSET];
+} __attribute__((packed));
+
+struct ProcErrorSection
+{
+    ProcInfoSection procInfoSection;
+    ProcessorErrorInfo procErrorInfo;
+    ProcContextSection procContextStruct;
+} __attribute__((packed));
+
+struct PcieVersion
+{
+    uint8_t minor;
+    uint8_t major;
+    uint8_t reserved[INDEX_2];
+} __attribute__((packed));
+
+struct DeviceId
+{
+    uint16_t vendorId;
+    uint16_t deviceId;
+    uint8_t classCode[INDEX_3];
+    uint8_t function;
+    uint8_t device;
+    uint16_t segment;
+    uint8_t bus;
+    uint8_t secondaryBus;
+    uint8_t Reserved[INDEX_3];
+} __attribute__((packed));
+
+struct PcieErrorSection
+{
+    uint64_t validationBits;
+    uint32_t portType;
+    PcieVersion version;
+    uint32_t commandStatus;
+    uint32_t reserved;
+    DeviceId deviceId;
+    uint64_t deviceSerialNumber;
+    uint32_t bridgeControlStatus;
+    uint8_t capability[INDEX_60];
+    uint32_t aerInfo[INDEX_24];
+} __attribute__((packed));
+
+struct ProcRuntimeErrRecord
+{
+    ErrorRecordHeader header;
+    ErrorSectionDescriptor* sectionDescriptor;
+    ProcErrorSection* procErrorSection;
+} __attribute__((packed));
+
+struct PcieRuntimeErrRecord
+{
+    ErrorRecordHeader header;
+    ErrorSectionDescriptor* sectionDescriptor;
+    PcieErrorSection* pcieErrorSection;
+} __attribute__((packed));

--- a/host-transport-extensions/default/inc/cper_generator.hpp
+++ b/host-transport-extensions/default/inc/cper_generator.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "cper.hpp"
+#include "ras.hpp"
+
+/** @class CperGenerator
+ *  @brief Implementation of CPER record creation
+ */
+template <typename T>
+class CperGenerator
+{
+
+  protected:
+    int boardId;
+    uint64_t recordId;
+    uint8_t numOfCpu;
+    uint8_t progId;
+    uint32_t familyId;
+    int errCount;
+
+  public:
+    /**
+     * @brief Constructs a CperGenerator object.
+     *
+     * @param[in] numOfCpu   The total number of sockets in the system.
+     * @param[in] progId     The program ID.
+     * @param[in] familyId   The family ID.
+     * @param[in] errCount   The preserved error count number for numbering cper
+     * files.
+     */
+    CperGenerator(uint8_t numOfCpu, uint8_t progId, uint32_t familyId,
+                  int errCount) :
+        numOfCpu(numOfCpu),
+        recordId(1), progId(progId), familyId(familyId), errCount(errCount)
+    {
+    }
+
+    /** @brief Push contents of the error record header of the CPER file
+     *  @param[in] data - Shared pointer to the CPER record object.
+     *  @param[in] sectionCount - Number of error sections in the CPER record.
+     *  @param[in] errorSeverity - Error Severity - fatal , correctable or
+     * uncorrectable.
+     *  @param[in] errorType - Fatal or runtime - MCA, DRAM or PCIE AER errors.
+     */
+    void dumpCperHeaderSection(const std::shared_ptr<T>& data,
+                               uint16_t sectionCount, uint32_t errorSeverity,
+                               std::string errorType);
+
+    /** @brief Create a GUID with the input reference number provided
+        @param[in] Input paramters a,b,c,d0 to d7.
+        @returns unique identifier as GUID_T
+     */
+    GUID_T initializeGUID(unsigned int, unsigned short, unsigned short,
+                          unsigned char, unsigned char, unsigned char,
+                          unsigned char, unsigned char, unsigned char,
+                          unsigned char, unsigned char);
+
+    /** @brief Function to calculate and set the timestamp for a given data
+     * object
+     *  @param[in] data - Shared pointer to the CPER record object.
+     */
+    void calculateTimeStamp(const std::shared_ptr<T>& data);
+
+    /** @brief Function to dump the error descriptor section of a given data
+     * object
+     *  @param[in] data - Shared pointer to CPER record object
+     *  @param[in] SectionCount - The number of error descriptor sections.
+     *  @param[in] ErrorType - The type of error.
+     *  @param[out] Severity - Pointer to the severity level of the error.
+     */
+    void dumpErrorDescriptorSection(const std::shared_ptr<T>&, uint16_t,
+                                    std::string, uint32_t*);
+
+    /** @brief Function to dump processor error section to CPER record.
+     *  @param[in] socNum - socket number.
+     */
+    void dumpProcessorErrorSection(const std::shared_ptr<CperRecord>&, uint8_t,
+                                   uint16_t, CpuId*);
+
+    /** @brief Function to write error information to a CPER file.
+     *  @param[in] data - Shared pointer to the CPER record object
+     *  @param[in] ErrorType - The type of error.
+     *  @param[in] SectionCount - The number of error descriptor sections.
+     */
+    void cperFileWrite(const std::shared_ptr<T>&, std::string, uint16_t);
+
+    /** @brief Function to dump context information to CPER record.
+     *  @param[in] data - Shared pointer to the CPER record object
+     *  @param[in]  - Number of valid MCA banks.
+     *  @param[in]  - Number of valid bytes per MCA bank.
+     *  @param[in]  - Socket Number
+     *  @param[in]  - The number of fatal error sections.
+     *  @param[in]  - A vector of uint8_t representing block IDs
+     *  @param[in]  - PPIn The processor pin read from apml commands
+     *  @param[in]  - Microcode version read from apml commands
+     *  @param[in]  - The total number of apml retriesi during failure.
+     */
+    void dumpContextInfo(const std::shared_ptr<CperRecord>&, uint16_t, uint16_t,
+                         uint8_t, uint16_t, std::vector<uint8_t>, uint64_t*,
+                         uint32_t*, int64_t*);
+
+    /** @brief Function to dump the last transaction address during a fatal
+     * error
+     *  @param[in] data - Shared pointer to the CPER record object
+     *  @param[in] socNum - socket number.
+     */
+    void getLastTransAddr(const std::shared_ptr<CperRecord>&, uint8_t);
+
+    /** @brief Function to harvest number of valid debug log instances during a
+     * Syncflood.
+     *  @param[in] data - Shared pointer to the CPER record object
+     *  @param[in] socNum - socket number.
+     *  @param[in]  - A vector of uint8_t representing block IDs
+     *  @param[in]  - PPIn The processor pin read from apml commands
+     *  @param[in]  - Offset for the debug log ID in the CPER record
+     */
+    void harvestDebugLogDump(const std::shared_ptr<CperRecord>&, uint8_t,
+                             uint8_t, int64_t*, uint16_t&);
+
+    /** @brief Function returns cper file name for the provided error count
+     * number
+     *  @param[in] num - Error count number.
+     */
+    std::string getCperFilename(int);
+};

--- a/host-transport-extensions/default/inc/interface_manager.hpp
+++ b/host-transport-extensions/default/inc/interface_manager.hpp
@@ -1,0 +1,281 @@
+#pragma once
+
+#include "config_manager.hpp"
+#include "cper.hpp"
+#include "cper_generator.hpp"
+#include "ras.hpp"
+
+#include <cstdint>
+
+extern "C" {
+#include "apml.h"
+#include "apml_common.h"
+#include "esmi_cpuid_msr.h"
+#include "esmi_mailbox.h"
+#include "esmi_rmi.h"
+}
+
+class InterfaceManager : public RasConfiguration
+{
+
+  private:
+    uint8_t numOfCpu;
+    CpuId* cpuId;
+    bool apmlInitialized;
+    std::vector<uint8_t> blockId;
+    uint32_t familyId;
+    unsigned int boardId;
+    uint8_t progId;
+    uint32_t* uCode;
+    uint64_t* ppin;
+    int errCount;
+    std::shared_ptr<CperRecord> rcd;
+    boost::asio::io_service& io;
+    gpiod::line p0_apmlAlertLine;
+    gpiod::line p1_apmlAlertLine;
+    boost::asio::posix::stream_descriptor p0_apmlAlertEvent;
+    boost::asio::posix::stream_descriptor p1_apmlAlertEvent;
+    void p0AlertEventHandler();
+    void p1AlertEventHandler();
+    std::string* inventoryPath;
+    bool p0AlertProcessed;
+    bool p1AlertProcessed;
+    std::mutex harvest_in_progress_mtx;
+
+    /**
+     * @brief Retrieves the CPU ID.
+     *
+     * This function obtains the CPU ID of the system.
+     */
+    void getCpuId();
+
+    /**
+     * @brief Retrieves the microcode revision.
+     *
+     * This function retrieves the version of microcode currently loaded on the
+     * CPU.
+     */
+    void getMicrocodeRev();
+
+    /**
+     * @brief Retrieves the PPIN (Platform Processor Identification Number)
+     * fuse.
+     *
+     * This function obtains the PPIN fuse value associated with the hardware
+     * platform.
+     */
+    void getPpinFuse();
+
+    /**
+     * @brief Retrieves the board ID.
+     *
+     * This function retrieves the Board ID of the motherboard.
+     */
+    void getBoardId();
+
+    /**
+     * @brief Retrieves the number of sockets
+     *
+     * This function determines the total number of sockets in the system.
+     */
+    void getNumberOfCpu();
+
+    /**
+     * @brief Finds the program ID.
+     */
+    void findProgramId();
+
+    /**
+     * @brief Creates an index file.
+     *
+     * This function generates an index file to keep track of error count.
+     */
+    void createIndexFile();
+
+    /**
+     * @brief Creates a configuration file.
+     *
+     * This function generates a configuration file with default settings and
+     * parameters. The configuration file can ve modified by the user in
+     * runtime.
+     */
+    void createConfigFile();
+
+    /**
+     * @brief Harvests information related to a fatal error.
+     *
+     * @param info The error code or information related to the fatal error.
+     */
+    void harvestFatalError(uint8_t);
+
+    /**
+     * @brief Clears SBRMI alert status register.
+     *
+     * @param info The socket number.
+     */
+    void clearSbrmiAlertMask(uint8_t);
+
+    /**
+     * @brief Checks if the APML interface is initialized or not.
+     */
+    void apmlInitializeCheck();
+
+    /**
+     * @brief Reads the value from a specified register.
+     *
+     * @param info The Socket Number.
+     * @param reg The register address.
+     * @param value Pointer to store the read value.
+     * @return The status of the read operation (e.g., success, failure).
+     */
+    oob_status_t readRegister(uint8_t, uint32_t, uint8_t*);
+
+    /**
+     * @brief Writes a value to the specified register.
+     *
+     * @param info The Socket Number.
+     * @param reg The register address.
+     * @param value The value to write to the register.
+     */
+    void writeRegister(uint8_t, uint32_t, uint32_t);
+
+    /**
+     * @brief Retrieves a property value from a D-Bus interface.
+     *
+     * @tparam T The type of the property value to retrieve.
+     * @param bus Reference to the D-Bus connection.
+     * @param service The D-Bus service name.
+     * @param path The D-Bus object path.
+     * @param interface The D-Bus interface name.
+     * @param propertyName The name of the property to retrieve.
+     * @return The value of the requested property (of type T).
+     */
+    template <typename T>
+    T getProperty(sdbusplus::bus::bus&, const char*, const char*, const char*,
+                  const char*);
+
+    /**
+     * @brief Request GPIO events for a specific GPIO line.
+     *
+     * @param[in] name - The name of the GPIO line.
+     * @param[in] handler - A function to be called when GPIO events occur.
+     * @param[in,out] gpioLine - The GPIO line to configure for events.
+     * @param[in,out] gpioEventDescriptor - A stream descriptor associated with
+     * the GPIO line's events.
+     */
+    void requestGPIOEvents(const std::string&, const std::function<void()>&,
+                           gpiod::line&,
+                           boost::asio::posix::stream_descriptor&);
+
+    /**
+     * @brief Monitors the current host state.
+     */
+    void currentHostStateMonitor();
+
+    /**
+     *
+     *@brief This function checks the validity of MCA data.
+     *
+     * @param The socket number.
+     * @param numbanks Pointer to the number of MCA banks.
+     * @param bytespermca Pointer to the size (in bytes) of each MCA entry.
+     * @return True if the MCA data is valid; otherwise, false.
+     */
+    bool harvestMcaValidityCheck(uint8_t, uint16_t*, uint16_t*);
+
+    /**
+     * @brief Harvests Machine Check Architecture (MCA) data banks.
+     *
+     * @param info he socket number.
+     * @param numbanks The number of MCA banks.
+     * @param bytespermca The size (in bytes) of each MCA entry.
+     * @param Shared pointer to the CPER record object.
+     */
+    template <typename T>
+    void harvestMcaDataBanks(uint8_t, uint16_t, uint16_t, CperGenerator<T>&);
+
+    /**
+     * @brief Requests a host transition based on the specified command.
+     *
+     * @param command The command indicating the desired host transition.
+     */
+    void requestHostTransition(std::string);
+
+    /**
+     * @brief Initiates a cold reset.
+     *
+     * This function triggers a cold reset, which involves a complete system
+     * restart. It performs a full power cycle, resetting all components and
+     * clearing any volatile state.
+     */
+    void triggerColdReset();
+
+  public:
+    /**
+     * @brief Constructor for the InterfaceManager class.
+     *
+     * Initializes an instance of InterfaceManager with the given parameters.
+     *
+     * @param objectServer Reference to the object server.
+     * @param systemBus Reference to the system D-Bus connection.
+     * @param io Reference to the boost::asio::io_service.
+     */
+    InterfaceManager(sdbusplus::asio::object_server& objectServer,
+                     std::shared_ptr<sdbusplus::asio::connection>& systemBus,
+                     boost::asio::io_service& io) :
+        RasConfiguration(objectServer, systemBus),
+        io(io), apmlInitialized(false), rcd(nullptr), p0_apmlAlertEvent(io),
+        p1_apmlAlertEvent(io), p0AlertProcessed(false), p1AlertProcessed(false)
+    {
+
+        init();
+
+        configure();
+
+        harvestDumps(ERROR_TYPE_FATAL);
+    }
+
+    ~InterfaceManager()
+    {
+        delete[] cpuId;
+        delete[] uCode;
+        delete[] ppin;
+    }
+
+    /**
+     * @brief Initializes the RAS module.
+     *
+     * This function performs necessary initialization steps for the module.
+     * It checks for number of CPU's, check if apml is initialized,
+     * find the program ID and board ID.
+     */
+    void init();
+
+    /**
+     * @brief Configures the RAS module.
+     *
+     * This function creates the error index file , RAS configuration file
+     * reads info such as PPIN and microcode.
+     */
+    void configure();
+
+    /**
+     * @brief Harvests dumps related to Fatal/Runtime error type
+     *
+     * This function collects relevant dump data associated with the given error
+     * type.
+     *
+     * @param errorType The type of error for which to harvest dumps.
+     */
+    void harvestDumps(ErrorType);
+
+    /**
+     * @brief Performs recovery actions.
+     *
+     * This function executes recovery actions based on the current user
+     * configuration. It may perfomr wam reset or cold reset or no reset.
+     *
+     * @param Value of RAS status register.
+     */
+    void rasRecoveryAction(uint8_t);
+};

--- a/host-transport-extensions/default/inc/ras.hpp
+++ b/host-transport-extensions/default/inc/ras.hpp
@@ -1,0 +1,152 @@
+#pragma once
+
+#include <sys/stat.h>
+
+#include <boost/asio.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <gpiod.hpp>
+#include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <phosphor-logging/log.hpp>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+
+static const int GENOA_MCA_BANKS = 32;
+static const int MAX_MCA_BANKS = 32;
+static const int CCM_COUNT = 8;
+static const int MCA_BANK_MAX_OFFSET = 128;
+static const int LAST_TRANS_ADDR_OFFSET = 4;
+static const int DEUB_LOG_DUMP_REGION = 12124;
+static const int FAILURE_SIGNATURE_ID = 0x04;
+static const int CPER_SIG_SIZE = 4;
+static const int INDEX_0 = 0;
+static const int INDEX_1 = 1;
+static const int INDEX_2 = 2;
+static const int INDEX_3 = 3;
+static const int INDEX_4 = 4;
+static const int INDEX_5 = 5;
+static const int INDEX_6 = 6;
+static const int INDEX_7 = 7;
+static const int INDEX_8 = 8;
+static const int INDEX_12 = 12;
+static const int INDEX_16 = 16;
+static const int INDEX_20 = 20;
+static const int INDEX_24 = 24;
+static const int INDEX_60 = 60;
+static const int RESERVE_96 = 96;
+static const int BYTE_4 = 4;
+static const int BYTE_2 = 2;
+
+static const std::string RAS_DIR = "/var/lib/amd-ras/";
+static const std::string INDEX_FILE = "/var/lib/amd-ras/current_index";
+static const std::string CONFIG_FILE = "/var/lib/amd-ras/ras-config.json";
+static const std::string SRC_CONFIG_FILE =
+    "/usr/share/ras-config/ras-config.json";
+static const int MAX_RETRIES = 10;
+static const std::string NO_RESET = "NO_RESET";
+static const std::string COLD_RESET = "COLD_RESET";
+static const std::string WARM_RESET = "WARM_RESET";
+static const std::string COMMAND_NUM_OF_CPU = "/sbin/fw_printenv -n num_of_cpu";
+static const std::string COMMAND_BOARD_ID = "/sbin/fw_printenv -n board_id";
+static const std::string INVENTORY_SERVICE =
+    "xyz.openbmc_project.Inventory.Manager";
+static const std::string CPU_INVENTORY_INTERFACE =
+    "xyz.openbmc_project.Inventory.Item.Cpu";
+static const int COMMAND_LEN = 3;
+static const int BAD_DATA = 0xBAADDA7A;
+static const int TWO_SOCKET = 2;
+static const int MI300A_MODEL_NUMBER = 0x90;
+static const int MI300C_MODEL_NUMBER = 0x80;
+static const int EPYC_PROG_SEG_ID = 0x01;
+static const int MI_PROG_SEG_ID = 0x02;
+static const int NAVI_PROG_SEG_ID = 0x03;
+static const int MCA_POLLING_PERIOD = 3;
+static const int DRAM_CECC_POLLING_PERIOD = 5;
+static const int PCIE_AER_POLLING_PERIOD = 7;
+static const std::string SYS_RESET = "SYS_RST";
+static const std::string RSMRST = "RSMRST";
+static const int ERROR_THRESHOLD_VAL = 1;
+static const std::string READ_REGISTER = "Read";
+static const std::string WRITE_REGISTER = "Write";
+
+static const int PCIE_ERROR_THRESHOLD = 32;
+static const int DRAM_CECC_ERROR_THRESHOLD = 16;
+static const int MCA_ERROR_THRESHOLD = 8;
+static const int FATAL_ERROR = 1;
+static const int MCA_ERR_OVERFLOW = 8;
+static const int DRAM_CECC_ERR_OVERFLOW = 16;
+static const int PCIE_ERR_OVERFLOW = 32;
+static const int SYS_MGMT_CTRL_ERR = 0x04;
+static const int RESET_HANG_ERR = 0x02;
+static const int INT_15 = 0xFF;
+static const int BASE_16 = 16;
+static const int RAS_STATUS_REGISTER = 0x4C;
+
+static const int GENOA_FAMILY_ID = 0x19;
+static const int TURIN_FAMILY_ID = 0x1A;
+static const std::string APML_INIT_DONE_FILE = "/tmp/apml_init_complete";
+static const int SBRMI_CONTROL_REGISTER = 0x1;
+static const std::string CPER_SIG_RECORD = "CPER";
+static const int CPER_RECORD_REV = 0x0100;
+static const int FATAL_SECTION_COUNT = 2;
+static const int CPER_SIG_END = 0xffffffff;
+static const int CPER_SEV_FATAL = 1;
+static const int CPER_VALID_PLATFORM_ID = 0x0001;
+static const int CPER_VALID_TIMESTAMP = 0x0002;
+static const int CPER_VALID_PARTITION_ID = 0x0004;
+static const std::string RUNTIME_MCA_ERR = "RUNTIME_MCA_ERROR";
+static const std::string RUNTIME_PCIE_ERR = "RUNTIME_PCIE_ERROR";
+static const std::string RUNTIME_DRAM_ERR = "RUNTIME_DRAM_ERROR";
+static const int RUNTIME_MCA_BANK_MAX_OFFSET = 32;
+static const std::string FATAL_ERR = "FATAL";
+static const int SEV_NON_FATAL_UNCORRECTED = 0;
+static const int SEV_NON_FATAL_CORRECTED = 2;
+static const int MAX_ERROR_FILE = 10;
+static const int CPER_MINOR_REV = 0x1;
+static const int FRU_ID_VALID = 0x01;
+static const int FRU_TEXT_VALID = 0x02;
+static const int CPER_PRIMARY = 1;
+static const int ADDC_GEN_NUMBER_1 = 0x01;
+static const int ADDC_GEN_NUMBER_2 = 0x02;
+static const int ADDC_GEN_NUMBER_3 = 0x03;
+static const int CPU_ID_VALID = 0x02;
+static const int LOCAL_APIC_ID_VALID = 0x01;
+static const int PROC_CONTEXT_STRUCT_VALID = 0x100;
+static const int CTX_OOB_CRASH = 0x01;
+static const int SHIFT_4 = 4;
+static const int SOCKET_0 = 0;
+static const int SOCKET_1 = 1;
+static const int SHIFT_23 = 23;
+static const int SHIFT_24 = 24;
+static const int SHIFT_25 = 25;
+static const int BLOCK_ID_1 = 1;
+static const int BLOCK_ID_2 = 2;
+static const int BLOCK_ID_3 = 3;
+static const int BLOCK_ID_24 = 24;
+static const int BLOCK_ID_33 = 33;
+static const int BLOCK_ID_36 = 36;
+static const int BLOCK_ID_37 = 37;
+static const int BLOCK_ID_38 = 38;
+static const int BLOCK_ID_39 = 39;
+static const int BLOCK_ID_40 = 40;
+
+static const std::string DBUS_SERVICE_NAME = "com.amd.RAS";
+static const std::string DBUS_OBJECT_NAME = "/com/amd/RAS";
+
+enum ErrorType
+{
+    ERROR_TYPE_FATAL,
+    ERROR_TYPE_NON_FATAL
+};
+
+struct CpuId
+{
+    uint32_t eax;
+    uint32_t ebx;
+    uint32_t ecx;
+    uint32_t edx;
+};

--- a/host-transport-extensions/default/meson.build
+++ b/host-transport-extensions/default/meson.build
@@ -1,0 +1,6 @@
+interface_src_files = ['host-transport-extensions/default/apml_interface.cpp',
+                       'host-transport-extensions/default/cper_generator.cpp',
+                       'host-transport-extensions/default/config_manager.cpp']
+
+interface_includes = 'host-transport-extensions/default/inc'
+

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,61 @@
+project(
+    'amd-bmc-ras',
+    'cpp',
+    default_options: [
+        'warning_level=3',
+        'cpp_std=c++23'
+    ],
+    license: 'Apache-2.0',
+    version: '0.1',
+    meson_version: '>=1.1.1',
+)
+
+cpp = meson.get_compiler('cpp')
+libdir = meson.current_source_dir() + './lib/'
+apml_dep = cpp.find_library('apml64', dirs : libdir) # ./lib/libapml64.lib
+
+deps = [
+  dependency('libgpiodcxx', default_options: ['bindings=cxx']),
+  dependency('systemd'),
+  dependency('sdbusplus'),
+  dependency('phosphor-logging'),
+  dependency('phosphor-dbus-interfaces'),
+  dependency('boost'),
+  dependency('threads'),
+  dependency('nlohmann_json', include_type: 'system'),
+  apml_dep,
+]
+
+hostInterface = get_option('host-transport')
+
+if hostInterface == 'default'
+    subdir('host-transport-extensions/default')
+endif
+
+executable(
+  'amd-bmc-ras',
+  'src/main.cpp',
+  interface_src_files,
+  include_directories: include_directories(interface_includes),
+  dependencies: deps,
+  install: true,
+  install_dir: get_option('bindir'))
+
+ras_config_dir = join_paths(get_option('datadir'), 'ras-config')
+install_data(
+    join_paths(meson.current_source_dir(), 'config', 'ras-config.json'),
+    install_dir: ras_config_dir,
+    rename: 'ras-config.json'
+)
+
+systemd = dependency('systemd')
+systemd_system_unit_dir = systemd.get_variable(
+    'systemdsystemunitdir',
+    pkgconfig_define: ['prefix', get_option('prefix')])
+
+fs = import('fs')
+fs.copyfile(
+    'service_files/com.amd.RAS.service',
+    install: true,
+    install_dir: systemd_system_unit_dir
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,10 @@
+option(
+    'systemd-target',
+    description: 'Target for starting this service.',
+    type: 'string'
+)
+
+option('host-transport', type : 'string',
+        value : 'default',
+        description : 'To specify the host dump transport protocol')
+

--- a/service_files/com.amd.RAS.service
+++ b/service_files/com.amd.RAS.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Crash dump manager
+After=xyz.openbmc_project.Chassis.Control.Power.service
+
+[Service]
+Restart=always
+ExecStart=/usr/bin/amd-bmc-ras
+
+[Install]
+WantedBy=multi-user.target

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,19 @@
+#include "config_manager.hpp"
+#include "interface_manager.hpp"
+
+int main()
+{
+    boost::asio::io_service io;
+
+    auto systemBus = std::make_shared<sdbusplus::asio::connection>(io);
+
+    systemBus->request_name(DBUS_SERVICE_NAME.data());
+
+    sdbusplus::asio::object_server objectServer(systemBus);
+
+    InterfaceManager manager(objectServer, systemBus, io);
+
+    io.run();
+
+    return 0;
+}


### PR DESCRIPTION
Add support to handle fatal errors for 1P/2P platforms. The application harvests MCA dump and debug log ID dump along with the  processor informations (CPUID, PPIN, Microcode , APIC ID etc) and creates a CPER record. The application also registers com.amd.RAS.Configuration interface to allow the user to set/get user configuration properties.