### PR TITLE
Add DeleteAll interface and implement CPER file cleanup

### DIFF
--- a/include/config_manager.hpp
+++ b/include/config_manager.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "xyz/openbmc_project/Collection/DeleteAll/server.hpp"
+
 #include <com/amd/RAS/Configuration/common.hpp>
 #include <com/amd/RAS/Configuration/server.hpp>
 #include <sdbusplus/asio/object_server.hpp>
@@ -16,8 +18,9 @@ namespace config
 static constexpr auto service = "com.amd.RAS";
 static constexpr auto objectPath = "/com/amd/RAS";
 
-using Configuration = sdbusplus::com::amd::RAS::server::Configuration;
-
+using ConfigIface = sdbusplus::server::object_t<
+    sdbusplus::com::amd::RAS::server::Configuration,
+    sdbusplus::xyz::openbmc_project::Collection::server::DeleteAll>;
 /**
  * @brief Manager class which adds the RAS configuration
  * parameter values to the D-Bus interface.
@@ -26,7 +29,7 @@ using Configuration = sdbusplus::com::amd::RAS::server::Configuration;
  * into the D-Bus interface and overrides the getAttribute()
  * and setAttribute() of the RAS configuration interface.
  */
-class Manager : public Configuration
+class Manager : public amd::ras::config::ConfigIface
 {
   public:
     using AttributeName = std::string;
@@ -92,6 +95,10 @@ class Manager : public Configuration
      * std::runtime_error exception.
      */
     void updateConfigToDbus();
+
+    /** @brief  Erase all entries
+     */
+    void deleteAll() override;
 
   private:
     sdbusplus::asio::object_server& objServer;

--- a/include/utils/cper.hpp
+++ b/include/utils/cper.hpp
@@ -76,6 +76,8 @@ void exportToDBus(size_t, const EFI_ERROR_TIME_STAMP&,
                   std::shared_ptr<sdbusplus::asio::connection>&,
                   const std::string&);
 
+void deleteCrashdumpInterface();
+
 /** @brief Creates D-Bus records for existing crashdumps.
  *
  *  @details Checks for existing crashdump files in the RAS directory, reads

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -1,6 +1,6 @@
 #include "config_manager.hpp"
-#include "utils/cper.hpp"
 
+#include "utils/cper.hpp"
 #include "xyz/openbmc_project/Common/File/error.hpp"
 #include "xyz/openbmc_project/Common/error.hpp"
 
@@ -302,6 +302,33 @@ void Manager::updateConfigToDbus()
     rasConfigTable(configMap);
 
     jsonRead.close();
+}
+
+void Manager::deleteAll()
+{
+    for (const auto& entry : std::filesystem::directory_iterator(RAS_DIR))
+    {
+        std::string filename = entry.path().filename().string();
+
+        if (node == "1" || node == "2")
+        {
+            if (filename.starts_with("node" + node) &&
+                filename.starts_with("node" + node))
+            {
+                lg2::info("{FILE} deleted", "FILE", filename);
+                fs::remove(entry.path());
+            }
+        }
+        else
+        {
+            if (filename.ends_with(".cper"))
+            {
+                lg2::info("{FILE} deleted", "FILE", filename);
+                fs::remove(entry.path());
+            }
+        }
+    }
+    amd::ras::util::cper::deleteCrashdumpInterface();
 }
 
 Manager::Manager(sdbusplus::asio::object_server& objectServer,

--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -265,6 +265,11 @@ void createRecord(sdbusplus::asio::object_server& objectServer,
     }
 }
 
+void deleteCrashdumpInterface()
+{
+    managers.clear();
+}
+
 void dumpProcessorError(const std::shared_ptr<FatalCperRecord>& fatalPtr,
                         uint8_t socNum, const std::unique_ptr<CpuId[]>& cpuId,
                         std::vector<size_t>& socIndex, uint16_t numbanks)


### PR DESCRIPTION
- Integrated DeleteAll D-Bus interface.
- Implemented deleteAll() to remove node-specific and .cper files.
- Cleared crashdump D-Bus interfaces if CPER files are deleted.

Tested fields: Verified in congo system