### PR TITLE
Clear RMI_ALERTSTATUS register during ALERT_L assertion

### DIFF
--- a/inc/cper.hpp
+++ b/inc/cper.hpp
@@ -27,6 +27,7 @@
 #define ENABLE_BIT (1)
 #define CHIP_SEL_NUM_POS (21)
 #define NIBBLE_MASK (0xF)
+#define BITMASK_FF (0xFF)
 
 /*
  * CPER section descriptor revision, used in revision field in struct

--- a/inc/ras.hpp
+++ b/inc/ras.hpp
@@ -140,6 +140,7 @@ template <typename T>
 void dump_proc_error_info_section(const std::shared_ptr<T>&, uint8_t, uint16_t,
                                   uint64_t*, uint32_t);
 void exportCrashdumpToDBus(int, const ERROR_TIME_STAMP&);
+oob_status_t read_register(uint8_t , uint32_t, uint8_t* );
 void write_register(uint8_t, uint32_t, uint32_t);
 template <typename T>
 T getProperty(sdbusplus::bus::bus& bus, const char* service, const char* path,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -526,14 +526,14 @@ void clearSbrmiAlertMask()
 
             if (ret == OOB_SUCCESS)
             {
-                if ((buffer & MASK_0X0F) != 0)
+                if ((buffer & BITMASK_FF) != 0)
                 {
                     sd_journal_print(
                         LOG_INFO,
                         "Socket%d: MCE Stat of SBRMIx[0x%x] is set to 0x%x\n",
                         socNum, alert_status[i], buffer);
 
-                    buffer = buffer & INT_255;
+                    buffer = buffer & BITMASK_FF;
                     write_register(socNum, alert_status[i],
                                    static_cast<uint32_t>(buffer));
                 }


### PR DESCRIPTION
1. Add redfish event log if the APML_ALERT_L is asserted due to MCE error.

2. clear the RMI_ALERTSTATUS [0x10 ~ 0x1f] [0x50 ~ 0x5f] at the time of APML_ALERT_L assertion in addition to clearing the RMI_ALERTSTATUS register during initialization.

3. MCE status register occupies 8 bits from C0 as it supports 256 cores. Clear 8 bits of MCE Status register if set.

4.  During a syncflood ( in certain type of errors such as CXL protocol errors) if BMC_RAS_MCA_VALIDITY_CHECK()
    returns 0 , do not exit the crashdump flow. Continue harvesting the additional debug log ID dumps and create
    the CPER record.

