### PR TITLE
Bug fixes in the crashdump event flow

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -1589,7 +1589,7 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                 }
                 harvestMcaDataBanks(socNum, errorCheck);
             }
-            else if (buf & nonMcaShutdownError)
+            else if (buf & shutdownError)
             {
                 std::string rasErrMsg =
                     "Non MCA Shutdown error detected in the system";

--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -507,6 +507,9 @@ void dumpHeader(const std::shared_ptr<PtrType>& data, uint16_t sectionCount,
             sizeof(EFI_COMMON_ERROR_RECORD_HEADER) +
             (sizeof(EFI_ERROR_SECTION_DESCRIPTOR) * sectionCount) +
             (sizeof(EFI_AMD_FATAL_ERROR_DATA) * sectionCount);
+
+            memcpy(&data->Header.NotificationType,
+                   &gEfiEventNotificationTypeMceGuid, sizeof(EFI_GUID));
     }
 
     /*TimeStamp when OOB controller received the event*/


### PR DESCRIPTION
Updated the logic to correctly detect Non-MCA shutdown errors by checking bit 6 of the RAS Status Register, instead of the previously incorrect check on bit 0.

Set the NotificationType in the event header to gEfiEventNotificationTypeMceGuid, enabling proper handling of fatal error notifications