### PR TITLE
Implement local AIFS trigger in amd-ras service

### DIFF
--- a/inc/Config.hpp
+++ b/inc/Config.hpp
@@ -13,6 +13,7 @@ class Configuration
     static bool McaThresholdEn;
     static bool DramCeccThresholdEn;
     static bool PcieAerThresholdEn;
+    static bool AifsArmed;
     static uint16_t McaPollingPeriod;
     static uint16_t DramCeccPollingPeriod;
     static uint16_t PcieAerPollingPeriod;
@@ -22,6 +23,7 @@ class Configuration
     static std::vector<std::string> sigIDOffset;
     static std::vector<std::pair<std::string, std::string>> P0_DimmLabels;
     static std::vector<std::pair<std::string, std::string>> P1_DimmLabels;
+    static std::vector<std::pair<std::string, std::string>> AifsSignatureId;
 
   public:
     Configuration();
@@ -55,6 +57,9 @@ class Configuration
     static void setPcieAerThresholdEn(bool);
     static bool getPcieAerThresholdEn();
 
+    static void setAifsArmed(bool);
+    static bool getAifsArmed();
+
     static void setMcaPollingPeriod(uint16_t);
     static uint16_t getMcaPollingPeriod();
 
@@ -83,15 +88,20 @@ class Configuration
         getAllP0_DimmLabels();
     static std::vector<std::pair<std::string, std::string>>
         getAllP1_DimmLabels();
+    static std::vector<std::pair<std::string, std::string>>
+        getAllAifsSignatureId();
 
     static void
         setAllP0_DimmLabels(std::vector<std::pair<std::string, std::string>>);
     static void
         setAllP1_DimmLabels(std::vector<std::pair<std::string, std::string>>);
+    static void
+        setAllAifsSignatureId(std::vector<std::pair<std::string, std::string>>);
 
     static std::string getP0_DimmLabels(const std::string&);
     static std::string getP1_DimmLabels(const std::string&);
 
     static void setP0_DimmLabels(const std::string&, const std::string&);
     static void setP1_DimmLabels(const std::string&, const std::string&);
+    static void setAifsSignatureId(const nlohmann::json&);
 };

--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -32,7 +32,7 @@
  * CPER section descriptor revision, used in revision field in struct
  * cper_section_descriptor
  */
-#define CPER_MINOR_REV (0x0008)
+#define CPER_MINOR_REV (0x0009)
 
 #define ADDC_GEN_NUMBER_1 (0x01)
 #define ADDC_GEN_NUMBER_2 (0x02)

