### PR TITLE
Add Break Event Handling in CPER Context Dump

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -60,6 +60,7 @@ constexpr size_t offHi2 = 12;
 constexpr size_t copySize = 4;
 constexpr size_t crashdump = 1;
 constexpr size_t shutdown = 2;
+constexpr size_t breakEvent = 3;
 constexpr size_t index28 = 28;
 constexpr size_t blockId25 = 25;
 
@@ -1348,7 +1349,7 @@ void Manager::harvestBreakEvent(uint8_t socNum)
                                               &errorSeverity, progId);
     amd::ras::util::cper::dumpProcessorError(rcd, socNum, cpuId, socIndex, 0);
     amd::ras::util::cper::dumpContext(rcd, 0, 0, socNum, ppin, uCode,
-                                      crashdump);
+                                      breakEvent);
     memcpy(rcd->SectionDescriptor[socNum].FruString, &socNum, sizeof(socNum));
 
     for (int offset : std::views::iota(0, regCount))

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -74,7 +74,8 @@ void writeOobRegister(uint8_t info, uint32_t reg, uint32_t value)
         lg2::error("Failed to write register: {REG}", "REG", lg2::hex, reg);
         return;
     }
-    lg2::debug("Write to register {REGISTER} is successful", "REGISTER", reg);
+    lg2::debug("Write to register {REGISTER} is successful", "REGISTER",
+               lg2::hex, reg);
 }
 
 oob_status_t readOobRegister(uint8_t info, uint32_t reg, uint8_t* value)
@@ -599,7 +600,7 @@ void Manager::clearSbrmiAlertMask(uint8_t socNum)
     }
 
     lg2::debug("Write to register {REGISTER} is successful", "REGISTER",
-               sbrmiControlRegister);
+               lg2::hex, sbrmiControlRegister);
 
     for (size_t i = 0; i < sizeof(alert_status); i++)
     {
@@ -1669,7 +1670,7 @@ bool Manager::decodeInterrupt(uint8_t socNum)
     if (read_sbrmi_status(socNum, &buf) == OOB_SUCCESS)
     {
         lg2::debug("Socket {SOC}: Read status register. Value: 0x{BUF}", "SOC",
-                   socNum, "BUF", buf);
+                   socNum, "BUF", lg2::hex, buf);
 
         /*Check if Alert Status bit is set and clear AlertSts*/
         if (buf & 0x1)
@@ -1722,7 +1723,8 @@ bool Manager::decodeInterrupt(uint8_t socNum)
     // Check if APML ALERT is because of RAS
     if (read_sbrmi_ras_status(socNum, &buf) == OOB_SUCCESS)
     {
-        lg2::debug("Read RAS status register. Value: {BUF}", "BUF", buf);
+        lg2::debug("Read RAS status register. Value: {BUF}", "BUF", lg2::hex,
+                   buf);
 
         // check RAS Status Register
         if (buf & 0xFF)

--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -691,7 +691,6 @@ void createFile(const std::shared_ptr<PtrType>& data,
     }
 
     std::string cperFilePath = RAS_DIR + cperFileName;
-    lg2::info("Saving CPER file to {CPER}", "CPER", cperFilePath);
 
     file = fopen(cperFilePath.c_str(), "w");
 
@@ -714,7 +713,13 @@ void createFile(const std::shared_ptr<PtrType>& data,
             fwrite(procPtr->McaErrorInfo,
                    sizeof(RUNTIME_ERROR_INFO) * sectionCount, singleBit, file);
 
-            // exportCrashdumpToDBus(err_count, ProcPtr->Header.TimeStamp);
+            std::string rasErrMsg = "Generated runtime CPER file : ";
+            rasErrMsg.append(cperFilePath);
+
+            sd_journal_send("MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i",
+                            LOG_ERR, "REDFISH_MESSAGE_ID=%s",
+                            "OpenBMC.0.1.AtScaleDebugConnected",
+                            "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
         }
     }
     else if (errorType == fatalErr)
@@ -732,9 +737,8 @@ void createFile(const std::shared_ptr<PtrType>& data,
                    sizeof(EFI_AMD_FATAL_ERROR_DATA) * sectionCount, singleBit,
                    file);
 
-            // exportCrashdumpToDBus(err_count, FatalPtr->Header.TimeStamp);
-
-            std::string rasErrMsg = "CPER file generated for fatal error";
+            std::string rasErrMsg = "Generated Fatal CPER file : ";
+            rasErrMsg.append(cperFilePath);
 
             sd_journal_send("MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i",
                             LOG_ERR, "REDFISH_MESSAGE_ID=%s",
@@ -751,7 +755,14 @@ void createFile(const std::shared_ptr<PtrType>& data,
                file);
         fwrite(pciePtr->PcieErrorData,
                sizeof(EFI_AMD_PCIE_ERROR_DATA) * sectionCount, singleBit, file);
-        // exportCrashdumpToDBus(err_count, PciePtr->Header.TimeStamp);
+
+        std::string rasErrMsg = "Generated runtime CPER file : ";
+        rasErrMsg.append(cperFilePath);
+
+        sd_journal_send("MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
+                        "REDFISH_MESSAGE_ID=%s",
+                        "OpenBMC.0.1.AtScaleDebugConnected",
+                        "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
     }
     fclose(file);
 


### PR DESCRIPTION
Introduced a new constant breakEvent for identifying Break Event type.
Updated dumpContext() call to use breakEvent instead of crashdump for
Break Event harvesting.

Tests:
Trigger a Break Event and confirm that CPER context section reflects the
correct event type (breakEvent).