### PR TITLE
Fix break event bank handling in harvestBreakEvent

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -61,6 +61,7 @@ constexpr size_t copySize = 4;
 constexpr size_t crashdump = 1;
 constexpr size_t shutdown = 2;
 constexpr size_t breakEvent = 3;
+constexpr uint16_t breakEventBanks = 1;
 constexpr size_t index28 = 28;
 constexpr size_t blockId25 = 25;
 
@@ -1347,9 +1348,10 @@ void Manager::harvestBreakEvent(uint8_t socNum)
                                      boardId, recordId);
     amd::ras::util::cper::dumpErrorDescriptor(rcd, sectionCount, fatalErr,
                                               &errorSeverity, progId);
-    amd::ras::util::cper::dumpProcessorError(rcd, socNum, cpuId, socIndex, 0);
-    amd::ras::util::cper::dumpContext(rcd, 0, 0, socNum, ppin, uCode,
-                                      breakEvent);
+    amd::ras::util::cper::dumpProcessorError(rcd, socNum, cpuId, socIndex,
+                                             breakEventBanks);
+    amd::ras::util::cper::dumpContext(rcd, breakEventBanks, 0, socNum, ppin,
+                                      uCode, breakEvent);
     memcpy(rcd->SectionDescriptor[socNum].FruString, &socNum, sizeof(socNum));
 
     for (int offset : std::views::iota(0, regCount))


### PR DESCRIPTION
Added breakEventBanks constant and updated dumpProcessorError() and dumpContext() calls to use the correct bank value instead of hardcoded 0 for break events.

Test:
valid bits(0x0103) and register context type(0x03) are updated properly.