### PR TITLE
Fix garbage values of the DIMM FruText in CPER

### DIFF
--- a/inc/Config.hpp
+++ b/inc/Config.hpp
@@ -82,10 +82,10 @@ class Configuration
     static void setPcieAerErrThresholdCnt(uint16_t);
     static uint16_t getPcieAerErrThresholdCnt();
 
-    static void setResetSignal(std::string);
+    static void setResetSignal(const std::string&);
     static std::string getResetSignal();
 
-    static void setSigIDOffset(std::vector<std::string>);
+    static void setSigIDOffset(const std::vector<std::string>&);
     static std::vector<std::string> getSigIDOffset();
 
     static std::vector<std::pair<std::string, std::string>>
@@ -96,11 +96,11 @@ class Configuration
         getAllAifsSignatureId();
 
     static void
-        setAllP0_DimmLabels(std::vector<std::pair<std::string, std::string>>);
+        setAllP0_DimmLabels(const std::vector<std::pair<std::string, std::string>>&);
     static void
-        setAllP1_DimmLabels(std::vector<std::pair<std::string, std::string>>);
+        setAllP1_DimmLabels(const std::vector<std::pair<std::string, std::string>>&);
     static void
-        setAllAifsSignatureId(std::vector<std::pair<std::string, std::string>>);
+        setAllAifsSignatureId(const std::vector<std::pair<std::string, std::string>>&);
 
     static std::string getP0_DimmLabels(const std::string&);
     static std::string getP1_DimmLabels(const std::string&);

--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -32,7 +32,7 @@
  * CPER section descriptor revision, used in revision field in struct
  * cper_section_descriptor
  */
-#define CPER_MINOR_REV (0x000A)
+#define CPER_MINOR_REV (0x000B)
 
 #define ADDC_GEN_NUMBER_1 (0x01)
 #define ADDC_GEN_NUMBER_2 (0x02)

--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -32,7 +32,7 @@
  * CPER section descriptor revision, used in revision field in struct
  * cper_section_descriptor
  */
-#define CPER_MINOR_REV (0x000B)
+#define CPER_MINOR_REV (0x000C)
 
 #define ADDC_GEN_NUMBER_1 (0x01)
 #define ADDC_GEN_NUMBER_2 (0x02)

--- a/inc/ras.hpp
+++ b/inc/ras.hpp
@@ -122,13 +122,13 @@ void HPMFPGALockoutEventHandler();
 template <typename T>
 void calculate_time_stamp(const std::shared_ptr<T>&);
 template <typename T>
-void write_to_cper_file(const std::shared_ptr<T>&, std::string, uint16_t);
+void write_to_cper_file(const std::shared_ptr<T>&,const std::string& , uint16_t);
 template <typename T>
 void dump_cper_header_section(const std::shared_ptr<T>&, uint16_t, uint32_t,
-                              std::string);
+                              const std::string&);
 template <typename T>
 void dump_error_descriptor_section(const std::shared_ptr<T>&, uint16_t,
-                                   std::string, uint32_t*);
+                                   const std::string&, uint32_t*);
 template <typename T>
 void dump_proc_error_section(const std::shared_ptr<T>&, uint8_t,
                              struct ras_rt_valid_err_inst, uint8_t, uint16_t,

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -210,7 +210,7 @@ uint16_t Configuration::getPcieAerErrThresholdCnt()
     return PcieAerErrThresholdCnt;
 }
 
-void Configuration::setResetSignal(std::string value)
+void Configuration::setResetSignal(const std::string& value)
 {
     ResetSignal = value;
 }
@@ -220,7 +220,7 @@ std::string Configuration::getResetSignal()
     return ResetSignal;
 }
 
-void Configuration::setSigIDOffset(std::vector<std::string> value)
+void Configuration::setSigIDOffset(const std::vector<std::string>& value)
 {
     sigIDOffset = value;
 }
