### PR TITLE
Fix APML offset to read PCIE root error status

### DIFF
--- a/inc/Config.hpp
+++ b/inc/Config.hpp
@@ -14,6 +14,7 @@ class Configuration
     static bool DramCeccThresholdEn;
     static bool PcieAerThresholdEn;
     static bool AifsArmed;
+    static bool DisableResetCounter;
     static uint16_t McaPollingPeriod;
     static uint16_t DramCeccPollingPeriod;
     static uint16_t PcieAerPollingPeriod;
@@ -59,6 +60,9 @@ class Configuration
 
     static void setAifsArmed(bool);
     static bool getAifsArmed();
+
+    static void setDisableResetCounter(bool);
+    static bool getDisableResetCounter();
 
     static void setMcaPollingPeriod(uint16_t);
     static uint16_t getMcaPollingPeriod();

--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -32,7 +32,7 @@
  * CPER section descriptor revision, used in revision field in struct
  * cper_section_descriptor
  */
-#define CPER_MINOR_REV (0x0009)
+#define CPER_MINOR_REV (0x000A)
 
 #define ADDC_GEN_NUMBER_1 (0x01)
 #define ADDC_GEN_NUMBER_2 (0x02)

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -11,6 +11,7 @@ bool Configuration::McaThresholdEn;
 bool Configuration::DramCeccThresholdEn;
 bool Configuration::PcieAerThresholdEn;
 bool Configuration::AifsArmed;
+bool Configuration::DisableResetCounter;
 uint16_t Configuration::McaPollingPeriod;
 uint16_t Configuration::DramCeccPollingPeriod;
 uint16_t Configuration::PcieAerPollingPeriod;
@@ -143,6 +144,16 @@ void Configuration::setAifsArmed(bool value)
 bool Configuration::getAifsArmed()
 {
     return AifsArmed;
+}
+
+void Configuration::setDisableResetCounter(bool value)
+{
+    DisableResetCounter = value;
+}
+
+bool Configuration::getDisableResetCounter()
+{
+    return DisableResetCounter;
 }
 
 void Configuration::setMcaPollingPeriod(uint16_t value)

--- a/src/dbus_ras.cpp
+++ b/src/dbus_ras.cpp
@@ -310,6 +310,15 @@ void CreateDbusInterface()
                                        return true;
                                    });
 
+   bool DisableResetCounter = Configuration::getDisableResetCounter();
+    configIface->register_property("DisableAifsResetOnSyncfloodCounter", DisableResetCounter,
+                                   [](const bool& requested, bool& resp) {
+                                       resp = requested;
+                                       Configuration::setDisableResetCounter(resp);
+                                       updateConfigFile("DisableAifsResetOnSyncfloodCounter", resp);
+                                       return true;
+                                   });
+
     std::vector<std::pair<std::string, std::string>> AifsSignatureId =
         Configuration::getAllAifsSignatureId();
     configIface->register_property(

--- a/src/fatal_error.cpp
+++ b/src/fatal_error.cpp
@@ -708,13 +708,13 @@ void harvest_fatal_errors(uint8_t info, uint16_t numbanks, uint16_t bytespermca)
     }
 }
 
