### PR TITLE
Fix uninitialised read in apmlActiveMonitor

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -686,7 +686,7 @@ void performPlatformInitialization()
 
 void apmlActiveMonitor()
 {
-    oob_status_t ret;
+    oob_status_t ret = OOB_UNKNOWN_ERROR;
 
     uint32_t d_out = 0;
 


### PR DESCRIPTION
Fixes the error when trying to build on the latest OpenBMC:
```
| ../git/src/main.cpp: In function 'apmlActiveMonitor()':
| ../git/src/main.cpp:693:16: error: 'ret' is used uninitialized [-Werror=uninitialized]
|   693 |     while (ret != OOB_SUCCESS)
|       |            ~~~~^~~~~~~~~~~~~~
| ../git/src/main.cpp:689:18: note: 'ret' was declared here
|   689 |     oob_status_t ret;
|       |                  ^~~
```
This change has not been tested.