@@ -232,12 +232,15 @@ std::vector<std::string> Configuration::getSigIDOffset()
 
 std::string Configuration::getP0_DimmLabels(const std::string& key)
 {
-    for (const auto& pair : P0_DimmLabels)
+    auto it =
+        std::find_if(P0_DimmLabels.begin(), P0_DimmLabels.end(),
+                     [&key](const std::pair<std::string, std::string>& pair) {
+                         return pair.first == key;
+                     });
+
+    if (it != P0_DimmLabels.end())
     {
-        if (pair.first == key)
-        {
-            return pair.second;
-        }
+        return it->second;
     }
     // Return an empty string if the key is not found
     return "";
@@ -245,12 +248,15 @@ std::string Configuration::getP0_DimmLabels(const std::string& key)
 
 std::string Configuration::getP1_DimmLabels(const std::string& key)
 {
-    for (const auto& pair : P1_DimmLabels)
+    auto it =
+        std::find_if(P1_DimmLabels.begin(), P1_DimmLabels.end(),
+                     [&key](const std::pair<std::string, std::string>& pair) {
+                         return pair.first == key;
+                     });
+
+    if (it != P1_DimmLabels.end())
     {
-        if (pair.first == key)
-        {
-            return pair.second;
-        }
+        return it->second;
     }
     // Return an empty string if the key is not found
     return "";
@@ -259,26 +265,30 @@ std::string Configuration::getP1_DimmLabels(const std::string& key)
 void Configuration::setP0_DimmLabels(const std::string& key,
                                      const std::string& value)
 {
-    for (auto& pair : P0_DimmLabels)
+    auto it =
+        std::find_if(P0_DimmLabels.begin(), P0_DimmLabels.end(),
+                     [&key](const std::pair<std::string, std::string>& pair) {
+                         return pair.first == key;
+                     });
+
+    if (it != P0_DimmLabels.end())
     {
-        if (pair.first == key)
-        {
-            pair.second = value;
-            return;
-        }
+        it->second = value;
     }
 }
 
 void Configuration::setP1_DimmLabels(const std::string& key,
                                      const std::string& value)
 {
-    for (auto& pair : P1_DimmLabels)
+    auto it =
+        std::find_if(P1_DimmLabels.begin(), P1_DimmLabels.end(),
+                     [&key](const std::pair<std::string, std::string>& pair) {
+                         return pair.first == key;
+                     });
+
+    if (it != P1_DimmLabels.end())
     {
-        if (pair.first == key)
-        {
-            pair.second = value;
-            return;
-        }
+        it->second = value;
     }
 }
 
@@ -324,19 +334,19 @@ std::vector<std::pair<std::string, std::string>>
 }
 
 void Configuration::setAllP0_DimmLabels(
-    std::vector<std::pair<std::string, std::string>> value)
+    const std::vector<std::pair<std::string, std::string>>& value)
 {
     P0_DimmLabels = value;
 }
 
 void Configuration::setAllP1_DimmLabels(
-    std::vector<std::pair<std::string, std::string>> value)
+    const std::vector<std::pair<std::string, std::string>>& value)
 {
     P1_DimmLabels = value;
 }
 
 void Configuration::setAllAifsSignatureId(
-    std::vector<std::pair<std::string, std::string>> value)
+    const std::vector<std::pair<std::string, std::string>>& value)
 {
     AifsSignatureId = value;
 }

--- a/src/dbus_ras.cpp
+++ b/src/dbus_ras.cpp
@@ -260,13 +260,15 @@ void CreateDbusInterface()
                 const std::string& key = keyValuePair.first;
                 const std::string& value = keyValuePair.second;
 
-                for (auto& pair : resp)
+                auto it = std::find_if(
+                    resp.begin(), resp.end(),
+                    [&key](const std::pair<std::string, std::string>& pair) {
+                        return pair.first == key;
+                    });
+
+                if (it != resp.end())
                 {
-                    if (pair.first == key)
-                    {
-                        pair.second = value;
-                        break;
-                    }
+                    it->second = value;
                 }
             }
 
