### PR TITLE
ErrCounter rename to ThresholdCnt in BMC config file

### DIFF
--- a/inc/Config.hpp
+++ b/inc/Config.hpp
@@ -17,9 +17,9 @@ class Configuration
     static uint16_t McaPollingPeriod;
     static uint16_t DramCeccPollingPeriod;
     static uint16_t PcieAerPollingPeriod;
-    static uint16_t McaErrCounter;
-    static uint16_t DramCeccErrCounter;
-    static uint16_t PcieAerErrCounter;
+    static uint16_t McaErrThresholdCnt;
+    static uint16_t DramCeccErrThresholdCnt;
+    static uint16_t PcieAerErrThresholdCnt;
     static std::vector<std::string> sigIDOffset;
     static std::vector<std::pair<std::string, std::string>> P0_DimmLabels;
     static std::vector<std::pair<std::string, std::string>> P1_DimmLabels;
@@ -69,14 +69,14 @@ class Configuration
     static void setPcieAerPollingPeriod(uint16_t);
     static uint16_t getPcieAerPollingPeriod();
 
-    static void setMcaErrCounter(uint16_t);
-    static uint16_t getMcaErrCounter();
+    static void setMcaErrThresholdCnt(uint16_t);
+    static uint16_t getMcaErrThresholdCnt();
 
-    static void setDramCeccErrCounter(uint16_t);
-    static uint16_t getDramCeccErrCounter();
+    static void setDramCeccErrThresholdCnt(uint16_t);
+    static uint16_t getDramCeccErrThresholdCnt();
 
-    static void setPcieAerErrCounter(uint16_t);
-    static uint16_t getPcieAerErrCounter();
+    static void setPcieAerErrThresholdCnt(uint16_t);
+    static uint16_t getPcieAerErrThresholdCnt();
 
     static void setResetSignal(std::string);
     static std::string getResetSignal();

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -14,9 +14,9 @@ bool Configuration::AifsArmed;
 uint16_t Configuration::McaPollingPeriod;
 uint16_t Configuration::DramCeccPollingPeriod;
 uint16_t Configuration::PcieAerPollingPeriod;
-uint16_t Configuration::McaErrCounter;
-uint16_t Configuration::DramCeccErrCounter;
-uint16_t Configuration::PcieAerErrCounter;
+uint16_t Configuration::McaErrThresholdCnt;
+uint16_t Configuration::DramCeccErrThresholdCnt;
+uint16_t Configuration::PcieAerErrThresholdCnt;
 std::string ResetSignal;
 std::vector<std::string> Configuration::sigIDOffset = {
     "0x30", "0x34", "0x28", "0x2c", "0x08", "0x0c", "null", "null"};
@@ -172,31 +172,31 @@ uint16_t Configuration::getPcieAerPollingPeriod()
     return PcieAerPollingPeriod;
 }
 
-void Configuration::setMcaErrCounter(uint16_t value)
+void Configuration::setMcaErrThresholdCnt(uint16_t value)
 {
-    McaErrCounter = value;
+    McaErrThresholdCnt = value;
 }
-uint16_t Configuration::getMcaErrCounter()
+uint16_t Configuration::getMcaErrThresholdCnt()
 {
-    return McaErrCounter;
-}
-
-void Configuration::setDramCeccErrCounter(uint16_t value)
-{
-    DramCeccErrCounter = value;
-}
-uint16_t Configuration::getDramCeccErrCounter()
-{
-    return DramCeccErrCounter;
+    return McaErrThresholdCnt;
 }
 
-void Configuration::setPcieAerErrCounter(uint16_t value)
+void Configuration::setDramCeccErrThresholdCnt(uint16_t value)
 {
-    PcieAerErrCounter = value;
+    DramCeccErrThresholdCnt = value;
 }
-uint16_t Configuration::getPcieAerErrCounter()
+uint16_t Configuration::getDramCeccErrThresholdCnt()
 {
-    return PcieAerErrCounter;
+    return DramCeccErrThresholdCnt;
+}
+
+void Configuration::setPcieAerErrThresholdCnt(uint16_t value)
+{
+    PcieAerErrThresholdCnt = value;
+}
+uint16_t Configuration::getPcieAerErrThresholdCnt()
+{
+    return PcieAerErrThresholdCnt;
 }
 
 void Configuration::setResetSignal(std::string value)