-
 std::vector<uint32_t> hexstring_to_vector(const std::string& hexString)
 {
     std::vector<uint32_t> result;
 
     // Skip the "0x" prefix if present
-    size_t start = (hexString.substr(INDEX_0, INDEX_2) == "0x") ? INDEX_2 : INDEX_0;
+    size_t start =
+        (hexString.substr(INDEX_0, INDEX_2) == "0x") ? INDEX_2 : INDEX_0;
 
     // Process the string in chunks of 8 characters (32 bits)
     for (size_t i = start; i < hexString.length(); i += INDEX_8)
@@ -1000,25 +1000,46 @@ bool harvest_ras_errors(uint8_t info, std::string alert_name)
                                                 d_in.stop_delay_counter = 1;
                                                 oob_status_t ret;
 
-                                                ret =
-                                                    override_delay_reset_on_sync_flood(
-                                                        info, d_in, &ack_resp);
-
-                                                if (ret)
-                                                {
-                                                    sd_journal_print(
-                                                        LOG_ERR,
-                                                        "Failed to override "
-                                                        "delay value reset on "
-                                                        "sync flood\n");
-                                                }
-                                                else
+                                                if (Configuration::
+                                                        getDisableResetCounter() ==
+                                                    true)
                                                 {
                                                     sd_journal_print(
                                                         LOG_INFO,
-                                                        "Successfully sent "
-                                                        "Reset delay on "
-                                                        "Syncflood command\n");
+                                                        "Disable Aifs Delay "
+                                                        "Reset on Syncflood "
+                                                        "counter is true. "
+                                                        "Sending Delay Reset "
+                                                        "on Syncflood override "
+                                                        "APML command\n");
+                                                    ret =
+                                                        override_delay_reset_on_sync_flood(
+                                                            info, d_in,
+                                                            &ack_resp);
+
+                                                    if (ret)
+                                                    {
+                                                        sd_journal_print(
+                                                            LOG_ERR,
+                                                            "Failed to "
+                                                            "override "
+                                                            "delay value reset "
+                                                            "on "
+                                                            "syncflood "
+                                                            "Err[%d]: %s \n",
+                                                            ret,
+                                                            esmi_get_err_msg(
+                                                                ret));
+                                                    }
+                                                    else
+                                                    {
+                                                        sd_journal_print(
+                                                            LOG_INFO,
+                                                            "Successfully sent "
+                                                            "Reset delay on "
+                                                            "Syncflood "
+                                                            "command\n");
+                                                    }
                                                 }
                                                 sd_journal_send(
                                                     "PRIORITY=%i", LOG_INFO,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -392,7 +392,7 @@ void CreateConfigFile()
         jsonConfig["McaPollingPeriod"] = MCA_POLLING_PERIOD;
         jsonConfig["DramCeccPollingEn"] = false;
         jsonConfig["DramCeccPollingPeriod"] = DRAM_CECC_POLLING_PERIOD;
-        jsonConfig["PcieAerPollingEn"] = true;
+        jsonConfig["PcieAerPollingEn"] = false;
         jsonConfig["PcieAerPollingPeriod"] = PCIE_AER_POLLING_PERIOD;
 
         jsonConfig["McaThresholdEn"] = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -402,6 +402,7 @@ void CreateConfigFile()
         jsonConfig["PcieAerThresholdEn"] = false;
         jsonConfig["PcieAerErrThresholdCnt"] = ERROR_THRESHOLD_VAL;
         jsonConfig["AifsArmed"] = false;
+        jsonConfig["DisableAifsResetOnSyncfloodCounter"] = true;
 
         std::ofstream jsonWrite(config_file);
         jsonWrite << jsonConfig;
@@ -433,6 +434,7 @@ void CreateConfigFile()
     Configuration::setPcieAerThresholdEn(data["PcieAerThresholdEn"]);
     Configuration::setPcieAerErrThresholdCnt(data["PcieAerErrThresholdCnt"]);
     Configuration::setAifsArmed(data["AifsArmed"]);
+    Configuration::setDisableResetCounter(data["DisableAifsResetOnSyncfloodCounter"]);
 
     if (data.contains("P0_DIMM_LABELS"))
     {

--- a/src/runtime_errors.cpp
+++ b/src/runtime_errors.cpp
@@ -131,7 +131,7 @@ oob_status_t getOobRegisters(struct oob_config_d_in* oob_config)
     else
     {
         oob_config->core_mca_err_reporting_en =
-            (d_out >> CORE_MCA_ERR_REPORT_EN & BIT_MASK);
+            (d_out >> MCA_ERR_REPORT_EN & BIT_MASK);
         oob_config->dram_cecc_oob_ec_mode =
             (d_out >> DRAM_CECC_OOB_EC_MODE & TRIBBLE_BITS);
         oob_config->pcie_err_reporting_en =

--- a/src/write_cper_data.cpp
+++ b/src/write_cper_data.cpp
@@ -471,7 +471,7 @@ void dump_proc_error_section(const std::shared_ptr<T>& data, uint8_t soc_num,
             {
                 PciePtr->PcieErrorSection[Section].AerInfo[DumpIndex] = d_out;
 
-                if (d_in.offset == INDEX_44)
+                if (d_in.offset == INDEX_52)
                 {
                     root_err_status = d_out;
                 }


### PR DESCRIPTION
Change the APML offset from 44 to 52 to read PCIE root error status.