@@ -286,16 +288,17 @@ void CreateDbusInterface()
                 const std::string& key = keyValuePair.first;
                 const std::string& value = keyValuePair.second;
 
-                for (auto& pair : resp)
+                auto it = std::find_if(
+                    resp.begin(), resp.end(),
+                    [&key](const std::pair<std::string, std::string>& pair) {
+                        return pair.first == key;
+                    });
+
+                if (it != resp.end())
                 {
-                    if (pair.first == key)
-                    {
-                        pair.second = value;
-                        break;
-                    }
+                    it->second = value;
                 }
             }
-
             Configuration::setAllP1_DimmLabels(resp);
             updateConfigFile("P1_DIMM_LABELS", resp);
             return true;
@@ -310,14 +313,15 @@ void CreateDbusInterface()
                                        return true;
                                    });
 
-   bool DisableResetCounter = Configuration::getDisableResetCounter();
-    configIface->register_property("DisableAifsResetOnSyncfloodCounter", DisableResetCounter,
-                                   [](const bool& requested, bool& resp) {
-                                       resp = requested;
-                                       Configuration::setDisableResetCounter(resp);
-                                       updateConfigFile("DisableAifsResetOnSyncfloodCounter", resp);
-                                       return true;
-                                   });
+    bool DisableResetCounter = Configuration::getDisableResetCounter();
+    configIface->register_property(
+        "DisableAifsResetOnSyncfloodCounter", DisableResetCounter,
+        [](const bool& requested, bool& resp) {
+            resp = requested;
+            Configuration::setDisableResetCounter(resp);
+            updateConfigFile("DisableAifsResetOnSyncfloodCounter", resp);
+            return true;
+        });
 
     std::vector<std::pair<std::string, std::string>> AifsSignatureId =
         Configuration::getAllAifsSignatureId();
@@ -429,7 +433,8 @@ void CreateDbusInterface()
             return true;
         });
 
-    uint16_t DramCeccErrThresholdCnt = Configuration::getDramCeccErrThresholdCnt();
+    uint16_t DramCeccErrThresholdCnt =
+        Configuration::getDramCeccErrThresholdCnt();
     configIface->register_property(
         "DramCeccErrThresholdCnt", DramCeccErrThresholdCnt,
         [](const uint16_t& requested, uint16_t& resp) {
@@ -439,7 +444,8 @@ void CreateDbusInterface()
             return true;
         });
 
-    uint16_t PcieAerErrThresholdCnt = Configuration::getPcieAerErrThresholdCnt();
+    uint16_t PcieAerErrThresholdCnt =
+        Configuration::getPcieAerErrThresholdCnt();
     configIface->register_property(
         "PcieAerErrThresholdCnt", PcieAerErrThresholdCnt,
         [](const uint16_t& requested, uint16_t& resp) {
@@ -459,9 +465,8 @@ void CreateDbusInterface()
             fut.wait_for(std::chrono::seconds(kCrashdumpTimeInSec)) !=
                 std::future_status::ready)
         {
-            sd_journal_print(
-                LOG_WARNING,
-                "A logging is still in progress, that one won't get removed\n");
+            sd_journal_print(LOG_WARNING, "A logging is still in progress, "
+                                          "that one won't get removed\n");
         }
         for (auto& [filename, interface] : crashdumpInterfaces)
         {
@@ -479,8 +484,9 @@ void CreateDbusInterface()
     });
     deleteAllIface->initialize();
 
-    // com.amd.crashdump.OnDemand/GenerateOnDemandLog currently not supported
-    // com.amd.crashdump.Telemetry/GenerateTelemetryLog currently not supported
+    // com.amd.crashdump.OnDemand/GenerateOnDemandLog currently not
+    // supported com.amd.crashdump.Telemetry/GenerateTelemetryLog currently
+    // not supported
 
     // Check if any crashdump already exists.
     if (std::filesystem::exists(std::filesystem::path(kRasDir.data())))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -610,6 +610,7 @@ static void currentHostStateMonitor()
                     if (ret == OOB_SUCCESS)
                     {
                         performPlatformInitialization();
+                        watchdogTimerCounter = 0;
                         break;
                     }
                     sleep(INDEX_1);

