### PR TITLE
amd-ras: Modify to call apml alert APIs to monitor RAS alerts

### DIFF
--- a/config/amd_ras_gpio_config.json
+++ b/config/amd_ras_gpio_config.json
@@ -1,3 +1,14 @@
 {
-    "GPIO_ALERT_LINES": ["P0_I3C_APML_ALERT_L", "P1_I3C_APML_ALERT_L"]
+    "Alert_Config": [
+        {
+            "AlertHandle": {
+                "Description": "Modes to handle RAS alert",
+                "Value": "UEVENT",
+                "ValidOptions": ["UEVENT", "GPIO"]
+            }
+        },
+        {
+            "GPIO_ALERT_LINES": ["P0_I3C_APML_ALERT_L", "P1_I3C_APML_ALERT_L"]
+        }
+    ]
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,13 @@ int main()
 #endif
 
     io.run();
+#ifdef APML
+    auto* apmlMgr = dynamic_cast<amd::ras::apml::Manager*>(errorMgr);
+    if (apmlMgr && apmlMgr->getAlertHandleMode() == "UEVENT")
+    {
+        apmlMgr->releaseUdevReSrc();
+    }
+#endif
 
     return 0;
 }


### PR DESCRIPTION
-Update apml_manager to call APML APIs to register for uevent from apml alertl driver.
- APML library  provides API to register, monitor and unregister for the alerts on RAS and temperature from apml alertl driver.
- The alertEventHandler can handle alerts from socket 0 and 1. 
- On alerts, the monitor_ras_alert returns socket & die-id and alertl source information.