--- a/inc/ras.hpp
+++ b/inc/ras.hpp
@@ -97,12 +97,15 @@ extern "C" {
 #define BIT_MASK (1)
 
 void RunTimeErrorPolling();
-oob_status_t SetOobConfig();
-oob_status_t ErrThresholdEnable();
+oob_status_t SetMcaOobConfig();
+oob_status_t SetPcieOobConfig();
+oob_status_t McaErrThresholdEnable();
+oob_status_t PcieErrThresholdEnable();
 void RunTimeErrorInfoCheck(uint8_t, uint8_t);
 void write_to_cper_file(std::string);
 void ErrorPollingHandler(uint8_t, uint16_t);
 void CreateDbusInterface();
+void performPlatformInitialization();
 
 bool requestGPIOEvents(const std::string&, const std::function<void()>&,
                        gpiod::line&, boost::asio::posix::stream_descriptor&);

--- a/inc/ras.hpp
+++ b/inc/ras.hpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <gpiod.hpp>
 #include <mutex>
+#include <charconv>
 #include <nlohmann/json.hpp>
 #include <phosphor-logging/log.hpp>
 #include <regex>
@@ -79,6 +80,7 @@ extern "C" {
 #define RUNTIME_PCIE_ERR ("RUNTIME_PCIE_ERROR")
 #define RUNTIME_DRAM_ERR ("RUNTIME_DRAM_ERROR")
 #define FATAL_ERR ("FATAL")
+#define EVENT_SUBSCRIPTION_FILE ("/var/lib/bmcweb/eventservice_config.json")
 
 #define WARM_RESET (0)
 #define COLD_RESET (1)

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -10,6 +10,7 @@ bool Configuration::PcieAerPollingEn;
 bool Configuration::McaThresholdEn;
 bool Configuration::DramCeccThresholdEn;
 bool Configuration::PcieAerThresholdEn;
+bool Configuration::AifsArmed;
 uint16_t Configuration::McaPollingPeriod;
 uint16_t Configuration::DramCeccPollingPeriod;
 uint16_t Configuration::PcieAerPollingPeriod;
@@ -39,6 +40,10 @@ std::vector<std::pair<std::string, std::string>> Configuration::P1_DimmLabels =
      {"P1_DIMM_H1", "null"}, {"P1_DIMM_I", "null"},  {"P1_DIMM_I1", "null"},
      {"P1_DIMM_J", "null"},  {"P1_DIMM_J1", "null"}, {"P1_DIMM_K", "null"},
      {"P1_DIMM_K1", "null"}, {"P1_DIMM_L", "null"},  {"P1_DIMM_L1", "null"}};
+
+std::vector<std::pair<std::string, std::string>>
+    Configuration::AifsSignatureId = {
+        {"EX-WDT", "0xaea0000000000108000500b020009a00000000004d000000"}};
 
 void Configuration::setApmlRetryCount(uint16_t value)
 {
@@ -128,6 +133,16 @@ void Configuration::setPcieAerThresholdEn(bool value)
 bool Configuration::getPcieAerThresholdEn()
 {
     return PcieAerThresholdEn;
+}
+
+void Configuration::setAifsArmed(bool value)
+{
+    AifsArmed = value;
+}
+
+bool Configuration::getAifsArmed()
+{
+    return AifsArmed;
 }
 
 void Configuration::setMcaPollingPeriod(uint16_t value)
@@ -256,6 +271,29 @@ void Configuration::setP1_DimmLabels(const std::string& key,
     }
 }
 
+void Configuration::setAifsSignatureId(
+    const nlohmann::json& AifsSignatureIdData)
+{
+    AifsSignatureId.clear();
+
+    for (const auto& item : AifsSignatureIdData)
+    {
+        if (item.size() == INDEX_2)
+        {
+            AifsSignatureId.emplace_back(item[INDEX_0], item[INDEX_1]);
+        }
+    }
+
+    for (auto it = AifsSignatureIdData.begin(); it != AifsSignatureIdData.end();
+         ++it)
+    {
+        const std::string& key = it.key();
+        const std::string& value = it.value();
+
+        AifsSignatureId.push_back(std::make_pair(key, value));
+    }
+}
+
 std::vector<std::pair<std::string, std::string>>
     Configuration::getAllP0_DimmLabels()
 {
@@ -268,6 +306,12 @@ std::vector<std::pair<std::string, std::string>>
     return P1_DimmLabels;
 }
 
+std::vector<std::pair<std::string, std::string>>
+    Configuration::getAllAifsSignatureId()
+{
+    return AifsSignatureId;
+}
+
 void Configuration::setAllP0_DimmLabels(
     std::vector<std::pair<std::string, std::string>> value)
 {
@@ -278,4 +322,10 @@ void Configuration::setAllP1_DimmLabels(
     std::vector<std::pair<std::string, std::string>> value)
 {
     P1_DimmLabels = value;
+}
+
+void Configuration::setAllAifsSignatureId(
+    std::vector<std::pair<std::string, std::string>> value)
+{
+    AifsSignatureId = value;
 }

--- a/src/dbus_ras.cpp
+++ b/src/dbus_ras.cpp
@@ -202,7 +202,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setApmlRetryCount(resp);
             updateConfigFile("apmlRetries", resp);
-            return 1;
+            return true;
         });
 
     uint16_t systemRecovery = Configuration::getSystemRecovery();
@@ -212,7 +212,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setSystemRecovery(resp);
             updateConfigFile("systemRecovery", resp);
-            return 1;
+            return true;
         });
 
     bool harvestuCodeVersionFlag = Configuration::getHarvestuCodeVersionFlag();
@@ -224,7 +224,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setHarvestuCodeVersionFlag(resp);
             updateConfigFile("harvestuCodeVersion", resp);
-            return 1;
+            return true;
         });
 
     bool harvestPpinFlag = Configuration::getHarvestPpinFlag();
@@ -233,7 +233,7 @@ void CreateDbusInterface()
                                        resp = requested;
                                        Configuration::setHarvestPpinFlag(resp);
                                        updateConfigFile("harvestPpin", resp);
-                                       return 1;
+                                       return true;
                                    });
 
     std::string ResetSignal = Configuration::getResetSignal();
@@ -243,7 +243,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setResetSignal(resp);
             updateConfigFile("ResetSignal", resp);
