### PR TITLE
Add and monitor apmlActive dbus signal

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -30,7 +30,7 @@
  * CPER section descriptor revision, used in revision field in struct
  * cper_section_descriptor
  */
-#define CPER_MINOR_REV (0x0007)
+#define CPER_MINOR_REV (0x0008)
 
 #define ADDC_GEN_NUMBER_1 (0x01)
 #define ADDC_GEN_NUMBER_2 (0x02)

--- a/inc/ras.hpp
+++ b/inc/ras.hpp
@@ -80,8 +80,6 @@ extern "C" {
 #define RUNTIME_DRAM_ERR ("RUNTIME_DRAM_ERROR")
 #define FATAL_ERR ("FATAL")
 
-#define RETRY_45 (45)
-#define SLEEP_20 (20)
 #define WARM_RESET (0)
 #define COLD_RESET (1)
 #define NO_RESET (2)
@@ -137,6 +135,9 @@ void dump_proc_error_info_section(const std::shared_ptr<T>&, uint8_t, uint16_t,
                                   uint64_t*, uint32_t);
 void exportCrashdumpToDBus(int, const ERROR_TIME_STAMP&);
 void write_register(uint8_t, uint32_t, uint32_t);
+template <typename T>
+T getProperty(sdbusplus::bus::bus& bus, const char* service, const char* path,
+              const char* interface, const char* propertyName);
 
 extern boost::asio::io_service io;
 extern std::vector<uint8_t> BlockId;

--- a/src/dbus_ras.cpp
+++ b/src/dbus_ras.cpp
@@ -20,6 +20,8 @@ constexpr std::string_view crashdumpAssertedInterface =
     "com.amd.crashdump.Asserted";
 constexpr std::string_view crashdumpConfigInterface =
     "com.amd.crashdump.Configuration";
+constexpr std::string_view apmlActiveInterface = "com.amd.crashdump.ApmlActive";
+
 constexpr std::string_view crashdumpAssertedMethod = "GenerateAssertedLog";
 // These 2 interfaces will be called by bmcweb, not supported now.
 // constexpr std::string_view crashdumpOnDemandInterface =
@@ -122,6 +124,12 @@ void CreateDbusInterface()
     conn->request_name(crashdumpService.data());
     server = std::make_shared<sdbusplus::asio::object_server>(conn);
 
+    std::shared_ptr<sdbusplus::asio::dbus_interface> apmlIface =
+        server->add_interface(crashdumpPath.data(), apmlActiveInterface.data());
+
+    // Set the signal handler using a lambda function
+    apmlIface->register_signal<std::string>("apmlActive");
+    apmlIface->initialize();
     // This DBus interface/method should be triggered by
     // host-error-monitor(https://github.com/openbmc/host-error-monitor).
     // However `amd-ras` monitors the alert pin by itself instead of asking

--- a/src/fatal_error.cpp
+++ b/src/fatal_error.cpp
@@ -217,7 +217,7 @@ void harvestDebugLogDump(uint8_t info, uint8_t blk_id)
                                     break;
                                 }
                                 retryCount--;
-                                usleep(1000 * 1000);
+                                sleep(INDEX_1);
                             }
 
                             if (ret != OOB_SUCCESS)
@@ -250,26 +250,6 @@ void harvestDebugLogDump(uint8_t info, uint8_t blk_id)
             }
         }
     }
-}
-
-template <typename T>
-T GetProperty(sdbusplus::bus::bus& bus, const char* service, const char* path,
-              const char* interface, const char* propertyName)
-{
-    auto method = bus.new_method_call(service, path,
-                                      "org.freedesktop.DBus.Properties", "Get");
-    method.append(interface, propertyName);
-    std::variant<T> value{};
-    try
-    {
-        auto reply = bus.call(method);
-        reply.read(value);
-    }
-    catch (const sdbusplus::exception::SdBusError& ex)
-    {
-        sd_journal_print(LOG_ERR, "GetProperty call failed \n");
-    }
-    return std::get<T>(value);
 }
 
 void requestHostTransition(std::string command)
@@ -313,7 +293,7 @@ void triggerRsmrstReset()
 
     sleep(1);
     sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
