### PR TITLE
Fix: Corrected data type of MaxBoundLimit

### DIFF
--- a/config/ras_config.json
+++ b/config/ras_config.json
@@ -4,7 +4,7 @@
             "ApmlRetries": {
                 "Description": "Number of APML retry count",
                 "Value": 10,
-                "MaxBoundLimit": "50"
+                "MaxBoundLimit": 50
             }
         },
         {


### PR DESCRIPTION
Changed "MaxBoundLimit" from a string to an integer to ensure proper type handling in configuration parsing.

Tested: Verified in Congo platform with Venice SOC