--- a/src/write_cper_data.cpp
+++ b/src/write_cper_data.cpp
@@ -512,8 +512,9 @@ void dump_proc_error_section(const std::shared_ptr<T>& data, uint8_t soc_num,
                 std::string FruText =
                     FindDimmFruText(soc_num, UMCInstance, DimmNumber);
 
-                memcpy(ProcPtr->SectionDescriptor[Section].FRUText,
-                       FruText.c_str(), INDEX_20);
+                std::strncpy(ProcPtr->SectionDescriptor[Section].FRUText, FruText.c_str(),
+                             INDEX_19);
+                ProcPtr->SectionDescriptor[Section].FRUText[INDEX_19] = '\0';
             }
         }
         else if (category == PCIE_ERR)

--- a/src/write_cper_data.cpp
+++ b/src/write_cper_data.cpp
@@ -618,19 +618,22 @@ void dump_error_descriptor_section(const std::shared_ptr<T>& data,
             if (strcasecmp(data->SectionDescriptor[i].FRUText, "null") ==
                 INDEX_0)
             {
-                std::strcpy(data->SectionDescriptor[i].FRUText, "MemoryError");
+                std::strncpy(data->SectionDescriptor[i].FRUText, "MemoryError", INDEX_19);
+                data->SectionDescriptor[i].FRUText[INDEX_19] = '\0';
             }
             else if (data->SectionDescriptor[i].FRUText[INDEX_0] == '\0')
             {
                 if (ErrorType == RUNTIME_MCA_ERR)
                 {
-                    std::strcpy(data->SectionDescriptor[i].FRUText,
-                                "ProcessorError");
+                    std::strncpy(data->SectionDescriptor[i].FRUText,
+                                "ProcessorError", INDEX_19);
+                    data->SectionDescriptor[i].FRUText[INDEX_19] = '\0';
                 }
                 else if (ErrorType == RUNTIME_DRAM_ERR)
                 {
-                    std::strcpy(data->SectionDescriptor[i].FRUText,
-                                "DramCeccError");
+                    std::strncpy(data->SectionDescriptor[i].FRUText,
+                                "DramCeccError", INDEX_19);
+                    data->SectionDescriptor[i].FRUText[INDEX_19] = '\0';
                 }
             }
         }

--- a/src/write_cper_data.cpp
+++ b/src/write_cper_data.cpp
@@ -326,6 +326,7 @@ std::string FindDimmFruText(uint8_t soc_num, uint8_t UMCInstance,
 }
 
 template <typename T>
