### PR TITLE
Fix garbage values of the DIMM FruText in CPER

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -32,7 +32,7 @@
  * CPER section descriptor revision, used in revision field in struct
  * cper_section_descriptor
  */
-#define CPER_MINOR_REV (0x000B)
+#define CPER_MINOR_REV (0x000C)
 
 #define ADDC_GEN_NUMBER_1 (0x01)
 #define ADDC_GEN_NUMBER_2 (0x02)

--- a/src/write_cper_data.cpp
+++ b/src/write_cper_data.cpp
@@ -512,8 +512,9 @@ void dump_proc_error_section(const std::shared_ptr<T>& data, uint8_t soc_num,
                 std::string FruText =
                     FindDimmFruText(soc_num, UMCInstance, DimmNumber);
 
-                memcpy(ProcPtr->SectionDescriptor[Section].FRUText,
-                       FruText.c_str(), INDEX_20);
+                std::strncpy(ProcPtr->SectionDescriptor[Section].FRUText, FruText.c_str(),
+                             INDEX_19);
+                ProcPtr->SectionDescriptor[Section].FRUText[INDEX_19] = '\0';
             }
         }
         else if (category == PCIE_ERR)


### PR DESCRIPTION
Decoding the CPER file displays garbage character added at the end of the DIMM FruText. Fixed the issue by terminating the DIMM FruText will null character.