-    std::string CurrentHostState = GetProperty<std::string>(
+    std::string CurrentHostState = getProperty<std::string>(
         bus, "xyz.openbmc_project.State.Host",
         "/xyz/openbmc_project/state/host0", "xyz.openbmc_project.State.Host",
         "CurrentHostState");
@@ -507,7 +487,7 @@ static bool harvest_mca_data_banks(uint8_t info, uint16_t numbanks,
                         break;
                     }
                     retryCount--;
-                    usleep(1000 * 1000);
+                    sleep(INDEX_1);
                 }
                 if (ret != OOB_SUCCESS)
                 {
@@ -664,7 +644,7 @@ static bool harvest_mca_validity_check(uint8_t info, uint16_t* numbanks,
                              "Retry Count: %d\n",
                              info, retries);
             ret = OOB_MAILBOX_CMD_UNKNOWN;
-            usleep(1000 * 1000);
+            sleep(INDEX_1);
             continue;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,6 @@
 //#define LOG_DEBUG LOG_ERR
 
 boost::asio::io_service io;
-static std::shared_ptr<sdbusplus::asio::connection> conn;
 static std::shared_ptr<sdbusplus::asio::object_server> server;
 static std::array<
     std::pair<std::string, std::shared_ptr<sdbusplus::asio::dbus_interface>>,
@@ -68,6 +67,8 @@ uint64_t p1_last_transact_addr = 0;
 std::vector<uint8_t> BlockId;
 uint8_t ProgId = 0;
 bool apmlInitialized = false;
+bool platformInitialized = false;
+bool runtimeErrPollingSupported = false;
 
 /**
  * Check number of CPU's of the current platform.
@@ -418,7 +419,8 @@ oob_status_t read_register(uint8_t info, uint32_t reg, uint8_t* value)
         }
         sd_journal_print(LOG_ERR, "Failed to read register:0x%x Retrying\n",
                          reg);
-        usleep(1000 * 1000);
+
+        sleep(INDEX_1);
         retryCount--;
     }
     if (ret != OOB_SUCCESS)
@@ -464,10 +466,9 @@ static void currentHostStateMonitor()
 {
     sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
     boost::system::error_code ec;
-    auto conn = std::make_shared<sdbusplus::asio::connection>(io);
 
     static auto match = sdbusplus::bus::match::match(
-        *conn,
+        bus,
         "type='signal',member='PropertiesChanged', "
         "interface='org.freedesktop.DBus.Properties', "
         "arg0='xyz.openbmc_project.State.Host'",
@@ -505,53 +506,17 @@ static void currentHostStateMonitor()
                 return;
             }
 
-            if (*currentHostState !=
-                "xyz.openbmc_project.State.Host.HostState.Off")
-            {
-
-                apmlInitialized = false;
-                struct stat buffer;
-
-                while (INDEX_1)
-                {
-                    if (stat(APML_INIT_DONE_FILE, &buffer) == 0)
-                    {
-                        sd_journal_print(LOG_INFO,
-                                         "APML initialization done \n");
-                        break;
-                    }
-                }
-
-                sleep(180);
-                apmlInitialized = true;
-                clearSbrmiAlertMask();
-                SetOobConfig();
-                ErrThresholdEnable();
-            }
+            apmlInitialized = false;
         });
 }
 
-/* Check if the ADDC feature is supported for the platform
- * Supported platform = Stones , Breithorn , MI300
- * @return true if the module is supported, false otherwise.
- */
-bool PlatformInitialization()
+void performPlatformInitialization()
 {
     oob_status_t ret;
     uint8_t soc_num = 0;
 
     struct processor_info plat_info[INDEX_1];
-    struct stat buffer;
     uint16_t retryCount = 10;
-
-    while (INDEX_1)
-    {
-        if (stat(APML_INIT_DONE_FILE, &buffer) == 0)
-        {
-            sd_journal_print(LOG_INFO, "APML initialization done\n");
-            break;
-        }
-    }
 
     while (retryCount > 0)
     {
@@ -562,12 +527,10 @@ bool PlatformInitialization()
             FamilyId = plat_info->family;
             break;
         }
-        usleep(1000 * 1000);
+        sleep(INDEX_1);
         retryCount--;
-        sd_journal_print(LOG_INFO,
-                         "Reading family ID failed. Retry count = %d \n",
-                         retryCount);
     }
+
     if (plat_info->family == GENOA_FAMILY_ID)
     {
         if ((plat_info->model != MI300A_MODEL_NUMBER) &&
@@ -579,21 +542,85 @@ bool PlatformInitialization()
     else if (plat_info->family == TURIN_FAMILY_ID)
     {
 
-        apmlInitialized = true;
-        clearSbrmiAlertMask();
-
         currentHostStateMonitor();
 
-        BlockId = {BLOCK_ID_1,  BLOCK_ID_2,  BLOCK_ID_3,
-                   BLOCK_ID_24, BLOCK_ID_33, BLOCK_ID_36,
-                   BLOCK_ID_37, BLOCK_ID_38, BLOCK_ID_40};
+        clearSbrmiAlertMask();
+
+        BlockId = {BLOCK_ID_1,  BLOCK_ID_2,  BLOCK_ID_3,  BLOCK_ID_23,
+                   BLOCK_ID_24, BLOCK_ID_33, BLOCK_ID_36, BLOCK_ID_37,
+                   BLOCK_ID_38, BLOCK_ID_40};
+
+        RunTimeErrorPolling();
+
+        runtimeErrPollingSupported = true;
     }
-    else
+    platformInitialized = true;
+}
+
+void apmlActiveMonitor()
+{
+
+    uint8_t rev;
+    oob_status_t ret;
+    uint8_t soc_num = INDEX_0;
+    uint16_t retryCount = 10;
+
+    while (retryCount > 0)
     {
-        sd_journal_print(LOG_ERR, "ADDC is not supported for this platform\n");
-        return false;
+        ret = read_sbrmi_revision(soc_num, &rev);
+
+        if (ret == OOB_SUCCESS)
+        {
+            performPlatformInitialization();
+            break;
+        }
+        sleep(INDEX_1);
+        retryCount--;
     }
-    return true;
+
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+    boost::system::error_code ec;
+
+    static auto match = sdbusplus::bus::match::match(
+        bus,
+        "type='signal',member='apmlActive', "
+        "interface='com.amd.crashdump.ApmlActive'",
+        [](sdbusplus::message::message& message) {
+            std::string apmlActive;
+            try
+            {
+                message.read(apmlActive);
+
+                sd_journal_print(LOG_INFO, "APML active signal received %s\n",
+                                 apmlActive.c_str());
+
+                if (apmlActive == "true")
+                {
+                    if (platformInitialized == false)
+                    {
+                        performPlatformInitialization();
+                    }
+                    else
+                    {
+
+                        apmlInitialized = true;
+                        clearSbrmiAlertMask();
+
+                        if (runtimeErrPollingSupported == true)
+                        {
+                            SetOobConfig();
+                            ErrThresholdEnable();
+                        }
+                    }
+                }
+            }
+            catch (std::exception& e)
+            {
+                sd_journal_print(LOG_ERR,
+                                 "Unable to read apmlActive D-bus signal\n");
+                return;
+            }
+        });
 }
 
 void findProgramId()
@@ -628,18 +655,17 @@ int main()
         return false;
     }
 
-    if (PlatformInitialization() == false)
-    {
-        return false;
-    }
+    CreateIndexFile();
+
+    CreateConfigFile();
+
+    CreateDbusInterface();
+
+    apmlActiveMonitor();
 
     getCpuID();
 
     getBoardID();
-
-    CreateIndexFile();
-
-    CreateConfigFile();
 
     findProgramId();
 
@@ -651,10 +677,6 @@ int main()
     {
         getPpinFuse();
     }
-
-    CreateDbusInterface();
-
-    RunTimeErrorPolling();
 
     requestGPIOEvents("P0_I3C_APML_ALERT_L", P0AlertEventHandler,
                       P0_apmlAlertLine, P0_apmlAlertEvent);

--- a/src/write_cper_data.cpp
+++ b/src/write_cper_data.cpp
@@ -875,8 +875,7 @@ void write_to_cper_file(const std::shared_ptr<T>& data, std::string ErrorType,
 
             exportCrashdumpToDBus(err_count, FatalPtr->Header.TimeStamp);
 
-            std::string ras_err_msg =
-                "CPER file generated for fatal error";
+            std::string ras_err_msg = "CPER file generated for fatal error";
 
             sd_journal_send(
                 "MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i", LOG_ERR,


### PR DESCRIPTION
1. Add apmlActive dbus signal and monitor the signal change to set RAS OOB registers
2. Add debug log ID 23 to the crashdump flow.
3. Stop polling for runtime errors when SUT is powered off.
4. Code cleanup