### PR TITLE
Fix objectMapper detection of dynamic paths

### DIFF
--- a/include/crashdump_manager.hpp
+++ b/include/crashdump_manager.hpp
@@ -14,7 +14,7 @@ using CrashdumpBase = sdbusplus::com::amd::server::Crashdump;
  * into the D-Bus interface and overrides the getAttribute()
  * and setAttribute() of the RAS configuration interface.
  */
-class CrashdumpInterface : public CrashdumpBase
+class CrashdumpInterface : virtual public sdbusplus::server::object_t<CrashdumpBase>
 {
   public:
     CrashdumpInterface() = delete;

--- a/src/crashdump_manager.cpp
+++ b/src/crashdump_manager.cpp
@@ -4,7 +4,8 @@ CrashdumpInterface::CrashdumpInterface(
     sdbusplus::asio::object_server& objectServer,
     std::shared_ptr<sdbusplus::asio::connection>& systemBus,
     const std::string& crashdumpObjPath) :
-    sdbusplus::com::amd::server::Crashdump(*systemBus, crashdumpObjPath.data()),
+    sdbusplus::server::object_t<CrashdumpBase>(*systemBus,
+                                               crashdumpObjPath.data()),
     objServer(objectServer), systemBus(systemBus),
     crashdumpObjPath(crashdumpObjPath)
 {}


### PR DESCRIPTION
Changed CrashdumpInterface to inherit from
sdbusplus::server::object_t<CrashdumpBase> using virtual inheritance. This ensures objectMapper correctly detects dynamically created object paths, which was previously failing.

Tested fields: Verified in Congo platform.