--- a/src/dbus_ras.cpp
+++ b/src/dbus_ras.cpp
@@ -417,33 +417,33 @@ void CreateDbusInterface()
             return true;
         });
 
-    uint16_t McaErrCounter = Configuration::getMcaErrCounter();
+    uint16_t McaErrThresholdCnt = Configuration::getMcaErrThresholdCnt();
     configIface->register_property(
-        "McaErrCounter", McaErrCounter,
+        "McaErrThresholdCnt", McaErrThresholdCnt,
         [](const uint16_t& requested, uint16_t& resp) {
             resp = requested;
-            Configuration::setMcaErrCounter(resp);
-            updateConfigFile("McaErrCounter", resp);
+            Configuration::setMcaErrThresholdCnt(resp);
+            updateConfigFile("McaErrThresholdCnt", resp);
             return true;
         });
 
-    uint16_t DramCeccErrCounter = Configuration::getDramCeccErrCounter();
+    uint16_t DramCeccErrThresholdCnt = Configuration::getDramCeccErrThresholdCnt();
     configIface->register_property(
-        "DramCeccErrCounter", DramCeccErrCounter,
+        "DramCeccErrThresholdCnt", DramCeccErrThresholdCnt,
         [](const uint16_t& requested, uint16_t& resp) {
             resp = requested;
-            Configuration::setDramCeccErrCounter(resp);
-            updateConfigFile("DramCeccErrCounter", resp);
+            Configuration::setDramCeccErrThresholdCnt(resp);
+            updateConfigFile("DramCeccErrThresholdCnt", resp);
             return true;
         });
 
-    uint16_t PcieAerErrCounter = Configuration::getPcieAerErrCounter();
+    uint16_t PcieAerErrThresholdCnt = Configuration::getPcieAerErrThresholdCnt();
     configIface->register_property(
-        "PcieAerErrCounter", PcieAerErrCounter,
+        "PcieAerErrThresholdCnt", PcieAerErrThresholdCnt,
         [](const uint16_t& requested, uint16_t& resp) {
             resp = requested;
-            Configuration::setPcieAerErrCounter(resp);
-            updateConfigFile("PcieAerErrCounter", resp);
+            Configuration::setPcieAerErrThresholdCnt(resp);
+            updateConfigFile("PcieAerErrThresholdCnt", resp);
             return true;
         });
 

--- a/src/dbus_ras.cpp
+++ b/src/dbus_ras.cpp
@@ -21,7 +21,6 @@ constexpr std::string_view crashdumpAssertedInterface =
     "com.amd.crashdump.Asserted";
 constexpr std::string_view crashdumpConfigInterface =
     "com.amd.crashdump.Configuration";
-constexpr std::string_view apmlActiveInterface = "com.amd.crashdump.ApmlActive";
 constexpr std::string_view dimmEccInterface =
     "com.amd.crashdump.DimmEcc.ErrorCount";
 
@@ -143,12 +142,6 @@ void CreateDbusInterface()
     conn->request_name(crashdumpService.data());
     server = std::make_shared<sdbusplus::asio::object_server>(conn);
 
-    std::shared_ptr<sdbusplus::asio::dbus_interface> apmlIface =
-        server->add_interface(crashdumpPath.data(), apmlActiveInterface.data());
-
-    // Set the signal handler using a lambda function
-    apmlIface->register_signal<std::string>("apmlActive");
-    apmlIface->initialize();
     // This DBus interface/method should be triggered by
     // host-error-monitor(https://github.com/openbmc/host-error-monitor).
     // However `amd-ras` monitors the alert pin by itself instead of asking

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -395,11 +395,11 @@ void CreateConfigFile()
         jsonConfig["PcieAerPollingPeriod"] = PCIE_AER_POLLING_PERIOD;
 
         jsonConfig["McaThresholdEn"] = false;
-        jsonConfig["McaErrCounter"] = ERROR_THRESHOLD_VAL;
+        jsonConfig["McaErrThresholdCnt"] = ERROR_THRESHOLD_VAL;
         jsonConfig["DramCeccThresholdEn"] = false;
-        jsonConfig["DramCeccErrCounter"] = ERROR_THRESHOLD_VAL;
+        jsonConfig["DramCeccErrThresholdCnt"] = ERROR_THRESHOLD_VAL;
         jsonConfig["PcieAerThresholdEn"] = false;
-        jsonConfig["PcieAerErrCounter"] = ERROR_THRESHOLD_VAL;
+        jsonConfig["PcieAerErrThresholdCnt"] = ERROR_THRESHOLD_VAL;
         jsonConfig["AifsArmed"] = false;
 
         std::ofstream jsonWrite(config_file);
