### PR TITLE
Stop monitoring for runtime errors when SUT is powered off

### DIFF
--- a/inc/ras.hpp
+++ b/inc/ras.hpp
@@ -137,7 +137,9 @@ void dump_proc_error_info_section(const std::shared_ptr<T>&, uint8_t, uint16_t,
                                   uint64_t*, uint32_t);
 void exportCrashdumpToDBus(int, const ERROR_TIME_STAMP&);
 void write_register(uint8_t, uint32_t, uint32_t);
-
+template <typename T>
+T getProperty(sdbusplus::bus::bus& bus, const char* service, const char* path,
+              const char* interface, const char* propertyName);
 extern boost::asio::io_service io;
 extern std::vector<uint8_t> BlockId;
 

--- a/src/fatal_error.cpp
+++ b/src/fatal_error.cpp
@@ -252,26 +252,6 @@ void harvestDebugLogDump(uint8_t info, uint8_t blk_id)
     }
 }
 
-template <typename T>
-T GetProperty(sdbusplus::bus::bus& bus, const char* service, const char* path,
-              const char* interface, const char* propertyName)
-{
-    auto method = bus.new_method_call(service, path,
-                                      "org.freedesktop.DBus.Properties", "Get");
-    method.append(interface, propertyName);
-    std::variant<T> value{};
-    try
-    {
-        auto reply = bus.call(method);
-        reply.read(value);
-    }
-    catch (const sdbusplus::exception::SdBusError& ex)
-    {
-        sd_journal_print(LOG_ERR, "GetProperty call failed \n");
-    }
-    return std::get<T>(value);
-}
-
 void requestHostTransition(std::string command)
 {
 
@@ -313,7 +293,7 @@ void triggerRsmrstReset()
 
     sleep(1);
     sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
-    std::string CurrentHostState = GetProperty<std::string>(
+    std::string CurrentHostState = getProperty<std::string>(
         bus, "xyz.openbmc_project.State.Host",
         "/xyz/openbmc_project/state/host0", "xyz.openbmc_project.State.Host",
         "CurrentHostState");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -528,6 +528,10 @@ static void currentHostStateMonitor()
                 SetOobConfig();
                 ErrThresholdEnable();
             }
+            else
+            {
+                apmlInitialized = false;
+            }
         });
 }
 
@@ -584,9 +588,9 @@ bool PlatformInitialization()
 
         currentHostStateMonitor();
 
-        BlockId = {BLOCK_ID_1,  BLOCK_ID_2,  BLOCK_ID_3,
-                   BLOCK_ID_24, BLOCK_ID_33, BLOCK_ID_36,
-                   BLOCK_ID_37, BLOCK_ID_38, BLOCK_ID_40};
+        BlockId = {BLOCK_ID_1,  BLOCK_ID_2,  BLOCK_ID_3,  BLOCK_ID_23,
+                   BLOCK_ID_24, BLOCK_ID_33, BLOCK_ID_36, BLOCK_ID_37,
+                   BLOCK_ID_38, BLOCK_ID_40};
     }
     else
     {

--- a/src/runtime_errors.cpp
+++ b/src/runtime_errors.cpp
@@ -28,7 +28,6 @@ oob_status_t RunTimeErrValidityCheck(uint8_t soc_num,
                 "Failed to get bmc ras runtime error validity check\n");
         }
     }
-
     return ret;
 }
 
@@ -47,7 +46,8 @@ oob_status_t RasErrThresholdSet(struct run_time_threshold th)
         if (ret != OOB_SUCCESS)
         {
             sd_journal_print(
-                LOG_INFO, "Failed to set MCA error threshold for processor P0\n");
+                LOG_INFO,
+                "Failed to set MCA error threshold for processor P0\n");
         }
         usleep(1000 * 1000);
         retryCount--;
@@ -59,7 +59,7 @@ oob_status_t RasErrThresholdSet(struct run_time_threshold th)
         retryCount = INDEX_20;
         ret = OOB_MAILBOX_CMD_UNKNOWN;
 
-        if(ret != OOB_SUCCESS)
+        if (ret != OOB_SUCCESS)
         {
             ret = set_bmc_ras_err_threshold(p1_info, th);
 

--- a/src/write_cper_data.cpp
+++ b/src/write_cper_data.cpp
@@ -875,8 +875,7 @@ void write_to_cper_file(const std::shared_ptr<T>& data, std::string ErrorType,
 
             exportCrashdumpToDBus(err_count, FatalPtr->Header.TimeStamp);
 
-            std::string ras_err_msg =
-                "CPER file generated for fatal error";
+            std::string ras_err_msg = "CPER file generated for fatal error";
 
             sd_journal_send(
                 "MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i", LOG_ERR,


### PR DESCRIPTION
1. Add debug log ID 23 to the crashdump flow.
2. Stop polling for runtime errors when SUT is powered off.
3. Code cleanup