### PR TITLE
Add support for fatal error monitoring

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,135 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:  Align
+AlignTrailingComments:
+  Kind: Never
+  OverEmptyLines: 1
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: true
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: None
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterExternBlock: true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction:   false
+  SplitEmptyRecord:     false
+  SplitEmptyNamespace:  false
+BreakAfterAttributes: Never
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
+BreakStringLiterals: false
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^[<"](gtest|gmock)'
+    Priority:        7
+  - Regex:           '^"config.h"'
+    Priority:        -1
+  - Regex:           '^".*\.h"'
+    Priority:        1
+  - Regex:           '^".*\.hpp"'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        3
+  - Regex:           '^<.*\.hpp>'
+    Priority:        4
+  - Regex:           '^<.*'
+    Priority:        5
+  - Regex:           '.*'
+    Priority:        6
+IndentCaseLabels: true
+IndentExternBlock: NoIndent
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: true
+InsertNewlineAtEOF: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+LineEnding: LF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 25
+PenaltyBreakBeforeFirstCallParameter: 50
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 1
+PointerAlignment: Left
+QualifierAlignment: Left
+ReferenceAlignment: Left
+ReflowComments:  true
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: Keyword
+SortIncludes: CaseSensitive
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: Never
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Latest
+TabWidth:        4
+UseTab:          Never
+...

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Full Description:
+Different components of meta-amd are under different licenses (a mix
+of MIT and Apache-2.0). Please see:
+
+COPYING.Apache-2.0
+COPYING.MIT (MIT)
+
+All metadata is MIT licensed unless otherwise stated. Source code
+included in tree for individual recipes is under the LICENSE stated in
+the associated recipe (.bb file) unless otherwise stated.
+
+License information for any other files is either explicitly stated
+or defaults to Apache-2.0.

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,40 @@
+# OWNERS
+# ------
+#
+# The OWNERS file maintains the list of individuals responsible for various
+# parts of this repository, including code review and approval.  We use the
+# Gerrit 'owners' plugin, which consumes this file, along with some extra
+# keywords for our own purposes and tooling.
+#
+# For details on the configuration used by 'owners' see:
+#  https://gerrit.googlesource.com/plugins/owners/+/refs/heads/master/owners/src/main/resources/Documentation/config.md
+#
+# An OWNERS file must be in the root of a repository but may also be present
+# in any subdirectory.  The contents of the subdirectory OWNERS file are
+# combined with parent directories unless 'inherit: false' is set.
+#
+# The owners file is YAML and has [up to] 4 top-level keywords.
+#   * owners: A list of individuals who have approval authority on the
+#     repository.
+#
+#   * reviewers: A list of individuals who have requested review notification
+#     on the repository.
+#
+#   * matches: A list of specific file/path matches for granular 'owners' and
+#     'reviewers'.  See 'owners' plugin documentation.
+#
+#   * openbmc: A list of openbmc-specific meta-data about owners and reviewers.
+#     - name: preferred name of the individual.
+#     - email: preferred email address of the individual.
+#     - discord: Discord nickname of the individual.
+#
+# It is expected that these 4 sections will be listed in the order above and
+# data within them will be kept sorted.
+
+owners:
+
+reviewers:
+
+matches:
+
+openbmc:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# AMD BMC RAS 
+# AMD BMC RAS
+
+The amd-bmc-ras service is intended to discover, configure and exercise OOB RAS capabilities supported by the processors.
+The application creates error records from RAS telemetry extracted from the processor over APML.

--- a/config/ras-config.json
+++ b/config/ras-config.json
@@ -1,0 +1,70 @@
+{
+  "Configuration": [
+    {
+      "ApmlRetries": {
+        "Description": "Number of APML retry count",
+        "Value": 10,
+        "MaxBoundLimit": "50"
+      }
+    },
+    {
+      "SystemRecovery": {
+        "Description": "System recovery mode",
+        "Value": "NO_RESET"
+      }
+    },
+    {
+      "HarvestMicrocode": {
+        "Description": "Harvest microcode version",
+        "Value": true
+      }
+    },
+    {
+      "HarvestPPIN": {
+        "Description": "Harvest PPIN",
+        "Value": true
+      }
+    },
+    {
+      "ResetSignal": {
+        "Description": "Reset Signal Type",
+        "Value": "SYS_RST"
+      }
+    },
+    {
+      "SigIdOffset": {
+        "Description": "List of Signature ID offsets",
+        "Value": [
+          "0x30",
+          "0x34",
+          "0x28",
+          "0x2c",
+          "0x08",
+          "0x0c",
+          "null",
+          "null"
+        ]
+      }
+    },
+    {
+      "AifsArmed": {
+        "Description": "If this field is true, AIFS flow is triggered",
+        "Value": false
+      }
+    },
+    {
+      "AifsSignatureId": {
+        "Description": "List of signature Id to check if Aifs is triggered",
+        "Value": {
+          "EX-WDT": "0xaea0000000000108000500b020009a00000000004d000000"
+        }
+      }
+    },
+    {
+      "DisableAifsResetOnSyncfloodCounter": {
+        "Description": "Disable AIFS Reset on syncfloow counter ",
+        "Value": true
+      }
+    }
+  ]
+}

--- a/inc/apml_manager.hpp
+++ b/inc/apml_manager.hpp
@@ -1,0 +1,47 @@
+#include "interface_manager_base.hpp"
+
+class ApmlInterfaceManager : public RasManagerBase
+{
+  public:
+    virtual void init();
+
+    virtual void configure();
+
+    ApmlInterfaceManager(
+        sdbusplus::asio::object_server& objectServer,
+        std::shared_ptr<sdbusplus::asio::connection>& systemBus,
+        boost::asio::io_service& io) :
+        RasManagerBase(objectServer, systemBus, io)
+    {}
+
+  protected:
+    std::vector<uint8_t> blockId;
+    uint32_t familyId;
+    std::mutex harvest_in_progress_mtx;
+    bool p0AlertProcessed = false;
+    bool p1AlertProcessed = false;
+    uint64_t recordId = 1;
+    uint16_t debugLogIdOffset;
+    uint32_t SignatureID[8];
+    virtual void interfaceActiveMonitor();
+    virtual void getCpuId();
+    virtual void findProgramId();
+    virtual bool harvestFatalError(uint8_t);
+
+    void clearSbrmiAlertMask(uint8_t);
+
+    void performPlatformInitialization();
+
+    oob_status_t readRegister(uint8_t, uint32_t, uint8_t*);
+
+    void writeRegister(uint8_t, uint32_t, uint32_t);
+    bool compare_with_bitwise_AND(const uint32_t*, const std::string&);
+    bool checkSignatureIdMatch();
+    std::vector<uint32_t> hexstring_to_vector(const std::string&);
+    bool harvestMcaValidityCheck(uint8_t, uint16_t*, uint16_t*);
+    bool harvestMcaDataBanks(uint8_t, uint16_t, uint16_t);
+    void updateCperRecord(const char*, uint16_t, uint16_t, uint8_t);
+    void getLastTransAddr(EFI_AMD_FATAL_ERROR_DATA*, uint8_t);
+    void dumpContextInfo(EFI_AMD_FATAL_ERROR_DATA*, uint8_t);
+    void harvestDebugLogDump(EFI_AMD_FATAL_ERROR_DATA*, uint8_t, uint8_t);
+};

--- a/inc/config_manager.hpp
+++ b/inc/config_manager.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <com/amd/RAS/Configuration/common.hpp>
+#include <com/amd/RAS/Configuration/server.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/server.hpp>
+
+#include <filesystem>
+#include <string>
+static constexpr auto objectPath = "/com/amd/RAS";
+
+using AttributeType =
+    sdbusplus::common::com::amd::ras::Configuration::AttributeType;
+using Base = sdbusplus::com::amd::RAS::server::Configuration;
+
+using AttributeName = std::string;
+using AttributeValue =
+    std::variant<bool, std::string, int64_t, std::vector<std::string>,
+                 std::map<std::string, std::string>>;
+using ConfigTable =
+    std::map<std::string,
+             std::tuple<AttributeType, std::string,
+                        std::variant<bool, std::string, int64_t,
+                                     std::vector<std::string>,
+                                     std::map<std::string, std::string>>,
+                        int64_t>>;
+
+struct EventDeleter
+{
+    void operator()(sd_event* event) const
+    {
+        event = sd_event_unref(event);
+    }
+};
+using EventPtr = std::unique_ptr<sd_event, EventDeleter>;
+
+/**
+ * @brief Definition of the RasConfiguration class.
+ *
+ * @tparam AttributeName The type for attribute names (usually std::string).
+ * @tparam AttributeValue The variant type for attribute values.
+ * @tparam ConfigTable The map type for storing attribute information.
+ */
+
+class RasConfiguration : public Base
+{
+  public:
+    /**
+     * Constructor for Configuration.
+     *
+     * @param objectServer Reference to the object server.
+     * @param systemBus Reference to the system D-Bus connection.
+     */
+    RasConfiguration(sdbusplus::asio::object_server& objectServer,
+                     std::shared_ptr<sdbusplus::asio::connection>& systemBus);
+
+    /**
+     * Set the value of an attribute.
+     *
+     * @param attribute The name of the attribute.
+     * @param value The value to set.
+     */
+    void setAttribute(AttributeName attribute, AttributeValue value) override;
+
+    /**
+     * Get the value of an attribute.
+     *
+     * @param attribute The name of the attribute.
+     * @return The value of the attribute.
+     */
+    AttributeValue getAttribute(AttributeName attribute) override;
+
+  private:
+    sdbusplus::asio::object_server& objServer;
+    std::shared_ptr<sdbusplus::asio::connection>& systemBus;
+};

--- a/inc/interface_manager_base.hpp
+++ b/inc/interface_manager_base.hpp
@@ -1,0 +1,60 @@
+#include "config_manager.hpp"
+#include "ras.hpp"
+
+class RasManagerBase : public RasConfiguration
+{
+  public:
+    RasManagerBase(sdbusplus::asio::object_server& objectServer,
+                   std::shared_ptr<sdbusplus::asio::connection>& systemBus,
+                   boost::asio::io_service& io) :
+        RasConfiguration(objectServer, systemBus), io(io),
+        p0_apmlAlertEvent(io), p1_apmlAlertEvent(io)
+    {}
+
+    virtual void init() = 0;
+
+    virtual void configure() = 0;
+
+    virtual ~RasManagerBase();
+
+    void p0AlertEventHandler();
+    void p1AlertEventHandler();
+
+  protected:
+    boost::asio::io_service& io;
+    uint8_t numOfCpu;
+    CpuId* cpuId;
+    uint32_t* uCode;
+    uint64_t* ppin;
+    std::string* inventoryPath;
+    unsigned int boardId;
+    uint8_t progId;
+    int errCount = 0;
+    boost::asio::posix::stream_descriptor p0_apmlAlertEvent;
+    boost::asio::posix::stream_descriptor p1_apmlAlertEvent;
+    gpiod::line p0_apmlAlertLine;
+    gpiod::line p1_apmlAlertLine;
+
+    void getNumberOfCpu();
+    void getBoardId();
+    void createIndexFile();
+    void createConfigFile();
+    void getMicrocodeRev();
+    void getPpinFuse();
+    template <typename T>
+    T getProperty(sdbusplus::bus::bus&, const char*, const char*, const char*,
+                  const char*);
+    void requestGPIOEvents(const std::string&, const std::function<void()>&,
+                           gpiod::line&,
+                           boost::asio::posix::stream_descriptor&);
+    void rasRecoveryAction(uint8_t);
+    void triggerColdReset();
+    void triggerRsmrstReset();
+    void triggerSysReset();
+    void requestHostTransition(std::string);
+
+    virtual void interfaceActiveMonitor() = 0;
+    virtual void getCpuId() = 0;
+    virtual void findProgramId() = 0;
+    virtual bool harvestFatalError(uint8_t) = 0;
+};

--- a/inc/ras.hpp
+++ b/inc/ras.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+#include "edk/Cper.h"
+#include "generator/cper-generate.h"
+
+#include <sys/stat.h>
+
+#include <boost/asio.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
+#include <gpiod.hpp>
+#include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <phosphor-logging/log.hpp>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <regex>
+
+extern "C"
+{
+#include "apml.h"
+#include "apml_common.h"
+#include "esmi_cpuid_msr.h"
+#include "esmi_mailbox.h"
+#include "esmi_rmi.h"
+}
+
+#define EFI_CPER_CREATOR_PSTORE                                                \
+    {                                                                          \
+        0x61fa3fac, 0xcb80, 0x4292,                                            \
+        {                                                                      \
+            0x8b, 0xfb, 0xd6, 0x43, 0xb1, 0xde, 0x17, 0xf4                     \
+        }                                                                      \
+    }
+
+#define EFI_CPER_NOTIFY_MCE                                                    \
+    {                                                                          \
+        0xE8F56FFE, 0x919C, 0x4cc5,                                            \
+        {                                                                      \
+            0xBA, 0x88, 0x65, 0xAB, 0xE1, 0x49, 0x13, 0xBB                     \
+        }                                                                      \
+    }
+
+static const int RESERVED = 0;
+static const int BASE_16 = 16;
+static const int TWO_SOCKET = 2;
+static const int INDEX_0 = 0;
+static const int INDEX_1 = 1;
+static const int INDEX_2 = 2;
+static const int INDEX_3 = 3;
+static const int INDEX_4 = 4;
+static const int INDEX_5 = 5;
+static const int INDEX_6 = 6;
+static const int INDEX_7 = 7;
+static const int INDEX_8 = 8;
+static const int INDEX_12 = 12;
+static const int INDEX_16 = 16;
+static const int INDEX_19 = 19;
+static const int INDEX_20 = 20;
+static const int BLOCK_ID_1 = 1;
+static const int BLOCK_ID_2 = 2;
+static const int BLOCK_ID_3 = 3;
+static const int BLOCK_ID_23 = 23;
+static const int BLOCK_ID_24 = 24;
+static const int BLOCK_ID_33 = 33;
+static const int BLOCK_ID_36 = 36;
+static const int BLOCK_ID_37 = 37;
+static const int BLOCK_ID_38 = 38;
+static const int BLOCK_ID_39 = 39;
+static const int BLOCK_ID_40 = 40;
+static const int MI300A_MODEL_NUMBER = 0x90;
+static const int MI300C_MODEL_NUMBER = 0x80;
+static const int TURIN_FAMILY_ID = 0x1A;
+static const int GENOA_FAMILY_ID = 0x19;
+static const int EPYC_PROG_SEG_ID = 0x01;
+static const int MI_PROG_SEG_ID = 0x02;
+static const int MAX_ERROR_FILE = 10;
+static const std::string RAS_DIR = "/var/lib/amd-ras/";
+static const std::string INDEX_FILE = "/var/lib/amd-ras/current_index";
+static const std::string CONFIG_FILE = "/var/lib/amd-ras/ras-config.json";
+static const std::string SRC_CONFIG_FILE =
+    "/usr/share/ras-config/ras-config.json";
+static const std::string INVENTORY_SERVICE =
+    "xyz.openbmc_project.Inventory.Manager";
+static const std::string CPU_INVENTORY_INTERFACE =
+    "xyz.openbmc_project.Inventory.Item.Cpu";
+static const std::string EVENT_SUBSCRIPTION_FILE =
+    "/var/lib/bmcweb/eventservice_config.json";
+static const int RAS_STATUS_REGISTER = 0x4C;
+static const std::string COMMAND_NUM_OF_CPU =
+    "/sbin/fw_printenv -n bootdelay"; // num_of_cpu
+static const std::string COMMAND_BOARD_ID = "/sbin/fw_printenv -n board_id";
+static const int COMMAND_LEN = 3;
+static const int SBRMI_CONTROL_REGISTER = 0x1;
+static const int SYS_MGMT_CTRL_ERR = 0x04;
+static const int RESET_HANG_ERR = 0x02;
+static const int INT_255 = 0xFF;
+static const int SOCKET_0 = 0;
+static const int SOCKET_1 = 1;
+static const int FATAL_ERROR = 1;
+static const int MAX_MCA_BANKS = 32;
+static const int CPER_RECORD_REV = 0x0100;
+static const int CPER_SEV_FATAL = 1;
+static const int CPER_VALID_PLATFORM_ID = 0x0001;
+static const int CPER_VALID_TIMESTAMP = 0x0002;
+static const int CPER_VALID_PARTITION_ID = 0x0004;
+static const int CPER_MINOR_REV = 0x1;
+static const std::string DBUS_SERVICE_NAME = "com.amd.RAS";
+static const int ADDC_GEN_NUMBER_1 = 0x01;
+static const int ADDC_GEN_NUMBER_2 = 0x02;
+static const int ADDC_GEN_NUMBER_3 = 0x03;
+static const int CTX_OOB_CRASH = 0x01;
+static const int CPU_ID_VALID = 0x02;
+static const int LOCAL_APIC_ID_VALID = 0x01;
+static const int CPER_PRIMARY = 1;
+static const int SHIFT_23 = 23;
+static const int SHIFT_24 = 24;
+static const int SHIFT_25 = 25;
+static const int SHIFT_4 = 4;
+static const int BYTE_4 = 4;
+static const int BYTE_2 = 2;
+static const int BAD_DATA = 0xBAADDA7A;
+static const int FAILURE_SIGNATURE_ID = 0x04;
+static const int PROC_CONTEXT_STRUCT_VALID = 0x100;
+
+struct CpuId
+{
+    uint32_t eax;
+    uint32_t ebx;
+    uint32_t ecx;
+    uint32_t edx;
+};

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,73 @@
+project(
+  'amd-bmc-ras',
+  'cpp',
+  default_options: [
+    'warning_level=3',
+    'werror=true',
+    'cpp_std=c++20'
+  ],
+  license: 'Apache-2.0',
+  version: '1.0',
+)
+
+
+conf_data = configuration_data()
+
+cpp_args = []
+
+cpp = meson.get_compiler('cpp')
+
+# (Meson requires an absolute path for find_library().)
+libdir = meson.current_source_dir() + './lib/'
+
+apml_dep = cpp.find_library('apml64', dirs : libdir) # ./lib/libapml64.lib
+cper_dep = cpp.find_library('cper-generate',dirs : libdir)
+
+deps = [
+  dependency('libgpiodcxx', default_options: ['bindings=cxx']),
+  dependency('systemd'),
+  dependency('sdbusplus'),
+  dependency('sdeventplus'),
+  dependency('phosphor-logging'),
+  dependency('nlohmann_json'),
+  dependency('threads'),
+  apml_dep,
+  cper_dep,
+]
+
+apml = get_option('apml-interface')
+if apml
+  add_project_arguments('-DAPML', language: 'cpp')
+endif
+
+pldm = get_option('pldm-interface')
+if pldm
+  add_project_arguments('-DPLDM', language: 'cpp')
+endif
+
+executable(
+  'amd-bmc-ras',
+  'src/main.cpp',
+  'src/apml_manager.cpp',
+  'src/interface_manager_base.cpp',
+  'src/config_manager.cpp',
+  include_directories: include_directories('inc'),
+  cpp_args: cpp_args,
+  dependencies: deps,
+  install: true,
+  install_dir: get_option('bindir'))
+
+ras_config_dir = join_paths(get_option('datadir'), 'ras-config')
+install_data(
+    join_paths(meson.current_source_dir(), 'config', 'ras-config.json'),
+    install_dir: ras_config_dir,
+    rename: 'ras-config.json'
+)
+
+systemd = dependency('systemd')
+
+install_data(
+  ['service_files/com.amd.RAS.service'],
+  install_dir: systemd.get_pkgconfig_variable('systemdsystemunitdir')
+)
+

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,8 @@
+option(
+    'systemd-target',
+    description: 'Target for starting this service.',
+    type: 'string'
+)
+
+option('apml-interface', type: 'boolean', value: true, description: 'Enable APML interface')
+option('pldm-interface', type: 'boolean', value: false, description: 'Enable PLDM interface')

--- a/service_files/com.amd.RAS.service
+++ b/service_files/com.amd.RAS.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Crash dump manager
+After=xyz.openbmc_project.Chassis.Control.Power.service
+
+[Service]
+Restart=always
+ExecStart=/usr/bin/amd-bmc-ras
+
+[Install]
+WantedBy=multi-user.target

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,0 +1,352 @@
+#include "Config.hpp"
+
+uint16_t Configuration::apmlRetryCount;
+uint16_t Configuration::systemRecovery;
+bool Configuration::harvestuCodeVersionFlag;
+bool Configuration::harvestPpinFlag;
+bool Configuration::McaPollingEn;
+bool Configuration::DramCeccPollingEn;
+bool Configuration::PcieAerPollingEn;
+bool Configuration::McaThresholdEn;
+bool Configuration::DramCeccThresholdEn;
+bool Configuration::PcieAerThresholdEn;
+bool Configuration::AifsArmed;
+bool Configuration::DisableResetCounter;
+uint16_t Configuration::McaPollingPeriod;
+uint16_t Configuration::DramCeccPollingPeriod;
+uint16_t Configuration::PcieAerPollingPeriod;
+uint16_t Configuration::McaErrThresholdCnt;
+uint16_t Configuration::DramCeccErrThresholdCnt;
+uint16_t Configuration::PcieAerErrThresholdCnt;
+std::string ResetSignal;
+std::vector<std::string> Configuration::sigIDOffset = {
+    "0x30", "0x34", "0x28", "0x2c", "0x08", "0x0c", "null", "null"};
+
+std::vector<std::pair<std::string, std::string>> Configuration::P0_DimmLabels =
+    {{"P0_DIMM_A", "null"},  {"P0_DIMM_A1", "null"}, {"P0_DIMM_B", "null"},
+     {"P0_DIMM_B1", "null"}, {"P0_DIMM_C", "null"},  {"P0_DIMM_C1", "null"},
+     {"P0_DIMM_D", "null"},  {"P0_DIMM_D1", "null"}, {"P0_DIMM_E", "null"},
+     {"P0_DIMM_E1", "null"}, {"P0_DIMM_F", "null"},  {"P0_DIMM_F1", "null"},
+     {"P0_DIMM_G", "null"},  {"P0_DIMM_G1", "null"}, {"P0_DIMM_H", "null"},
+     {"P0_DIMM_H1", "null"}, {"P0_DIMM_I", "null"},  {"P0_DIMM_I1", "null"},
+     {"P0_DIMM_J", "null"},  {"P0_DIMM_J1", "null"}, {"P0_DIMM_K", "null"},
+     {"P0_DIMM_K1", "null"}, {"P0_DIMM_L", "null"},  {"P0_DIMM_L1", "null"}};
+
+std::vector<std::pair<std::string, std::string>> Configuration::P1_DimmLabels =
+    {{"P1_DIMM_A", "null"},  {"P1_DIMM_A1", "null"}, {"P1_DIMM_B", "null"},
+     {"P1_DIMM_B1", "null"}, {"P1_DIMM_C", "null"},  {"P1_DIMM_C1", "null"},
+     {"P1_DIMM_D", "null"},  {"P1_DIMM_D1", "null"}, {"P1_DIMM_E", "null"},
+     {"P1_DIMM_E1", "null"}, {"P1_DIMM_F", "null"},  {"P1_DIMM_F1", "null"},
+     {"P1_DIMM_G", "null"},  {"P1_DIMM_G1", "null"}, {"P1_DIMM_H", "null"},
+     {"P1_DIMM_H1", "null"}, {"P1_DIMM_I", "null"},  {"P1_DIMM_I1", "null"},
+     {"P1_DIMM_J", "null"},  {"P1_DIMM_J1", "null"}, {"P1_DIMM_K", "null"},
+     {"P1_DIMM_K1", "null"}, {"P1_DIMM_L", "null"},  {"P1_DIMM_L1", "null"}};
+
+std::vector<std::pair<std::string, std::string>>
+    Configuration::AifsSignatureId = {
+        {"EX-WDT", "0xaea0000000000108000500b020009a00000000004d000000"}};
+
+void Configuration::setApmlRetryCount(uint16_t value)
+{
+    apmlRetryCount = value;
+}
+uint16_t Configuration::getApmlRetryCount()
+{
+    return apmlRetryCount;
+}
+
+void Configuration::setSystemRecovery(uint16_t value)
+{
+    systemRecovery = value;
+}
+uint16_t Configuration::getSystemRecovery()
+{
+    return systemRecovery;
+}
+
+void Configuration::setHarvestuCodeVersionFlag(bool value)
+{
+    harvestuCodeVersionFlag = value;
+}
+bool Configuration::getHarvestuCodeVersionFlag()
+{
+    return harvestuCodeVersionFlag;
+}
+
+void Configuration::setHarvestPpinFlag(bool value)
+{
+    harvestPpinFlag = value;
+}
+bool Configuration::getHarvestPpinFlag()
+{
+    return harvestPpinFlag;
+}
+
+void Configuration::setMcaPollingEn(bool value)
+{
+    McaPollingEn = value;
+}
+bool Configuration::getMcaPollingEn()
+{
+    return McaPollingEn;
+}
+
+void Configuration::setDramCeccPollingEn(bool value)
+{
+    DramCeccPollingEn = value;
+}
+bool Configuration::getDramCeccPollingEn()
+{
+    return DramCeccPollingEn;
+}
+
+void Configuration::setPcieAerPollingEn(bool value)
+{
+    PcieAerPollingEn = value;
+}
+bool Configuration::getPcieAerPollingEn()
+{
+    return PcieAerPollingEn;
+}
+
+void Configuration::setMcaThresholdEn(bool value)
+{
+    McaThresholdEn = value;
+}
+bool Configuration::getMcaThresholdEn()
+{
+    return McaThresholdEn;
+}
+
+void Configuration::setDramCeccThresholdEn(bool value)
+{
+    DramCeccThresholdEn = value;
+}
+bool Configuration::getDramCeccThresholdEn()
+{
+    return DramCeccThresholdEn;
+}
+
+void Configuration::setPcieAerThresholdEn(bool value)
+{
+    PcieAerThresholdEn = value;
+}
+bool Configuration::getPcieAerThresholdEn()
+{
+    return PcieAerThresholdEn;
+}
+
+void Configuration::setAifsArmed(bool value)
+{
+    AifsArmed = value;
+}
+
+bool Configuration::getAifsArmed()
+{
+    return AifsArmed;
+}
+
+void Configuration::setDisableResetCounter(bool value)
+{
+    DisableResetCounter = value;
+}
+
+bool Configuration::getDisableResetCounter()
+{
+    return DisableResetCounter;
+}
+
+void Configuration::setMcaPollingPeriod(uint16_t value)
+{
+    McaPollingPeriod = value;
+}
+uint16_t Configuration::getMcaPollingPeriod()
+{
+    return McaPollingPeriod;
+}
+
+void Configuration::setDramCeccPollingPeriod(uint16_t value)
+{
+    DramCeccPollingPeriod = value;
+}
+uint16_t Configuration::getDramCeccPollingPeriod()
+{
+    return DramCeccPollingPeriod;
+}
+
+void Configuration::setPcieAerPollingPeriod(uint16_t value)
+{
+    PcieAerPollingPeriod = value;
+}
+uint16_t Configuration::getPcieAerPollingPeriod()
+{
+    return PcieAerPollingPeriod;
+}
+
+void Configuration::setMcaErrThresholdCnt(uint16_t value)
+{
+    McaErrThresholdCnt = value;
+}
+uint16_t Configuration::getMcaErrThresholdCnt()
+{
+    return McaErrThresholdCnt;
+}
+
+void Configuration::setDramCeccErrThresholdCnt(uint16_t value)
+{
+    DramCeccErrThresholdCnt = value;
+}
+uint16_t Configuration::getDramCeccErrThresholdCnt()
+{
+    return DramCeccErrThresholdCnt;
+}
+
+void Configuration::setPcieAerErrThresholdCnt(uint16_t value)
+{
+    PcieAerErrThresholdCnt = value;
+}
+uint16_t Configuration::getPcieAerErrThresholdCnt()
+{
+    return PcieAerErrThresholdCnt;
+}
+
+void Configuration::setResetSignal(const std::string& value)
+{
+    ResetSignal = value;
+}
+
+std::string Configuration::getResetSignal()
+{
+    return ResetSignal;
+}
+
+void Configuration::setSigIDOffset(const std::vector<std::string>& value)
+{
+    sigIDOffset = value;
+}
+
+std::vector<std::string> Configuration::getSigIDOffset()
+{
+    return sigIDOffset;
+}
+
+std::string Configuration::getP0_DimmLabels(const std::string& key)
+{
+    auto it =
+        std::find_if(P0_DimmLabels.begin(), P0_DimmLabels.end(),
+                     [&key](const std::pair<std::string, std::string>& pair) {
+                         return pair.first == key;
+                     });
+
+    if (it != P0_DimmLabels.end())
+    {
+        return it->second;
+    }
+    // Return an empty string if the key is not found
+    return "";
+}
+
+std::string Configuration::getP1_DimmLabels(const std::string& key)
+{
+    auto it =
+        std::find_if(P1_DimmLabels.begin(), P1_DimmLabels.end(),
+                     [&key](const std::pair<std::string, std::string>& pair) {
+                         return pair.first == key;
+                     });
+
+    if (it != P1_DimmLabels.end())
+    {
+        return it->second;
+    }
+    // Return an empty string if the key is not found
+    return "";
+}
+
+void Configuration::setP0_DimmLabels(const std::string& key,
+                                     const std::string& value)
+{
+    auto it =
+        std::find_if(P0_DimmLabels.begin(), P0_DimmLabels.end(),
+                     [&key](const std::pair<std::string, std::string>& pair) {
+                         return pair.first == key;
+                     });
+
+    if (it != P0_DimmLabels.end())
+    {
+        it->second = value;
+    }
+}
+
+void Configuration::setP1_DimmLabels(const std::string& key,
+                                     const std::string& value)
+{
+    auto it =
+        std::find_if(P1_DimmLabels.begin(), P1_DimmLabels.end(),
+                     [&key](const std::pair<std::string, std::string>& pair) {
+                         return pair.first == key;
+                     });
+
+    if (it != P1_DimmLabels.end())
+    {
+        it->second = value;
+    }
+}
+
+void Configuration::setAifsSignatureId(
+    const nlohmann::json& AifsSignatureIdData)
+{
+    AifsSignatureId.clear();
+
+    for (const auto& item : AifsSignatureIdData)
+    {
+        if (item.size() == INDEX_2)
+        {
+            AifsSignatureId.emplace_back(item[INDEX_0], item[INDEX_1]);
+        }
+    }
+
+    for (auto it = AifsSignatureIdData.begin(); it != AifsSignatureIdData.end();
+         ++it)
+    {
+        const std::string& key = it.key();
+        const std::string& value = it.value();
+
+        AifsSignatureId.push_back(std::make_pair(key, value));
+    }
+}
+
+std::vector<std::pair<std::string, std::string>>
+    Configuration::getAllP0_DimmLabels()
+{
+    return P0_DimmLabels;
+}
+
+std::vector<std::pair<std::string, std::string>>
+    Configuration::getAllP1_DimmLabels()
+{
+    return P1_DimmLabels;
+}
+
+std::vector<std::pair<std::string, std::string>>
+    Configuration::getAllAifsSignatureId()
+{
+    return AifsSignatureId;
+}
+
+void Configuration::setAllP0_DimmLabels(
+    const std::vector<std::pair<std::string, std::string>>& value)
+{
+    P0_DimmLabels = value;
+}
+
+void Configuration::setAllP1_DimmLabels(
+    const std::vector<std::pair<std::string, std::string>>& value)
+{
+    P1_DimmLabels = value;
+}
+
+void Configuration::setAllAifsSignatureId(
+    const std::vector<std::pair<std::string, std::string>>& value)
+{
+    AifsSignatureId = value;
+}

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -1,0 +1,1222 @@
+#include "apml_manager.hpp"
+
+void ApmlInterfaceManager::init()
+{
+    getNumberOfCpu();
+
+    interfaceActiveMonitor();
+
+    getCpuId();
+
+    getBoardId();
+
+    findProgramId();
+}
+
+void ApmlInterfaceManager::configure()
+{
+    createIndexFile();
+
+    createConfigFile();
+
+    AttributeValue uCodeVersion = getAttribute("HarvestMicrocode");
+    bool* uCodeVersionFlag = std::get_if<bool>(&uCodeVersion);
+
+    AttributeValue harvestPpin = getAttribute("HarvestPPIN");
+    bool* harvestPpinFlag = std::get_if<bool>(&harvestPpin);
+
+    if (*uCodeVersionFlag == true)
+    {
+        getMicrocodeRev();
+    }
+    if (*harvestPpinFlag == true)
+    {
+        getPpinFuse();
+    }
+
+    requestGPIOEvents("P0_I3C_APML_ALERT_L",
+                      std::bind(&RasManagerBase::p0AlertEventHandler, this),
+                      p0_apmlAlertLine, p0_apmlAlertEvent);
+
+    if (numOfCpu == TWO_SOCKET)
+    {
+        requestGPIOEvents("P1_I3C_APML_ALERT_L",
+                          std::bind(&RasManagerBase::p1AlertEventHandler, this),
+                          p1_apmlAlertLine, p1_apmlAlertEvent);
+    }
+}
+
+void ApmlInterfaceManager::interfaceActiveMonitor()
+{
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+
+    uint32_t d_out = 0;
+
+    while (ret != OOB_SUCCESS)
+    {
+        ret = get_bmc_ras_oob_config(INDEX_0, &d_out);
+
+        if (ret == OOB_MAILBOX_CMD_UNKNOWN)
+        {
+            ret = esmi_get_processor_info(INDEX_0, plat_info);
+        }
+        sleep(INDEX_1);
+    }
+    performPlatformInitialization();
+}
+
+void ApmlInterfaceManager::writeRegister(uint8_t info, uint32_t reg,
+                                         uint32_t value)
+{
+    oob_status_t ret;
+
+    ret = esmi_oob_write_byte(info, reg, SBRMI, value);
+    if (ret != OOB_SUCCESS)
+    {
+        lg2::error("Failed to write register: {REG}", "REG", lg2::hex, reg);
+        return;
+    }
+    lg2::debug("Write to register {REGISTER} is successful", "REGISTER", reg);
+}
+
+oob_status_t ApmlInterfaceManager::readRegister(uint8_t info, uint32_t reg,
+                                                uint8_t* value)
+{
+    oob_status_t ret;
+    uint16_t retryCount = 10;
+
+    while (retryCount > 0)
+    {
+        ret = esmi_oob_read_byte(info, reg, SBRMI, value);
+        if (ret == OOB_SUCCESS)
+        {
+            break;
+        }
+
+        lg2::error("Failed to read register: {REGISTER} Retrying\n", "REGISTER",
+                   lg2::hex, reg);
+
+        usleep(1000 * 1000);
+        retryCount--;
+    }
+    if (ret != OOB_SUCCESS)
+    {
+        lg2::error("Failed to read register: {REGISTER}\n", "REGISTER",
+                   lg2::hex, reg);
+    }
+
+    return ret;
+}
+
+void ApmlInterfaceManager::clearSbrmiAlertMask(uint8_t socNum)
+{
+    oob_status_t ret;
+
+    lg2::info("Clear Alert Mask bit of SBRMI Control register");
+
+    uint8_t buffer;
+
+    ret = readRegister(socNum, SBRMI_CONTROL_REGISTER, &buffer);
+
+    if (ret == OOB_SUCCESS)
+    {
+        buffer = buffer & 0xFE;
+        writeRegister(socNum, SBRMI_CONTROL_REGISTER,
+                      static_cast<uint32_t>(buffer));
+    }
+}
+
+void ApmlInterfaceManager::performPlatformInitialization()
+{
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+    struct processor_info platInfo[INDEX_1];
+
+    while (ret != OOB_SUCCESS)
+    {
+        uint8_t soc_num = 0;
+        ret = esmi_get_processor_info(soc_num, platInfo);
+
+        if (ret == OOB_SUCCESS)
+        {
+            familyId = platInfo->family;
+            break;
+        }
+        sleep(INDEX_1);
+    }
+
+    if (ret == OOB_SUCCESS)
+    {
+        if (platInfo->family == GENOA_FAMILY_ID)
+        {
+            if ((platInfo->model != MI300A_MODEL_NUMBER) &&
+                (platInfo->model != MI300C_MODEL_NUMBER))
+            {
+                blockId = {BLOCK_ID_33};
+            }
+        }
+        else if (platInfo->family == TURIN_FAMILY_ID)
+        {
+            for (uint8_t i = 0; i < numOfCpu; i++)
+            {
+                clearSbrmiAlertMask(i);
+            }
+
+            blockId = {BLOCK_ID_1,  BLOCK_ID_2,  BLOCK_ID_3,  BLOCK_ID_23,
+                       BLOCK_ID_24, BLOCK_ID_33, BLOCK_ID_36, BLOCK_ID_37,
+                       BLOCK_ID_38, BLOCK_ID_40};
+        }
+    }
+    else
+    {
+        sd_journal_print(LOG_ERR,
+                         "Failed to perform platform initialization\n");
+    }
+}
+
+void ApmlInterfaceManager::getCpuId()
+{
+    for (int i = 0; i < numOfCpu; i++)
+    {
+        uint32_t core_id = 0;
+        oob_status_t ret;
+        cpuId[i].eax = 1;
+        cpuId[i].ebx = 0;
+        cpuId[i].ecx = 0;
+        cpuId[i].edx = 0;
+
+        ret = esmi_oob_cpuid(i, core_id, &cpuId[i].eax, &cpuId[i].ebx,
+                             &cpuId[i].ecx, &cpuId[i].edx);
+
+        if (ret)
+        {
+            lg2::error("Failed to get the CPUID for socket {CPU}", "CPU", i);
+        }
+    }
+}
+
+void ApmlInterfaceManager::findProgramId()
+{
+    oob_status_t ret;
+    uint8_t socNum = 0;
+
+    struct processor_info platInfo[INDEX_1];
+
+    ret = esmi_get_processor_info(socNum, platInfo);
+
+    if (ret == OOB_SUCCESS)
+    {
+        if ((platInfo->model == MI300A_MODEL_NUMBER) ||
+            (platInfo->model == MI300C_MODEL_NUMBER))
+        {
+            progId = MI_PROG_SEG_ID;
+        }
+        else
+        {
+            progId = EPYC_PROG_SEG_ID;
+        }
+    }
+}
+
+bool ApmlInterfaceManager::harvestMcaValidityCheck(
+    uint8_t info, uint16_t* numbanks, uint16_t* bytespermca)
+{
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+    uint16_t retries = 0;
+    bool mcaValidityCheck = true;
+
+    AttributeValue apmlRetry = getAttribute("ApmlRetries");
+    int64_t* apmlRetryCount = std::get_if<int64_t>(&apmlRetry);
+
+    while (ret != OOB_SUCCESS)
+    {
+        retries++;
+
+        ret = read_bmc_ras_mca_validity_check(info, bytespermca, numbanks);
+
+        if (retries > *apmlRetryCount)
+        {
+            lg2::error(
+                "Socket {SOCK}: Failed to get MCA banks with valid status",
+                "SOCK", info);
+            break;
+        }
+
+        if ((*numbanks == 0) || (*numbanks > MAX_MCA_BANKS))
+        {
+            lg2::error("Socket {SOCKET}: Invalid MCA bank validity status. "
+                       "Retry Count: {RETRY_COUNT}",
+                       "SOCKET", info, "RETRY_COUNT", retries);
+            ret = OOB_MAILBOX_CMD_UNKNOWN;
+            usleep(1000 * 1000);
+            continue;
+        }
+    }
+
+    if ((*numbanks <= 0) || (*numbanks > MAX_MCA_BANKS))
+    {
+        mcaValidityCheck = false;
+    }
+
+    return mcaValidityCheck;
+}
+
+inline std::string getCperFilename(int num)
+{
+    return "ras-error" + std::to_string(num) + ".cper";
+}
+
+void ApmlInterfaceManager::updateCperRecord(
+    const char* file_path, uint16_t numbanks, uint16_t bytespermca,
+    uint8_t soc_num)
+{
+    FILE* file = fopen(file_path, "r+b");
+
+    if (!file)
+    {
+        perror("Failed to open file");
+        return;
+    }
+
+    // Update CPER header section
+    EFI_COMMON_ERROR_RECORD_HEADER header;
+    size_t result =
+        fread(&header, sizeof(EFI_COMMON_ERROR_RECORD_HEADER), 1, file);
+
+    if (result != 1)
+    {
+        perror("Failed to read processor error header");
+        fclose(file);
+        return;
+    }
+
+    header.Revision = CPER_RECORD_REV;
+    header.ErrorSeverity = CPER_SEV_FATAL;
+    header.ValidationBits = (CPER_VALID_PLATFORM_ID | CPER_VALID_TIMESTAMP);
+    memset(&header.PartitionID, 0, sizeof(EFI_GUID));
+    header.PlatformID.Data1 = boardId;
+    header.PartitionID = {0, 0, 0, {0}};
+    header.CreatorID = EFI_CPER_CREATOR_PSTORE;
+    header.NotificationType = EFI_CPER_NOTIFY_MCE;
+    header.RecordID = recordId++;
+    header.Flags = RESERVED;
+    header.PersistenceInfo = RESERVED;
+    header.Resv1[12] = {0};
+
+    fseek(file, 0, SEEK_SET);
+    fwrite(&header, sizeof(EFI_COMMON_ERROR_RECORD_HEADER), 1, file);
+
+    // Update CPER section descriptor
+    EFI_ERROR_SECTION_DESCRIPTOR section_descriptor;
+    for (uint16_t i = 0; i < header.SectionCount; ++i)
+    {
+        fseek(file,
+              sizeof(EFI_COMMON_ERROR_RECORD_HEADER) +
+                  i * sizeof(EFI_ERROR_SECTION_DESCRIPTOR),
+              SEEK_SET);
+        result = fread(&section_descriptor,
+                       sizeof(EFI_ERROR_SECTION_DESCRIPTOR), 1, file);
+
+        if (result != 1)
+        {
+            perror("Failed to read processor error record");
+            return;
+        }
+
+        section_descriptor.Revision =
+            ((((uint16_t)(ADDC_GEN_NUMBER_2 & INT_255) << SHIFT_4) | progId)
+             << INDEX_8) |
+            CPER_MINOR_REV;
+        section_descriptor.Resv1 = RESERVED;
+        section_descriptor.SectionFlags = CPER_PRIMARY;
+        section_descriptor.FruId = {0, 0, 0, {0}};
+        section_descriptor.Severity = CPER_SEV_FATAL;
+        memset(section_descriptor.FruString, '\0',
+               sizeof(section_descriptor.FruString));
+        section_descriptor.FruString[INDEX_0] = 'P';
+        section_descriptor.FruString[INDEX_1] = '0' + i;
+
+        if (fseek(file,
+                  sizeof(EFI_COMMON_ERROR_RECORD_HEADER) +
+                      i * sizeof(EFI_ERROR_SECTION_DESCRIPTOR),
+                  SEEK_SET) != 0)
+        {
+            perror("fseek to section offset failed");
+            fclose(file);
+            return;
+        }
+        fwrite(&section_descriptor, sizeof(EFI_ERROR_SECTION_DESCRIPTOR), 1,
+               file);
+
+        EFI_AMD_FATAL_ERROR_DATA fatal_error_data;
+
+        if (fseek(file, section_descriptor.SectionOffset, SEEK_SET) != 0)
+        {
+            perror("fseek to section offset failed");
+            fclose(file);
+            return;
+        }
+        result =
+            fread(&fatal_error_data, sizeof(EFI_AMD_FATAL_ERROR_DATA), 1, file);
+
+        if (result != 1)
+        {
+            perror("Failed to read fatal error data");
+            fclose(file);
+            return;
+        }
+
+        if (i < numOfCpu)
+        {
+            fatal_error_data.ProcError.ValidFields =
+                CPU_ID_VALID | LOCAL_APIC_ID_VALID;
+            fatal_error_data.ProcError.CpuIdInfo[INDEX_0] = cpuId[i].eax;
+            fatal_error_data.ProcError.CpuIdInfo[INDEX_2] = cpuId[i].ebx;
+            fatal_error_data.ProcError.CpuIdInfo[INDEX_4] = cpuId[i].ecx;
+            fatal_error_data.ProcError.CpuIdInfo[INDEX_6] = cpuId[i].edx;
+            fatal_error_data.ProcError.ApicId =
+                ((cpuId[i].ebx >> SHIFT_24) & INT_255);
+            fatal_error_data.MicrocodeVersion = uCode[i];
+            fatal_error_data.Ppin = ppin[i];
+        }
+
+        if (i == soc_num)
+        {
+            fatal_error_data.ProcError.ValidFields |= PROC_CONTEXT_STRUCT_VALID;
+            fatal_error_data.RegisterContextType = CTX_OOB_CRASH;
+            fatal_error_data.RegisterArraySize = numbanks * bytespermca;
+        }
+
+        fseek(file, section_descriptor.SectionOffset, SEEK_SET);
+        fwrite(&fatal_error_data, sizeof(EFI_AMD_FATAL_ERROR_DATA), 1, file);
+    }
+    fclose(file);
+}
+
+void ApmlInterfaceManager::getLastTransAddr(
+    EFI_AMD_FATAL_ERROR_DATA* fatal_error_data, uint8_t info)
+{
+    oob_status_t ret;
+    uint8_t blk_id = 0;
+    uint16_t n = 0;
+    uint16_t maxOffset32;
+    uint32_t data;
+    struct ras_df_err_chk err_chk;
+    union ras_df_err_dump df_err = {0};
+
+    ret = read_ras_df_err_validity_check(info, blk_id, &err_chk);
+
+    if (ret)
+    {
+        sd_journal_print(LOG_ERR, "Failed to read RAS DF validity check\n");
+    }
+    else
+    {
+        if (err_chk.df_block_instances != 0)
+        {
+            maxOffset32 = ((err_chk.err_log_len % BYTE_4) ? INDEX_1 : INDEX_0) +
+                          (err_chk.err_log_len >> BYTE_2);
+            while (n < err_chk.df_block_instances)
+            {
+                for (int offset = 0; offset < maxOffset32; offset++)
+                {
+                    memset(&data, 0, sizeof(data));
+                    /* Offset */
+                    df_err.input[INDEX_0] = offset * BYTE_4;
+                    /* DF block ID */
+                    df_err.input[INDEX_1] = blk_id;
+                    /* DF block ID instance */
+                    df_err.input[INDEX_2] = n;
+
+                    ret = read_ras_df_err_dump(info, df_err, &data);
+
+                    if (ret != OOB_SUCCESS)
+                    {
+                        // retry
+                        AttributeValue apmlRetry = getAttribute("ApmlRetries");
+                        int64_t* retryCount = std::get_if<int64_t>(&apmlRetry);
+                        int64_t retries = 0;
+                        while (ret != OOB_SUCCESS)
+                        {
+                            retries++;
+                            memset(&data, 0, sizeof(data));
+                            memset(&df_err, 0, sizeof(df_err));
+
+                            /* Offset */
+                            df_err.input[INDEX_0] = offset * BYTE_4;
+                            /* DF block ID */
+                            df_err.input[INDEX_1] = blk_id;
+                            /* DF block ID instance */
+                            df_err.input[INDEX_2] = n;
+
+                            ret = read_ras_df_err_dump(info, df_err, &data);
+
+                            if (retries > *retryCount)
+                            {
+                                break;
+                            }
+                            sleep(INDEX_1);
+                        }
+
+                        if (ret != OOB_SUCCESS)
+                        {
+                            data = 0;
+                        }
+                    }
+                    fatal_error_data->DfDumpData.LastTransAddr[n]
+                        .WdtData[offset] = data;
+                }
+                n++;
+            }
+        }
+    }
+}
+
+void ApmlInterfaceManager::harvestDebugLogDump(
+    EFI_AMD_FATAL_ERROR_DATA* fatal_error_data, uint8_t info, uint8_t blk_id)
+{
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+    uint16_t retries = 0;
+    uint32_t data;
+    struct ras_df_err_chk err_chk;
+    union ras_df_err_dump df_err = {0};
+
+    AttributeValue apmlRetry = getAttribute("ApmlRetries");
+    int64_t* apmlRetryCount = std::get_if<int64_t>(&apmlRetry);
+
+    while (ret != OOB_SUCCESS)
+    {
+        retries++;
+
+        ret = read_ras_df_err_validity_check(info, blk_id, &err_chk);
+
+        if (ret == OOB_SUCCESS)
+        {
+            sd_journal_print(LOG_INFO,
+                             "Socket : %d , Debug Log ID : %d , Block Instance "
+                             "= %d, Err Log Length = %d\n",
+                             info, blk_id, err_chk.df_block_instances,
+                             err_chk.err_log_len);
+            break;
+        }
+
+        if (retries > *apmlRetryCount)
+        {
+            sd_journal_print(LOG_ERR,
+                             "Socket %d: Failed to get valid debug log for Dbg "
+                             "Log ID %d . Error: %d\n",
+                             info, blk_id, ret);
+
+            /*If 5Bh command fails ,0xBAADDA7A is written thrice in the PCIE
+             * dump region*/
+            fatal_error_data->DebugLogIdData[debugLogIdOffset++] = blk_id;
+            fatal_error_data->DebugLogIdData[debugLogIdOffset++] = BAD_DATA;
+            fatal_error_data->DebugLogIdData[debugLogIdOffset++] = BAD_DATA;
+            fatal_error_data->DebugLogIdData[debugLogIdOffset++] = BAD_DATA;
+            break;
+        }
+    }
+
+    if (ret == OOB_SUCCESS)
+    {
+        if (err_chk.df_block_instances != 0)
+        {
+            uint16_t n = 0;
+            uint16_t maxOffset32;
+
+            uint32_t DbgLogIdHeader =
+                (static_cast<uint32_t>(err_chk.err_log_len) << INDEX_16) |
+                (static_cast<uint32_t>(err_chk.df_block_instances) << INDEX_8) |
+                static_cast<uint32_t>(blk_id);
+
+            if (info == SOCKET_0)
+            {
+                fatal_error_data->DebugLogIdData[debugLogIdOffset++] =
+                    DbgLogIdHeader;
+            }
+            else if (info == SOCKET_1)
+            {
+                fatal_error_data->DebugLogIdData[debugLogIdOffset++] =
+                    DbgLogIdHeader;
+            }
+
+            maxOffset32 = ((err_chk.err_log_len % BYTE_4) ? INDEX_1 : INDEX_0) +
+                          (err_chk.err_log_len >> BYTE_2);
+
+            while (n < err_chk.df_block_instances)
+            {
+                bool apmlHang = false;
+
+                for (int offset = 0; offset < maxOffset32; offset++)
+                {
+                    if (apmlHang == false)
+                    {
+                        memset(&data, 0, sizeof(data));
+                        memset(&df_err, 0, sizeof(df_err));
+
+                        /* Offset */
+                        df_err.input[INDEX_0] = offset * BYTE_4;
+                        /* DF block ID */
+                        df_err.input[INDEX_1] = blk_id;
+                        /* DF block ID instance */
+                        df_err.input[INDEX_2] = n;
+
+                        ret = read_ras_df_err_dump(info, df_err, &data);
+
+                        if (ret != OOB_SUCCESS)
+                        {
+                            // retry
+                            AttributeValue apmlRetry =
+                                getAttribute("ApmlRetries");
+                            int64_t* retryCount =
+                                std::get_if<int64_t>(&apmlRetry);
+                            int64_t retries = 0;
+                            while (ret != OOB_SUCCESS)
+                            {
+                                retries++;
+                                memset(&data, 0, sizeof(data));
+                                memset(&df_err, 0, sizeof(df_err));
+
+                                /* Offset */
+                                df_err.input[INDEX_0] = offset * BYTE_4;
+                                /* DF block ID */
+                                df_err.input[INDEX_1] = blk_id;
+                                /* DF block ID instance */
+                                df_err.input[INDEX_2] = n;
+
+                                ret = read_ras_df_err_dump(info, df_err, &data);
+
+                                if (retries > *retryCount)
+                                {
+                                    break;
+                                }
+                                sleep(INDEX_1);
+                            }
+
+                            if (ret != OOB_SUCCESS)
+                            {
+                                sd_journal_print(LOG_ERR,
+                                                 "Failed to read debug log "
+                                                 "dump for debug log ID : %d\n",
+                                                 blk_id);
+                                data = BAD_DATA;
+                                /*the Dump APML command fails in the middle
+                                  of the iterative loop, then write BAADDA7A
+                                  for the remaining iterations in the for
+                                  loop*/
+                                apmlHang = true;
+                            }
+                        }
+                    }
+
+                    if (info == SOCKET_0)
+                    {
+                        fatal_error_data->DebugLogIdData[debugLogIdOffset++] =
+                            data;
+                    }
+                    else if (info == SOCKET_1)
+                    {
+                        fatal_error_data->DebugLogIdData[debugLogIdOffset++] =
+                            data;
+                    }
+                }
+                n++;
+            }
+        }
+    }
+}
+
+void ApmlInterfaceManager::dumpContextInfo(
+    EFI_AMD_FATAL_ERROR_DATA* fatal_error_data, uint8_t info)
+{
+    if ((info == SOCKET_1) && (numOfCpu != TWO_SOCKET))
+    {
+        return;
+    }
+
+    getLastTransAddr(fatal_error_data, info);
+
+    uint8_t blk_id;
+
+    debugLogIdOffset = 0;
+
+    for (blk_id = 0; blk_id < blockId.size(); blk_id++)
+    {
+        harvestDebugLogDump(fatal_error_data, info, blockId[blk_id]);
+    }
+}
+
+bool ApmlInterfaceManager::harvestMcaDataBanks(uint8_t info, uint16_t numbanks,
+                                               uint16_t bytespermca)
+{
+    uint16_t n = 0;
+    uint16_t maxOffset32;
+    uint32_t buffer;
+    struct mca_bank mca_dump;
+    oob_status_t ret;
+    uint32_t mca_status_lo = 0;
+    uint32_t mca_status_hi = 0;
+    uint32_t mca_ipid_lo = 0;
+    uint32_t mca_ipid_hi = 0;
+    uint32_t mca_synd_lo = 0;
+    uint32_t mca_synd_hi = 0;
+
+    int synd_lo_offset = 0;
+    int synd_hi_offset = 0;
+    int ipid_lo_offset = 0;
+    int ipid_hi_offset = 0;
+    int status_lo_offset = 0;
+    int status_hi_offset = 0;
+    bool ValidSignatureID = false;
+
+    std::string cperFileName = getCperFilename(errCount);
+
+    std::string cperFilePath = RAS_DIR.data() + cperFileName;
+
+    char** sections = NULL;
+    FILE* cper_file = fopen(cperFilePath.data(), "wb");
+    uint16_t num_sections = 2;
+
+    sections = (char**)malloc(sizeof(char*) * num_sections);
+
+    for (int i = 0; i < num_sections; i++)
+    {
+        sections[i] = strdup("amd-fatalerror");
+    }
+
+    generate_cper_record(sections, num_sections, cper_file);
+
+    fclose(cper_file);
+
+    for (int i = 0; i < num_sections; i++)
+    {
+        free(sections[i]);
+    }
+
+    errCount++;
+
+    if (errCount >= MAX_ERROR_FILE)
+    {
+        /*The maximum number of error files supported is 10.
+          The counter will be rotated once it reaches max count*/
+        errCount = (errCount % MAX_ERROR_FILE);
+    }
+
+    FILE* file = fopen(INDEX_FILE.data(), "w");
+    if (file != NULL)
+    {
+        fprintf(file, "%d", errCount);
+        fclose(file);
+    }
+
+    updateCperRecord(cperFilePath.data(), numbanks, bytespermca, info);
+
+    file = fopen(cperFilePath.data(), "r+b");
+
+    // Read the header
+    EFI_COMMON_ERROR_RECORD_HEADER header;
+    size_t result =
+        fread(&header, sizeof(EFI_COMMON_ERROR_RECORD_HEADER), 1, file);
+    if (result != 1)
+    {
+        perror("Failed to read error header data");
+        fclose(file);
+        return false;
+    }
+
+    EFI_ERROR_SECTION_DESCRIPTOR section_descriptor;
+    for (uint16_t i = 0; i < header.SectionCount; ++i)
+    {
+        fseek(file,
+              sizeof(EFI_COMMON_ERROR_RECORD_HEADER) +
+                  i * sizeof(EFI_ERROR_SECTION_DESCRIPTOR),
+              SEEK_SET);
+        result = fread(&section_descriptor,
+                       sizeof(EFI_ERROR_SECTION_DESCRIPTOR), 1, file);
+
+        EFI_AMD_FATAL_ERROR_DATA fatal_error_data;
+        fseek(file, section_descriptor.SectionOffset, SEEK_SET);
+        result =
+            fread(&fatal_error_data, sizeof(EFI_AMD_FATAL_ERROR_DATA), 1, file);
+        if (result != 1)
+        {
+            perror("Failed to read fatal error data");
+            fclose(file);
+            return false;
+        }
+        AttributeValue sigIdOffsetVal = getAttribute("SigIdOffset");
+        std::vector<std::string>* sigIDOffset =
+            std::get_if<std::vector<std::string>>(&sigIdOffsetVal);
+
+        dumpContextInfo(&fatal_error_data, i);
+
+        if (i != info)
+        {
+            fseek(file, section_descriptor.SectionOffset, SEEK_SET);
+            fwrite(&fatal_error_data, sizeof(EFI_AMD_FATAL_ERROR_DATA), 1,
+                   file);
+            continue;
+        }
+
+        synd_lo_offset = std::stoul((*sigIDOffset)[INDEX_0], nullptr, BASE_16);
+        synd_hi_offset = std::stoul((*sigIDOffset)[INDEX_1], nullptr, BASE_16);
+        ipid_lo_offset = std::stoul((*sigIDOffset)[INDEX_2], nullptr, BASE_16);
+        ipid_hi_offset = std::stoul((*sigIDOffset)[INDEX_3], nullptr, BASE_16);
+        status_lo_offset =
+            std::stoul((*sigIDOffset)[INDEX_4], nullptr, BASE_16);
+        status_hi_offset =
+            std::stoul((*sigIDOffset)[INDEX_5], nullptr, BASE_16);
+
+        maxOffset32 = ((bytespermca % BYTE_4) ? INDEX_1 : INDEX_0) +
+                      (bytespermca >> BYTE_2);
+        sd_journal_print(LOG_INFO, "Number of Valid MCA bank:%d\n", numbanks);
+        sd_journal_print(LOG_INFO, "Number of 32 Bit Words:%d\n", maxOffset32);
+
+        while (n < numbanks)
+        {
+            for (int offset = 0; offset < maxOffset32; offset++)
+            {
+                memset(&buffer, 0, sizeof(buffer));
+                memset(&mca_dump, 0, sizeof(mca_dump));
+                mca_dump.index = n;
+                mca_dump.offset = offset * BYTE_4;
+
+                ret = read_bmc_ras_mca_msr_dump(info, mca_dump, &buffer);
+
+                if (ret != OOB_SUCCESS)
+                {
+                    // retry
+                    AttributeValue apmlRetry = getAttribute("ApmlRetries");
+                    int64_t* retryCount = std::get_if<int64_t>(&apmlRetry);
+                    int64_t retries = 0;
+
+                    while (ret != OOB_SUCCESS)
+                    {
+                        retries++;
+                        memset(&buffer, 0, sizeof(buffer));
+                        memset(&mca_dump, 0, sizeof(mca_dump));
+                        mca_dump.index = n;
+                        mca_dump.offset = offset * BYTE_4;
+
+                        ret =
+                            read_bmc_ras_mca_msr_dump(info, mca_dump, &buffer);
+
+                        if (retries > *retryCount)
+                        {
+                            break;
+                        }
+                        sleep(INDEX_1);
+                    }
+                    if (ret != OOB_SUCCESS)
+                    {
+                        sd_journal_print(
+                            LOG_ERR,
+                            "Socket %d : Failed to get MCA bank data "
+                            "from Bank:%d, Offset:0x%x\n",
+                            info, n, offset);
+                        fatal_error_data.CrashDumpData[n].McaData[offset] =
+                            BAD_DATA;
+                    }
+
+                } // if (ret != OOB_SUCCESS)
+                fatal_error_data.CrashDumpData[n].McaData[offset] = buffer;
+                if (mca_dump.offset == status_lo_offset)
+                {
+                    mca_status_lo = buffer;
+                }
+                if (mca_dump.offset == status_hi_offset)
+                {
+                    mca_status_hi = buffer;
+
+                    /*Bit 23 and bit 25 of MCA_STATUS_HI
+                      should be set for a valid signature ID*/
+                    if ((mca_status_hi & (INDEX_1 << SHIFT_25)) &&
+                        (mca_status_hi & (INDEX_1 << SHIFT_23)))
+                    {
+                        ValidSignatureID = true;
+                    }
+                }
+                if (mca_dump.offset == ipid_lo_offset)
+                {
+                    mca_ipid_lo = buffer;
+                }
+                if (mca_dump.offset == ipid_hi_offset)
+                {
+                    mca_ipid_hi = buffer;
+                }
+                if (mca_dump.offset == synd_lo_offset)
+                {
+                    mca_synd_lo = buffer;
+                }
+                if (mca_dump.offset == synd_hi_offset)
+                {
+                    mca_synd_hi = buffer;
+                }
+
+            } // for loop
+
+            if (ValidSignatureID == true)
+            {
+                fatal_error_data.SignatureID[INDEX_0] = SignatureID[INDEX_0] =
+                    mca_synd_lo;
+                fatal_error_data.SignatureID[INDEX_1] = SignatureID[INDEX_1] =
+                    mca_synd_hi;
+                fatal_error_data.SignatureID[INDEX_2] = SignatureID[INDEX_2] =
+                    mca_ipid_lo;
+                fatal_error_data.SignatureID[INDEX_3] = SignatureID[INDEX_3] =
+                    mca_ipid_hi;
+                fatal_error_data.SignatureID[INDEX_4] = SignatureID[INDEX_4] =
+                    mca_status_lo;
+                fatal_error_data.SignatureID[INDEX_5] = SignatureID[INDEX_5] =
+                    mca_status_hi;
+
+                fatal_error_data.ProcError.ValidFields =
+                    fatal_error_data.ProcError.ValidFields |
+                    FAILURE_SIGNATURE_ID;
+
+                ValidSignatureID = false;
+            }
+            else
+            {
+                mca_synd_lo = 0;
+                mca_synd_hi = 0;
+                mca_ipid_lo = 0;
+                mca_ipid_hi = 0;
+                mca_status_lo = 0;
+                mca_status_hi = 0;
+            }
+            n++;
+        }
+        fseek(file, section_descriptor.SectionOffset, SEEK_SET);
+        fwrite(&fatal_error_data, sizeof(EFI_AMD_FATAL_ERROR_DATA), 1, file);
+    }
+    fclose(file);
+    return true;
+}
+
+bool ApmlInterfaceManager::harvestFatalError(uint8_t info)
+{
+    std::unique_lock lock(harvest_in_progress_mtx);
+
+    uint16_t bytespermca = 0;
+    uint16_t numbanks = 0;
+    bool fchHangError = false;
+    uint8_t buf;
+    bool resetReady = false;
+
+    // Check if APML ALERT is because of RAS
+    if (read_sbrmi_ras_status(info, &buf) == OOB_SUCCESS)
+    {
+        lg2::debug("Read RAS status register. Value: {BUF}", "BUF", buf);
+
+        // check RAS Status Register
+        if (buf & INT_255)
+        {
+            lg2::error("The alert signaled is due to a RAS fatal error");
+
+            if (buf & SYS_MGMT_CTRL_ERR)
+            {
+                /*if RasStatus[reset_ctrl_err] is set in any of the processors,
+                  proceed to cold reset, regardless of the status of the other P
+                */
+
+                std::string ras_err_msg =
+                    "Fatal error detected in the control fabric. "
+                    "BMC may trigger a reset based on policy set. ";
+
+                sd_journal_send(
+                    "MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i", LOG_ERR,
+                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
+                    "REDFISH_MESSAGE_ARGS=%s", ras_err_msg.c_str(), NULL);
+
+                p0AlertProcessed = true;
+                p1AlertProcessed = true;
+            }
+            else if (buf & RESET_HANG_ERR)
+            {
+                std::string ras_err_msg =
+                    "System hang while resetting in syncflood."
+                    "Suggested next step is to do an additional manual "
+                    "immediate reset";
+
+                sd_journal_send(
+                    "MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i", LOG_ERR,
+                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
+                    "REDFISH_MESSAGE_ARGS=%s", ras_err_msg.c_str(), NULL);
+
+                fchHangError = true;
+            }
+            else if (buf & FATAL_ERROR)
+            {
+                std::string ras_err_msg = "RAS FATAL Error detected. "
+                                          "System may reset after harvesting "
+                                          "MCA data based on policy set. ";
+
+                sd_journal_send(
+                    "MESSAGE=%s", ras_err_msg.c_str(), "PRIORITY=%i", LOG_ERR,
+                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
+                    "REDFISH_MESSAGE_ARGS=%s", ras_err_msg.c_str(), NULL);
+
+                if (true ==
+                    harvestMcaValidityCheck(info, &numbanks, &bytespermca))
+                {
+                    memset(SignatureID, 0, sizeof(SignatureID));
+                    harvestMcaDataBanks(info, numbanks, bytespermca);
+                }
+            }
+
+            if (info == SOCKET_0)
+            {
+                p0AlertProcessed = true;
+            }
+
+            if (info == SOCKET_1)
+            {
+                p1AlertProcessed = true;
+            }
+
+            // Clear RAS status register
+            // 0x4c is a SB-RMI register acting as write to clear
+            // check PPR to determine whether potential bug in PPR or in
+            // implementation of SMU?
+
+            writeRegister(info, RAS_STATUS_REGISTER, buf);
+
+            if (fchHangError == true)
+            {
+                return true;
+            }
+
+            if (numOfCpu == TWO_SOCKET)
+            {
+                if ((p0AlertProcessed == true) && (p1AlertProcessed == true))
+                {
+                    resetReady = true;
+                }
+            }
+            else
+            {
+                resetReady = true;
+            }
+
+            if (resetReady == true)
+            {
+                bool recoveryAction = true;
+
+                AttributeValue aifsArmed = getAttribute("AifsArmed");
+                bool* aifsArmedFlag = std::get_if<bool>(&aifsArmed);
+
+                if ((*aifsArmedFlag == true) &&
+                    (checkSignatureIdMatch() == true))
+                {
+                    sd_journal_print(LOG_INFO, "AIFS armed for the system\n");
+
+                    std::ifstream inputFile(EVENT_SUBSCRIPTION_FILE);
+
+                    if (inputFile.is_open())
+                    {
+                        nlohmann::json jsonData;
+                        inputFile >> jsonData;
+
+                        if (jsonData.find("Subscriptions") != jsonData.end())
+                        {
+                            const auto& subscriptionsArray =
+                                jsonData["Subscriptions"];
+                            if (subscriptionsArray.is_array())
+                            {
+                                for (const auto& subscription :
+                                     subscriptionsArray)
+                                {
+                                    const auto& messageIds =
+                                        subscription["MessageIds"];
+                                    if (messageIds.is_array())
+                                    {
+                                        bool messageIdFound = std::any_of(
+                                            messageIds.begin(),
+                                            messageIds.end(),
+                                            [](const std::string& messageId) {
+                                                return messageId ==
+                                                       "AifsFailureMatch";
+                                            });
+                                        if (messageIdFound)
+                                        {
+                                            recoveryAction = false;
+
+                                            struct ras_override_delay d_in = {
+                                                0, 0, 0};
+                                            bool ack_resp;
+                                            d_in.stop_delay_counter = 1;
+                                            oob_status_t ret;
+
+                                            AttributeValue disableResetCounter =
+                                                getAttribute(
+                                                    "DisableAifsResetOnSyncfloodCounter");
+                                            bool* disableResetCntr =
+                                                std::get_if<bool>(
+                                                    &disableResetCounter);
+
+                                            if (*disableResetCntr == true)
+                                            {
+                                                sd_journal_print(
+                                                    LOG_INFO,
+                                                    "Disable Aifs Delay "
+                                                    "Reset on Syncflood "
+                                                    "counter is true. "
+                                                    "Sending Delay Reset "
+                                                    "on Syncflood override "
+                                                    "APML command\n");
+                                                ret =
+                                                    override_delay_reset_on_sync_flood(
+                                                        info, d_in, &ack_resp);
+
+                                                if (ret)
+                                                {
+                                                    sd_journal_print(
+                                                        LOG_ERR,
+                                                        "Failed to "
+                                                        "override "
+                                                        "delay value reset "
+                                                        "on "
+                                                        "syncflood "
+                                                        "Err[%d]: %s \n",
+                                                        ret,
+                                                        esmi_get_err_msg(ret));
+                                                }
+                                                else
+                                                {
+                                                    sd_journal_print(
+                                                        LOG_INFO,
+                                                        "Successfully sent "
+                                                        "Reset delay on "
+                                                        "Syncflood "
+                                                        "command\n");
+                                                }
+                                            }
+                                            sd_journal_send(
+                                                "PRIORITY=%i", LOG_INFO,
+                                                "REDFISH_MESSAGE_ID=%s",
+                                                "OpenBMC.0.1."
+                                                "AifsFailureMatch",
+                                                NULL);
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        inputFile.close();
+                    }
+                }
+                if (recoveryAction == true)
+                {
+                    rasRecoveryAction(buf);
+                }
+
+                p0AlertProcessed = false;
+                p1AlertProcessed = false;
+            }
+        }
+    }
+    else
+    {
+        lg2::debug("Nothing to Harvest. Not RAS Error");
+    }
+    return true;
+}
+
+std::vector<uint32_t>
+    ApmlInterfaceManager::hexstring_to_vector(const std::string& hexString)
+{
+    std::vector<uint32_t> result;
+
+    // Skip the "0x" prefix if present
+    size_t start =
+        (hexString.substr(INDEX_0, INDEX_2) == "0x") ? INDEX_2 : INDEX_0;
+
+    // Process the string in chunks of 8 characters (32 bits)
+    for (size_t i = start; i < hexString.length(); i += INDEX_8)
+    {
+        std::string chunk = hexString.substr(i, INDEX_8);
+        std::istringstream iss(chunk);
+        uint32_t value = 0;
+        iss >> std::hex >> value;
+        if (iss)
+        {
+            result.push_back(value);
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    // Pad the result vector with leading zeros if necessary
+    while (result.size() < 8)
+    {
+        result.insert(result.begin(), 0);
+    }
+
+    return result;
+}
+
+bool ApmlInterfaceManager::compare_with_bitwise_AND(
+    const uint32_t* Var, const std::string& hexString)
+{
+    std::vector<uint32_t> hexVector = hexstring_to_vector(hexString);
+    std::vector<uint32_t> result(8);
+
+    // Pad the Var array with leading zeros if necessary
+    std::vector<uint32_t> varVector(8);
+
+    std::copy(Var, Var + 8, varVector.begin());
+
+    // Reverse the order of elements in varVector
+    std::reverse(varVector.begin(), varVector.end());
+
+    // Perform the bitwise AND operation
+    for (size_t i = 0; i < 8; i++)
+    {
+        result[i] = varVector[i] & hexVector[i];
+    }
+
+    // Compare the result with the original hexVector
+    return std::equal(result.begin(), result.end(), hexVector.begin(),
+                      hexVector.end());
+}
+
+bool ApmlInterfaceManager::checkSignatureIdMatch()
+{
+    bool ret = false;
+
+    AttributeValue configSigId = getAttribute("AifsSignatureId");
+    std::map<std::string, std::string>* configSigIdList =
+        std::get_if<std::map<std::string, std::string>>(&configSigId);
+
+    uint32_t P0_tempVar[8];
+    std::memcpy(P0_tempVar, SignatureID, sizeof(P0_tempVar));
+
+    uint32_t P1_tempVar[8];
+    std::memcpy(P1_tempVar, SignatureID, sizeof(P1_tempVar));
+
+    for (const auto& pair : *configSigIdList)
+    {
+        bool equal = compare_with_bitwise_AND(P0_tempVar, pair.second);
+
+        if (equal == true)
+        {
+            sd_journal_print(LOG_INFO, "Signature ID matched with the config "
+                                       "file signature ID list\n");
+            ret = true;
+            break;
+        }
+
+        equal = compare_with_bitwise_AND(P1_tempVar, pair.second);
+        if (equal == true)
+        {
+            sd_journal_print(LOG_INFO, "Signature ID matched with the config "
+                                       "file signature ID list\n");
+            ret = true;
+            break;
+        }
+    }
+    return ret;
+}

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -1,0 +1,85 @@
+#include "config_manager.hpp"
+
+#include "ras.hpp"
+
+void RasConfiguration::setAttribute(AttributeName attribute,
+                                    AttributeValue value)
+{
+    nlohmann::json j;
+
+    auto configMap = rasConfigTable();
+
+    try
+    {
+        std::ifstream jsonFile(CONFIG_FILE);
+        if (!jsonFile.is_open())
+        {
+            throw std::runtime_error("Could not open JSON file");
+        }
+
+        jsonFile >> j;
+        jsonFile.close();
+
+        bool attributeFound = false;
+        for (auto& configItem : j["Configuration"])
+        {
+            auto it = configItem.find(attribute);
+            if (it != configItem.end())
+            {
+                std::visit([&](auto&& arg) { it.value()["Value"] = arg; },
+                           value);
+                attributeFound = true;
+                break;
+            }
+        }
+        if (attributeFound)
+        {
+            for (auto& [key, tuple] : configMap)
+            {
+                if (key == attribute)
+                {
+                    std::get<2>(tuple) = value;
+                    break;
+                }
+            }
+            lg2::info("Attribute updated successfully");
+        }
+        else
+        {
+            lg2::error("Attribute not found");
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Error : {ERROR}", "ERROR", e.what());
+    }
+
+    rasConfigTable(configMap);
+
+    std::ofstream jsonFileOut(CONFIG_FILE);
+    jsonFileOut << j.dump(4);
+    jsonFileOut.close();
+}
+
+AttributeValue RasConfiguration::getAttribute(AttributeName attribute)
+{
+    auto configMap = rasConfigTable();
+    AttributeValue value;
+
+    for (auto& [key, tuple] : configMap)
+    {
+        if (key == attribute)
+        {
+            value = std::get<2>(tuple);
+            break;
+        }
+    }
+    return value;
+}
+
+RasConfiguration::RasConfiguration(
+    sdbusplus::asio::object_server& objectServer,
+    std::shared_ptr<sdbusplus::asio::connection>& systemBus) :
+    sdbusplus::com::amd::RAS::server::Configuration(*systemBus, objectPath),
+    objServer(objectServer), systemBus(systemBus)
+{}

--- a/src/interface_manager_base.cpp
+++ b/src/interface_manager_base.cpp
@@ -1,0 +1,504 @@
+#include "interface_manager_base.hpp"
+
+void RasManagerBase::getNumberOfCpu()
+{
+    FILE* pf;
+    char data[COMMAND_LEN];
+    std::stringstream ss;
+
+    pf = popen(COMMAND_NUM_OF_CPU.data(), "r");
+    if (pf)
+    {
+        if (fgets(data, COMMAND_LEN, pf))
+        {
+            ss << std::hex << (std::string)data;
+            ss >> numOfCpu;
+
+            lg2::info("Number of Cpu: {CPU}", "CPU", numOfCpu);
+            cpuId = new CpuId[numOfCpu];
+
+            uCode = new uint32_t[numOfCpu];
+            std::memset(uCode, 0, numOfCpu * sizeof(uint32_t));
+
+            ppin = new uint64_t[numOfCpu];
+            std::memset(ppin, 0, numOfCpu * sizeof(uint64_t));
+
+            inventoryPath = new std::string[numOfCpu];
+
+            for (int i = 0; i < numOfCpu; i++)
+            {
+                inventoryPath[i] =
+                    "/xyz/openbmc_project/inventory/system/processor/P" +
+                    std::to_string(i);
+            }
+        }
+        else
+        {
+            throw std::runtime_error("Error reading data from the process.");
+        }
+        pclose(pf);
+    }
+    else
+    {
+        throw std::runtime_error("Error opening the process.");
+    }
+}
+
+void RasManagerBase::getBoardId()
+{
+    FILE* pf;
+    char data[COMMAND_LEN];
+    std::stringstream ss;
+
+    // Setup pipe for reading and execute to get u-boot environment
+    // variable board_id.
+    pf = popen(COMMAND_BOARD_ID.data(), "r");
+    // Error handling
+    if (pf)
+    {
+        // Get the data from the process execution
+        if (fgets(data, COMMAND_LEN, pf))
+        {
+            ss << std::hex << (std::string)data;
+            ss >> boardId;
+
+            lg2::debug("Board ID: {BOARD_ID}", "BOARD_ID", boardId);
+        }
+        // the data is now in 'data'
+        pclose(pf);
+    }
+}
+
+void RasManagerBase::createIndexFile()
+{
+    try
+    {
+        struct stat buffer;
+
+        // Create the RAS directory if it doesn't exist
+        if (stat(RAS_DIR.data(), &buffer) != 0)
+        {
+            if (mkdir(RAS_DIR.data(), 0777) != 0)
+            {
+                throw std::runtime_error(
+                    "Failed to create ras-error-logging directory");
+            }
+        }
+
+        memset(&buffer, 0, sizeof(buffer));
+
+        // Create or read the index file
+        if (stat(INDEX_FILE.data(), &buffer) != 0)
+        {
+            std::ofstream file(INDEX_FILE.data());
+            if (file.is_open())
+            {
+                file << "0";
+                file.close();
+            }
+            else
+            {
+                throw std::runtime_error("Failed to create index file");
+            }
+        }
+        else
+        {
+            std::ifstream file(INDEX_FILE);
+            if (file.is_open())
+            {
+                if (!(file >> errCount) || errCount < INDEX_0)
+                {
+                    throw std::runtime_error(
+                        "Failed to read CPER index number");
+                }
+                file.close();
+            }
+            else
+            {
+                throw std::runtime_error("Failed to read from index file");
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Exception: {ERROR}", "ERROR", e.what());
+    }
+}
+
+void RasManagerBase::createConfigFile()
+{
+    struct stat buffer;
+
+    /*Create Cdump Config file to store the system recovery*/
+    if (stat(CONFIG_FILE.data(), &buffer) != 0)
+    {
+        std::string copyCommand =
+            std::string("cp ") + SRC_CONFIG_FILE + " " + CONFIG_FILE;
+
+        int result = system(copyCommand.c_str());
+        if (result != 0)
+        {
+            lg2::error("Error copying RAS config file.");
+        }
+    }
+
+    std::ifstream jsonRead(CONFIG_FILE);
+    nlohmann::json data = nlohmann::json::parse(jsonRead);
+
+    ConfigTable configMap;
+
+    for (const auto& item : data["Configuration"])
+    {
+        AttributeType attributeType;
+        std::string key;
+        std::string description;
+        std::variant<bool, std::string, int64_t, std::vector<std::string>,
+                     std::map<std::string, std::string>>
+            value;
+        int64_t maxBoundValue = 0;
+
+        if (item.is_object() && item.size() == 1)
+        {
+            key = item.begin().key();
+
+            const auto& obj = item[key];
+            description = obj["Description"];
+            if (value.index() == 0)
+            {
+                attributeType = sdbusplus::common::com::amd::ras::
+                    Configuration::AttributeType::Boolean;
+            }
+            else if (value.index() == 1)
+            {
+                attributeType = sdbusplus::common::com::amd::ras::
+                    Configuration::AttributeType::String;
+            }
+            else if (value.index() == 2)
+            {
+                attributeType = sdbusplus::common::com::amd::ras::
+                    Configuration::AttributeType::Integer;
+            }
+            else if (value.index() == 3)
+            {
+                attributeType = sdbusplus::common::com::amd::ras::
+                    Configuration::AttributeType::ArrayOfStrings;
+            }
+            else if (value.index() == 4)
+            {
+                attributeType = sdbusplus::common::com::amd::ras::
+                    Configuration::AttributeType::KeyValueMap;
+            }
+
+            // Determine the type of the value and construct the std::variant
+            // accordingly
+            if (obj["Value"].is_boolean())
+            {
+                value = obj["Value"].get<bool>();
+            }
+            else if (obj["Value"].is_string())
+            {
+                value = obj["Value"].get<std::string>();
+            }
+            else if (obj["Value"].is_number_integer())
+            {
+                value = obj["Value"].get<int64_t>();
+            }
+            else if (obj["Value"].is_array())
+            {
+                value = obj["Value"].get<std::vector<std::string>>();
+            }
+            else if (obj["Value"].is_object())
+            {
+                value = obj["Value"].get<std::map<std::string, std::string>>();
+            }
+        }
+
+        configMap[key] =
+            std::make_tuple(attributeType, description, value, maxBoundValue);
+    }
+
+    rasConfigTable(configMap);
+
+    jsonRead.close();
+}
+
+void RasManagerBase::getMicrocodeRev()
+{
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+
+    for (int i = 0; i < numOfCpu; i++)
+    {
+        std::string microCode = getProperty<std::string>(
+            bus, INVENTORY_SERVICE.data(), inventoryPath[i].c_str(),
+            CPU_INVENTORY_INTERFACE.data(), "Microcode");
+
+        if (microCode.empty())
+        {
+            lg2::error("Failed to read ucode revision");
+        }
+        else
+        {
+            uCode[i] = std::stoul(microCode, nullptr, BASE_16);
+        }
+    }
+}
+
+void RasManagerBase::getPpinFuse()
+{
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+
+    for (int i = 0; i < numOfCpu; i++)
+    {
+        std::string Ppin = getProperty<std::string>(
+            bus, INVENTORY_SERVICE.data(), inventoryPath[i].c_str(),
+            CPU_INVENTORY_INTERFACE.data(), "PPIN");
+
+        if (Ppin.empty())
+        {
+            lg2::error("Failed to read ppin");
+        }
+        else
+        {
+            ppin[i] = std::stoul(Ppin, nullptr, BASE_16);
+        }
+    }
+}
+
+template <typename T>
+T RasManagerBase::getProperty(sdbusplus::bus::bus& bus, const char* service,
+                              const char* path, const char* interface,
+                              const char* propertyName)
+{
+    auto method = bus.new_method_call(service, path,
+                                      "org.freedesktop.DBus.Properties", "Get");
+    method.append(interface, propertyName);
+    std::variant<T> value{};
+    try
+    {
+        auto reply = bus.call(method);
+        reply.read(value);
+    }
+    catch (const sdbusplus::exception::SdBusError& ex)
+    {
+        lg2::info("GetProperty call failed");
+    }
+    return std::get<T>(value);
+}
+
+void RasManagerBase::requestGPIOEvents(
+    const std::string& name, const std::function<void()>& handler,
+    gpiod::line& gpioLine,
+    boost::asio::posix::stream_descriptor& gpioEventDescriptor)
+{
+    try
+    {
+        // Find the GPIO line
+        gpioLine = gpiod::find_line(name);
+        if (!gpioLine)
+        {
+            throw std::runtime_error("Failed to find GPIO line: " + name);
+        }
+
+        // Request events for the GPIO line
+        gpioLine.request(
+            {"RAS", gpiod::line_request::EVENT_BOTH_EDGES, INDEX_0});
+
+        // Get the GPIO line file descriptor
+        int gpioLineFd = gpioLine.event_get_fd();
+        if (gpioLineFd < 0)
+        {
+            throw std::runtime_error(
+                "Failed to get GPIO line file descriptor: " + name);
+        }
+
+        // Assign the file descriptor to gpioEventDescriptor
+        gpioEventDescriptor.assign(gpioLineFd);
+
+        // Set up asynchronous wait for events
+        gpioEventDescriptor.async_wait(
+            boost::asio::posix::stream_descriptor::wait_read,
+            [&name, handler](const boost::system::error_code ec) {
+                if (ec)
+                {
+                    throw std::runtime_error(
+                        "Error in fd handler: " + ec.message());
+                }
+                handler();
+            });
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Exception: {ERROR}", "ERROR", e.what());
+    }
+}
+
+void RasManagerBase::p0AlertEventHandler()
+{
+    gpiod::line_event gpioLineEvent = p0_apmlAlertLine.event_read();
+
+    if (gpioLineEvent.event_type == gpiod::line_event::FALLING_EDGE)
+    {
+        lg2::debug("Falling Edge: P0 APML Alert received");
+        harvestFatalError(SOCKET_0);
+    }
+    p0_apmlAlertEvent.async_wait(
+        boost::asio::posix::stream_descriptor::wait_read,
+        [this](const boost::system::error_code ec) {
+            if (ec)
+            {
+                lg2::error("P0 APML alert handler error: {ERROR}", "ERROR",
+                           ec.message().c_str());
+                return;
+            }
+            p0AlertEventHandler();
+        });
+}
+
+void RasManagerBase::p1AlertEventHandler()
+{
+    gpiod::line_event gpioLineEvent = p1_apmlAlertLine.event_read();
+
+    if (gpioLineEvent.event_type == gpiod::line_event::FALLING_EDGE)
+    {
+        lg2::debug("Falling Edge: P1 APML Alert received");
+        harvestFatalError(SOCKET_1);
+    }
+    p1_apmlAlertEvent.async_wait(
+        boost::asio::posix::stream_descriptor::wait_read,
+        [this](const boost::system::error_code ec) {
+            if (ec)
+            {
+                lg2::error("P1 APML alert handler error: {ERROR}", "ERROR",
+                           ec.message().c_str());
+                return;
+            }
+            p1AlertEventHandler();
+        });
+}
+
+void RasManagerBase::rasRecoveryAction(uint8_t buf)
+{
+    oob_status_t ret;
+    uint32_t ack_resp = 0;
+
+    AttributeValue SystemRecoveryVal = getAttribute("SystemRecovery");
+    std::string* SystemRecovery = std::get_if<std::string>(&SystemRecoveryVal);
+
+    if (*SystemRecovery == "WARM_RESET")
+    {
+        if ((buf & SYS_MGMT_CTRL_ERR))
+        {
+            triggerColdReset();
+        }
+        else
+        {
+            /* In a 2P config, it is recommended to only send this command to P0
+            Hence, sending the Signal only to socket 0*/
+            ret = reset_on_sync_flood(INDEX_0, &ack_resp);
+            if (ret)
+            {
+                lg2::error("Failed to request reset after sync flood");
+            }
+            else
+            {
+                lg2::info("Warm reset triggered");
+            }
+        }
+    }
+    else if (*SystemRecovery == "COLD_RESET")
+    {
+        triggerColdReset();
+    }
+    else if (*SystemRecovery == "NO_RESET")
+    {
+        lg2::info("NO RESET triggered");
+    }
+    else
+    {
+        lg2::error("CdumpResetPolicy is not valid");
+    }
+}
+
+void RasManagerBase::triggerRsmrstReset()
+{
+    boost::system::error_code ec;
+    boost::asio::io_context io_conn;
+    auto conn = std::make_shared<sdbusplus::asio::connection>(io_conn);
+
+    conn->async_method_call(
+        [](boost::system::error_code ec) {
+            if (ec)
+            {
+                sd_journal_print(
+                    LOG_ERR, "Failed to trigger cold reset of the system\n");
+            }
+        },
+        "xyz.openbmc_project.State.Host",
+        "/xyz/openbmc_project/control/host0/SOCReset",
+        "xyz.openbmc_project.Control.Host.SOCReset", "SOCReset");
+
+    sleep(1);
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+    std::string CurrentHostState = getProperty<std::string>(
+        bus, "xyz.openbmc_project.State.Host",
+        "/xyz/openbmc_project/state/host0", "xyz.openbmc_project.State.Host",
+        "CurrentHostState");
+
+    if (CurrentHostState.compare(
+            "xyz.openbmc_project.State.Host.HostState.Off") == 0)
+    {
+        std::string command = "xyz.openbmc_project.State.Host.Transition.On";
+        requestHostTransition(command);
+    }
+}
+
+void RasManagerBase::requestHostTransition(std::string command)
+{
+    boost::system::error_code ec;
+    boost::asio::io_context io;
+    auto conn = std::make_shared<sdbusplus::asio::connection>(io);
+
+    conn->async_method_call(
+        [](boost::system::error_code ec) {
+            if (ec)
+            {
+                sd_journal_print(
+                    LOG_ERR, "Failed to trigger cold reset of the system\n");
+            }
+        },
+        "xyz.openbmc_project.State.Host", "/xyz/openbmc_project/state/host0",
+        "org.freedesktop.DBus.Properties", "Set",
+        "xyz.openbmc_project.State.Host", "RequestedHostTransition",
+        std::variant<std::string>{command});
+}
+
+void RasManagerBase::triggerSysReset()
+{
+    std::string command = "xyz.openbmc_project.State.Host.Transition.Reboot";
+
+    requestHostTransition(command);
+}
+
+void RasManagerBase::triggerColdReset()
+{
+    AttributeValue ResetSignalVal = getAttribute("ResetSignal");
+    std::string* ResetSignal = std::get_if<std::string>(&ResetSignalVal);
+
+    if (*ResetSignal == "RSMRST")
+    {
+        sd_journal_print(LOG_INFO, "RSMRST RESET triggered\n");
+        triggerRsmrstReset();
+    }
+    else if (*ResetSignal == "SYS_RST")
+    {
+        sd_journal_print(LOG_INFO, "SYS RESET triggered\n");
+        triggerSysReset();
+    }
+}
+RasManagerBase::~RasManagerBase()
+{
+    delete[] cpuId;
+    delete[] uCode;
+    delete[] ppin;
+    delete[] inventoryPath;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,42 @@
+/**
+ * A user-space application that monitors APML_ALERT_L gpio line
+ * for fatal error detecttion and creates CPER record
+ *
+ * Author: abinaya.dhandapani@amd.com
+ **/
+
+#include "apml_manager.hpp"
+
+#include <iostream>
+
+int main()
+{
+    boost::asio::io_service io;
+
+    auto systemBus = std::make_shared<sdbusplus::asio::connection>(io);
+
+    systemBus->request_name(DBUS_SERVICE_NAME.data());
+
+    sdbusplus::asio::object_server objectServer(systemBus);
+
+    RasManagerBase* rasManagerObj;
+
+#ifdef APML
+    rasManagerObj = new ApmlInterfaceManager(objectServer, systemBus, io);
+
+    rasManagerObj->init();
+
+    rasManagerObj->configure();
+
+#endif
+    /* TODO: Enable PLDM : Create rasManagerObj pointer
+     * poiting to PLDM derived class object if PLDM is enabled in meson*/
+
+    io.run();
+
+    if (rasManagerObj != NULL)
+    {
+        delete rasManagerObj;
+    }
+    return 0;
+}


### PR DESCRIPTION
- The application monitors APML_ALERT_L and upon assertion of the GPIO PIN , BMC collects
the MCA MSR dump and creates CPER record. 

- Depending on the user configuration , the application initiates system recovery.

- ras-config.json contains the configuration parameters with default value. User can get and set
the conifguration parameters using d-bus calls to the methods getAttribute and setAttribute.

- The application also contains harvesting of last transaction address , debug log ID's.

- The application is intended to be supported for 1P and 2P platforms. 