-            return 1;
+            return true;
         });
 
     std::vector<std::string> sigIDOffset = Configuration::getSigIDOffset();
@@ -253,7 +253,7 @@ void CreateDbusInterface()
                                        resp = requested;
                                        Configuration::setSigIDOffset(resp);
                                        updateConfigFile("sigIDOffset", resp);
-                                       return 1;
+                                       return true;
                                    });
 
     std::vector<std::pair<std::string, std::string>> P0_DimmLabels =
@@ -279,7 +279,7 @@ void CreateDbusInterface()
 
             Configuration::setAllP0_DimmLabels(resp);
             updateConfigFile("P0_DIMM_LABELS", resp);
-            return 1;
+            return true;
         });
 
     std::vector<std::pair<std::string, std::string>> P1_DimmLabels =
@@ -305,7 +305,28 @@ void CreateDbusInterface()
 
             Configuration::setAllP1_DimmLabels(resp);
             updateConfigFile("P1_DIMM_LABELS", resp);
-            return 1;
+            return true;
+        });
+
+    bool AifsArmed = Configuration::getAifsArmed();
+    configIface->register_property("AifsArmed", AifsArmed,
+                                   [](const bool& requested, bool& resp) {
+                                       resp = requested;
+                                       Configuration::setAifsArmed(resp);
+                                       updateConfigFile("AifsArmed", resp);
+                                       return true;
+                                   });
+
+    std::vector<std::pair<std::string, std::string>> AifsSignatureId =
+        Configuration::getAllAifsSignatureId();
+    configIface->register_property(
+        "AifsSignatureId", AifsSignatureId,
+        [](const std::vector<std::pair<std::string, std::string>>& requested,
+           std::vector<std::pair<std::string, std::string>>& resp) {
+            resp = requested;
+            Configuration::setAllAifsSignatureId(resp);
+            updateConfigFile("AifsSignatureId", resp);
+            return true;
         });
 
     bool McaPollingEn = Configuration::getMcaPollingEn();
@@ -314,7 +335,7 @@ void CreateDbusInterface()
                                        resp = requested;
                                        Configuration::setMcaPollingEn(resp);
                                        updateConfigFile("McaPollingEn", resp);
-                                       return 1;
+                                       return true;
                                    });
 
     bool DramCeccPollingEn = Configuration::getDramCeccPollingEn();
@@ -324,7 +345,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setDramCeccPollingEn(resp);
             updateConfigFile("DramCeccPollingEn", resp);
-            return 1;
+            return true;
         });
 
     bool PcieAerPollingEn = Configuration::getPcieAerPollingEn();
@@ -334,7 +355,7 @@ void CreateDbusInterface()
                                        Configuration::setPcieAerPollingEn(resp);
                                        updateConfigFile("PcieAerPollingEn",
                                                         resp);
-                                       return 1;
+                                       return true;
                                    });
 
     bool McaThresholdEn = Configuration::getMcaThresholdEn();
@@ -343,7 +364,7 @@ void CreateDbusInterface()
                                        resp = requested;
                                        Configuration::setMcaThresholdEn(resp);
                                        updateConfigFile("McaThresholdEn", resp);
-                                       return 1;
+                                       return true;
                                    });
 
     bool DramCeccThresholdEn = Configuration::getDramCeccThresholdEn();
@@ -353,7 +374,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setDramCeccThresholdEn(resp);
             updateConfigFile("DramCeccThresholdEn", resp);
-            return 1;
+            return true;
         });
 
     bool PcieAerThresholdEn = Configuration::getPcieAerThresholdEn();
@@ -363,7 +384,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setPcieAerThresholdEn(resp);
             updateConfigFile("PcieAerThresholdEn", resp);
-            return 1;
+            return true;
         });
 
     uint16_t McaPollingPeriod = Configuration::getMcaPollingPeriod();
@@ -373,7 +394,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setMcaPollingPeriod(resp);
             updateConfigFile("McaPollingPeriod", resp);
-            return 1;
+            return true;
         });
 
     uint16_t DramCeccPollingPeriod = Configuration::getDramCeccPollingPeriod();
@@ -383,7 +404,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setDramCeccPollingPeriod(resp);
             updateConfigFile("DramCeccPollingPeriod", resp);
-            return 1;
+            return true;
         });
 
     uint16_t PcieAerPollingPeriod = Configuration::getPcieAerPollingPeriod();