+// cppcheck-suppress unusedFunction
 void dump_proc_error_section(const std::shared_ptr<T>& data, uint8_t soc_num,
                              struct ras_rt_valid_err_inst inst,
                              uint8_t category, uint16_t Section,
@@ -336,12 +337,12 @@ void dump_proc_error_section(const std::shared_ptr<T>& data, uint8_t soc_num,
     uint32_t d_out = 0;
     uint64_t mca_status_register = 0;
     uint32_t root_err_status = 0;
-    uint32_t offset = 0;
+    uint32_t offset;
     uint32_t mca_ipid_lo_register = 0;
     uint32_t mca_ipid_hi_register = 0;
     uint32_t mca_synd_lo_register = 0;
 
-    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+    oob_status_t ret;
 
     sd_journal_print(LOG_INFO, "Harvesting errors for category %d\n", category);
     std::shared_ptr<PROC_RUNTIME_ERR_RECORD> ProcPtr;
@@ -550,23 +551,13 @@ void dump_proc_error_section(const std::shared_ptr<T>& data, uint8_t soc_num,
 }
 
 template <typename T>
+// cppcheck-suppress unusedFunction
 void calculate_time_stamp(const std::shared_ptr<T>& data)
 {
     using namespace std;
     using namespace std::chrono;
-    typedef duration<int, ratio_multiply<hours::period, ratio<24>>::type> days;
 
     system_clock::time_point now = system_clock::now();
-    system_clock::duration tp = now.time_since_epoch();
-
-    days d = duration_cast<days>(tp);
-    tp -= d;
-    hours h = duration_cast<hours>(tp);
-    tp -= h;
-    minutes m = duration_cast<minutes>(tp);
-    tp -= m;
-    seconds s = duration_cast<seconds>(tp);
-    tp -= s;
 
     time_t tt = system_clock::to_time_t(now);
     tm utc_tm = *gmtime(&tt);
@@ -583,8 +574,9 @@ void calculate_time_stamp(const std::shared_ptr<T>& data)
 }
 
 template <typename T>
+// cppcheck-suppress unusedFunction
 void dump_error_descriptor_section(const std::shared_ptr<T>& data,
-                                   uint16_t SectionCount, std::string ErrorType,
+                                   uint16_t SectionCount,const std::string& ErrorType,
                                    uint32_t* Severity)
 {
     for (int i = 0; i < SectionCount; i++)
@@ -618,7 +610,8 @@ void dump_error_descriptor_section(const std::shared_ptr<T>& data,
             if (strcasecmp(data->SectionDescriptor[i].FRUText, "null") ==
                 INDEX_0)
             {
-                std::strncpy(data->SectionDescriptor[i].FRUText, "MemoryError", INDEX_19);
+                std::strncpy(data->SectionDescriptor[i].FRUText, "MemoryError",
+                             INDEX_19);
                 data->SectionDescriptor[i].FRUText[INDEX_19] = '\0';
             }
             else if (data->SectionDescriptor[i].FRUText[INDEX_0] == '\0')
@@ -626,13 +619,13 @@ void dump_error_descriptor_section(const std::shared_ptr<T>& data,
                 if (ErrorType == RUNTIME_MCA_ERR)
                 {
                     std::strncpy(data->SectionDescriptor[i].FRUText,
-                                "ProcessorError", INDEX_19);
+                                 "ProcessorError", INDEX_19);
                     data->SectionDescriptor[i].FRUText[INDEX_19] = '\0';
                 }
                 else if (ErrorType == RUNTIME_DRAM_ERR)
                 {
                     std::strncpy(data->SectionDescriptor[i].FRUText,
-                                "DramCeccError", INDEX_19);
+                                 "DramCeccError", INDEX_19);
                     data->SectionDescriptor[i].FRUText[INDEX_19] = '\0';
                 }
             }
@@ -669,9 +662,10 @@ void dump_error_descriptor_section(const std::shared_ptr<T>& data,
 }
 
 template <typename T>
+// cppcheck-suppress unusedFunction
 void dump_cper_header_section(const std::shared_ptr<T>& data,
                               uint16_t SectionCount, uint32_t ErrorSeverity,
-                              std::string ErrorType)
+                              const std::string& ErrorType)
 {
     /*ASCII 4-character array “CPER” (0x43, 0x50, 0x45, 0x52) */
     memcpy(data->Header.Signature, CPER_SIG_RECORD, CPER_SIG_SIZE);
@@ -742,6 +736,7 @@ void dump_cper_header_section(const std::shared_ptr<T>& data,
 }
 
 template <typename T>
+// cppcheck-suppress unusedFunction
 void dump_proc_error_info_section(const std::shared_ptr<T>& ProcPtr,
                                   uint8_t soc_num, uint16_t SectionCount,
                                   uint64_t* CheckInfo, uint32_t SectionStart)
@@ -795,7 +790,8 @@ inline std::string getCperFilename(int num)
 }
 
 template <typename T>
-void write_to_cper_file(const std::shared_ptr<T>& data, std::string ErrorType,
+// cppcheck-suppress unusedFunction
+void write_to_cper_file(const std::shared_ptr<T>& data, const std::string& ErrorType,
                         uint16_t SectionCount)
 {
 
@@ -878,8 +874,7 @@ void write_to_cper_file(const std::shared_ptr<T>& data, std::string ErrorType,
 
             exportCrashdumpToDBus(err_count, FatalPtr->Header.TimeStamp);
 
-            std::string ras_err_msg =
-                "CPER file generated for fatal error";
+            std::string ras_err_msg = "CPER file generated for fatal error";
 
             sd_journal_send(
                 "MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i", LOG_ERR,
@@ -911,7 +906,7 @@ void write_to_cper_file(const std::shared_ptr<T>& data, std::string ErrorType,
     file = fopen(index_file, "w");
     if (file != NULL)
     {
-        fprintf(file, "%d", err_count);
+        fprintf(file, "%u", err_count);
         fclose(file);
     }
 
@@ -927,31 +922,31 @@ template void calculate_time_stamp<PCIE_RUNTIME_ERR_RECORD>(
     const std::shared_ptr<PCIE_RUNTIME_ERR_RECORD>&);
 
 template void dump_error_descriptor_section<CPER_RECORD>(
-    const std::shared_ptr<CPER_RECORD>&, uint16_t, std::string, uint32_t*);
+    const std::shared_ptr<CPER_RECORD>&, uint16_t, const std::string& , uint32_t*);
 template void dump_error_descriptor_section<PROC_RUNTIME_ERR_RECORD>(
-    const std::shared_ptr<PROC_RUNTIME_ERR_RECORD>&, uint16_t, std::string,
+    const std::shared_ptr<PROC_RUNTIME_ERR_RECORD>&, uint16_t,const std::string&,
     uint32_t*);
 template void dump_error_descriptor_section<PCIE_RUNTIME_ERR_RECORD>(
-    const std::shared_ptr<PCIE_RUNTIME_ERR_RECORD>&, uint16_t, std::string,
+    const std::shared_ptr<PCIE_RUNTIME_ERR_RECORD>&, uint16_t,const std::string&,
     uint32_t*);
 
 template void
     dump_cper_header_section<CPER_RECORD>(const std::shared_ptr<CPER_RECORD>&,
-                                          uint16_t, uint32_t, std::string);
+                                          uint16_t, uint32_t,const std::string&);
 template void dump_cper_header_section<PROC_RUNTIME_ERR_RECORD>(
     const std::shared_ptr<PROC_RUNTIME_ERR_RECORD>&, uint16_t, uint32_t,
-    std::string);
+    const std::string&);
 template void dump_cper_header_section<PCIE_RUNTIME_ERR_RECORD>(
     const std::shared_ptr<PCIE_RUNTIME_ERR_RECORD>&, uint16_t, uint32_t,
-    std::string);
+    const std::string&);
 
 template void
     write_to_cper_file<CPER_RECORD>(const std::shared_ptr<CPER_RECORD>&,
-                                    std::string, uint16_t);
+                                    const std::string&, uint16_t);
 template void write_to_cper_file<PROC_RUNTIME_ERR_RECORD>(
-    const std::shared_ptr<PROC_RUNTIME_ERR_RECORD>&, std::string, uint16_t);
+    const std::shared_ptr<PROC_RUNTIME_ERR_RECORD>&, const std::string& , uint16_t);
 template void write_to_cper_file<PCIE_RUNTIME_ERR_RECORD>(
-    const std::shared_ptr<PCIE_RUNTIME_ERR_RECORD>&, std::string, uint16_t);
+    const std::shared_ptr<PCIE_RUNTIME_ERR_RECORD>&, const std::string& , uint16_t);
 
 template void dump_proc_error_section<PROC_RUNTIME_ERR_RECORD>(
     const std::shared_ptr<PROC_RUNTIME_ERR_RECORD>&, uint8_t,


### PR DESCRIPTION
Decoding the CPER file displays garbage character added at the end of the DIMM FruText. Fixed the issue by terminating the DIMM FruText will null character.