@@ -426,11 +426,11 @@ void CreateConfigFile()
     Configuration::setPcieAerPollingPeriod(data["PcieAerPollingPeriod"]);
 
     Configuration::setMcaThresholdEn(data["McaThresholdEn"]);
-    Configuration::setMcaErrCounter(data["McaErrCounter"]);
+    Configuration::setMcaErrThresholdCnt(data["McaErrThresholdCnt"]);
     Configuration::setDramCeccThresholdEn(data["DramCeccThresholdEn"]);
-    Configuration::setDramCeccErrCounter(data["DramCeccErrCounter"]);
+    Configuration::setDramCeccErrThresholdCnt(data["DramCeccErrThresholdCnt"]);
     Configuration::setPcieAerThresholdEn(data["PcieAerThresholdEn"]);
-    Configuration::setPcieAerErrCounter(data["PcieAerErrCounter"]);
+    Configuration::setPcieAerErrThresholdCnt(data["PcieAerErrThresholdCnt"]);
     Configuration::setAifsArmed(data["AifsArmed"]);
 
     if (data.contains("P0_DIMM_LABELS"))

--- a/src/runtime_errors.cpp
+++ b/src/runtime_errors.cpp
@@ -136,6 +136,7 @@ oob_status_t getOobRegisters(struct oob_config_d_in* oob_config)
             (d_out >> DRAM_CECC_OOB_EC_MODE & TRIBBLE_BITS);
         oob_config->pcie_err_reporting_en =
             (d_out >> PCIE_ERR_REPORT_EN & BIT_MASK);
+        oob_config->mca_oob_misc0_ec_enable = (d_out & BIT_MASK);
     }
     return ret;
 }
@@ -179,6 +180,7 @@ oob_status_t McaErrThresholdEnable()
 
         /* Core MCA Error Reporting Enable */
         oob_config.core_mca_err_reporting_en = ENABLE_BIT;
+        oob_config.mca_oob_misc0_ec_enable = ENABLE_BIT;
 
         ret = BmcRasOobConfig(oob_config);
 
@@ -196,7 +198,9 @@ oob_status_t McaErrThresholdEnable()
         memset(&oob_config, 0, sizeof(oob_config));
 
         getOobRegisters(&oob_config);
+
         oob_config.dram_cecc_oob_ec_mode = ENABLE_BIT;
+        oob_config.mca_oob_misc0_ec_enable = ENABLE_BIT;
 
         ret = BmcRasOobConfig(oob_config);
 

--- a/src/runtime_errors.cpp
+++ b/src/runtime_errors.cpp
@@ -168,7 +168,7 @@ oob_status_t McaErrThresholdEnable()
     if (Configuration::getMcaThresholdEn() == true)
     {
         th.err_type = 0; /*00 = MCA error type*/
-        th.err_count_th = Configuration::getMcaErrCounter();
+        th.err_count_th = Configuration::getMcaErrThresholdCnt();
         th.max_intrupt_rate = 1;
 
         struct oob_config_d_in oob_config;
@@ -188,7 +188,7 @@ oob_status_t McaErrThresholdEnable()
     if (Configuration::getDramCeccThresholdEn() == true)
     {
         th.err_type = 1; /*01 = DRAM CECC error type*/
-        th.err_count_th = Configuration::getDramCeccErrCounter();
+        th.err_count_th = Configuration::getDramCeccErrThresholdCnt();
         th.max_intrupt_rate = 1;
 
         struct oob_config_d_in oob_config;
@@ -219,7 +219,7 @@ oob_status_t PcieErrThresholdEnable()
         SetPcieOobRegisters();
 
         th.err_type = 2; /*00 = PCIE error type*/
-        th.err_count_th = Configuration::getPcieAerErrCounter();
+        th.err_count_th = Configuration::getPcieAerErrThresholdCnt();
         th.max_intrupt_rate = 1;
 
         sd_journal_print(LOG_INFO, "Setting PCIE error threshold\n");


### PR DESCRIPTION
Rename the below properties in /var/lib/amd-ras/config_file to avoid confusion and distinguish from MaxInterruptRate.

DramCeccErrCounter > DramCeccErrThresholdCnt

McaErrCounter > McaErrThresholdCnt

PcieAerErrCounter > PcieAerErrThresholdCnt