### PR TITLE
Prioritize rasStatus bit handling and Correct index file naming

### DIFF
--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -764,7 +764,7 @@ void createFile(const std::shared_ptr<PtrType>& data,
         errCount = (errCount % maxCperCount);
     }
 
-    std::string indexFile = std::string(INDEX_FILE) + "/" + node;
+    std::string indexFile = std::string(INDEX_FILE) + "_" + node;
 
     file = fopen(indexFile.c_str(), "w");
     if (file != nullptr)


### PR DESCRIPTION
 Updated the RAS service to correctly handle cases where multiple rasStatus bits are set simultaneously.
 
Previously, the index file path used a directory separator ("/") which caused incorrect file naming and update failures.
This change replaces it with an underscore ("_") to ensure the index file is created and accessed correctly.