@@ -393,7 +414,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setPcieAerPollingPeriod(resp);
             updateConfigFile("PcieAerPollingPeriod", resp);
-            return 1;
+            return true;
         });
 
     uint16_t McaErrCounter = Configuration::getMcaErrCounter();
@@ -403,7 +424,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setMcaErrCounter(resp);
             updateConfigFile("McaErrCounter", resp);
-            return 1;
+            return true;
         });
 
     uint16_t DramCeccErrCounter = Configuration::getDramCeccErrCounter();
@@ -413,7 +434,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setDramCeccErrCounter(resp);
             updateConfigFile("DramCeccErrCounter", resp);
-            return 1;
+            return true;
         });
 
     uint16_t PcieAerErrCounter = Configuration::getPcieAerErrCounter();
@@ -423,7 +444,7 @@ void CreateDbusInterface()
             resp = requested;
             Configuration::setPcieAerErrCounter(resp);
             updateConfigFile("PcieAerErrCounter", resp);
-            return 1;
+            return true;
         });
 
     configIface->initialize();

--- a/src/fatal_error.cpp
+++ b/src/fatal_error.cpp
@@ -827,9 +827,6 @@ bool harvest_ras_errors(uint8_t info, std::string alert_name)
         // check RAS Status Register
         if (buf & INT_15)
         {
-            sd_journal_print(
-                LOG_INFO, "The alert signaled is due to a RAS fatal error\n");
-
             if (buf & SYS_MGMT_CTRL_ERR)
             {
                 /*if RasStatus[reset_ctrl_err] is set in any of the processors,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -360,6 +360,9 @@ void CreateConfigFile()
         std::vector<std::pair<std::string, std::string>> P1_DimmLabels =
             Configuration::getAllP1_DimmLabels();
 
+        std::vector<std::pair<std::string, std::string>> AifsSignatureId =
+            Configuration::getAllAifsSignatureId();
+
         nlohmann::json jsonP0_DimmLabel;
 
         for (const auto& pair : P0_DimmLabels)
@@ -376,6 +379,14 @@ void CreateConfigFile()
         }
         jsonConfig["P1_DIMM_LABELS"] = jsonP1_DimmLabel;
 
+        nlohmann::json jsonAifsSignatureId;
+
+        for (const auto& pair : AifsSignatureId)
+        {
+            jsonAifsSignatureId[pair.first] = pair.second;
+        }
+        jsonConfig["AifsSignatureId"] = jsonAifsSignatureId;
+
         jsonConfig["McaPollingEn"] = true;
         jsonConfig["McaPollingPeriod"] = MCA_POLLING_PERIOD;
         jsonConfig["DramCeccPollingEn"] = false;
@@ -389,6 +400,7 @@ void CreateConfigFile()
         jsonConfig["DramCeccErrCounter"] = ERROR_THRESHOLD_VAL;
         jsonConfig["PcieAerThresholdEn"] = false;
         jsonConfig["PcieAerErrCounter"] = ERROR_THRESHOLD_VAL;
+        jsonConfig["AifsArmed"] = false;
 
         std::ofstream jsonWrite(config_file);
         jsonWrite << jsonConfig;
@@ -419,6 +431,7 @@ void CreateConfigFile()
     Configuration::setDramCeccErrCounter(data["DramCeccErrCounter"]);
     Configuration::setPcieAerThresholdEn(data["PcieAerThresholdEn"]);
     Configuration::setPcieAerErrCounter(data["PcieAerErrCounter"]);
+    Configuration::setAifsArmed(data["AifsArmed"]);
 
     if (data.contains("P0_DIMM_LABELS"))
     {
@@ -442,6 +455,13 @@ void CreateConfigFile()
             std::string value = it.value();
             Configuration::setP1_DimmLabels(key, value);
         }
+    }
+
+    if (data.contains("AifsSignatureId"))
+    {
+
+        nlohmann::json AifsSignatureIdData = data["AifsSignatureId"];
+        Configuration::setAifsSignatureId(AifsSignatureIdData);
     }
 
     jsonRead.close();


### PR DESCRIPTION
Added the new RAS configuration parameters AifsArmed and AifsSigId.

If AifsArmed is true and valid mca bank is > 0 , Check if current-failure SigID matches any of the AifsSigId entries in the AifsSignatureIdList. If SigID matches, start the AIFS flow.

Signed-off-by: Abinaya Dhandapani <adhandap@amd.com>