### PR TITLE
move index update to new helper and fix D-Bus index

### DIFF
--- a/include/utils/cper.hpp
+++ b/include/utils/cper.hpp
@@ -55,6 +55,18 @@ std::string findCperFilename(size_t);
  */
 void createIndexFile(size_t&, const std::string&);
 
+/** @brief Updates the index file with the incremented error count.
+ *
+ *  @details Increments the error count and wraps it around when it reaches
+ * the maximum CPER count. Writes the updated error count to the index file
+ * in a thread-safe manner using a mutex lock.
+ *
+ *  @param[in,out] errCount - Reference to the error count to be incremented
+ * and written to the index file.
+ *  @param[in] node - host node number to determine single or multi host.
+ */
+void updateIndexFile(size_t& errCount, const std::string& node);
+
 /** @brief Exports crashdump data to D-Bus.
  *
  *  @details Creates a D-Bus instance for crashdump data using the provided

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -883,9 +883,9 @@ void Manager::harvestRuntimeErrors(uint8_t errorPollingType,
         amd::ras::util::cper::createFile(mcaPtr, runtimeMcaErr, sectionCount,
                                          errCount, node);
 
-        amd::ras::util::cper::exportToDBus(errCount - 1,
-                                           mcaPtr->Header.TimeStamp,
+        amd::ras::util::cper::exportToDBus(errCount, mcaPtr->Header.TimeStamp,
                                            objectServer, systemBus, node);
+        amd::ras::util::cper::updateIndexFile(errCount, node);
 
         if (mcaPtr->SectionDescriptor != nullptr)
         {
@@ -945,9 +945,9 @@ void Manager::harvestRuntimeErrors(uint8_t errorPollingType,
         amd::ras::util::cper::createFile(dramPtr, runtimeDramErr, sectionCount,
                                          errCount, node);
 
-        amd::ras::util::cper::exportToDBus(errCount - 1,
-                                           dramPtr->Header.TimeStamp,
+        amd::ras::util::cper::exportToDBus(errCount, dramPtr->Header.TimeStamp,
                                            objectServer, systemBus, node);
+        amd::ras::util::cper::updateIndexFile(errCount, node);
 
         if (dramPtr->SectionDescriptor != nullptr)
         {
@@ -1001,9 +1001,9 @@ void Manager::harvestRuntimeErrors(uint8_t errorPollingType,
         amd::ras::util::cper::createFile(pciePtr, runtimePcieErr, sectionCount,
                                          errCount, node);
 
-        amd::ras::util::cper::exportToDBus(errCount - 1,
-                                           pciePtr->Header.TimeStamp,
+        amd::ras::util::cper::exportToDBus(errCount, pciePtr->Header.TimeStamp,
                                            objectServer, systemBus, node);
+        amd::ras::util::cper::updateIndexFile(errCount, node);
 
         if (pciePtr->SectionDescriptor != nullptr)
         {
@@ -1945,8 +1945,9 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
     {
         amd::ras::util::cper::createFile(rcd, fatalErr, 2, errCount, node);
 
-        amd::ras::util::cper::exportToDBus(errCount - 1, rcd->Header.TimeStamp,
+        amd::ras::util::cper::exportToDBus(errCount, rcd->Header.TimeStamp,
                                            objectServer, systemBus, node);
+        amd::ras::util::cper::updateIndexFile(errCount, node);
 
         bool recoveryAction = true;
 
@@ -2309,8 +2310,9 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                                                  node);
 
                 amd::ras::util::cper::exportToDBus(
-                    errCount - 1, rcd->Header.TimeStamp, objectServer,
-                    systemBus, node);
+                    errCount, rcd->Header.TimeStamp, objectServer, systemBus,
+                    node);
+                amd::ras::util::cper::updateIndexFile(errCount, node);
 
                 bool recoveryAction = true;
 

--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -8,6 +8,7 @@
 #include <phosphor-logging/lg2.hpp>
 #include <phosphor-logging/log.hpp>
 
+#include <filesystem>
 #include <regex>
 
 namespace amd
@@ -79,6 +80,8 @@ EFI_GUID gEfiEventNotificationTypeMceGuid = {
     0x919C,
     0x4cc5,
     {0xBA, 0x88, 0x65, 0xAB, 0xE1, 0x49, 0x13, 0xBB}};
+
+std::mutex indexFileMtx;
 
 std::map<int, std::unique_ptr<CrashdumpInterface>> managers;
 
@@ -631,14 +634,38 @@ void dumpErrorDescriptor(const std::shared_ptr<PtrType>& data,
     }
 }
 
+void updateIndexFile(size_t& errCount, const std::string& node)
+{
+    errCount++;
+
+    if (errCount >= maxCperCount)
+    {
+        /*The maximum number of error files supported is 10.
+          The counter will be rotated once it reaches max count*/
+        errCount = (errCount % maxCperCount);
+    }
+
+    // Lock the critical section (RAII)
+    std::scoped_lock lk(indexFileMtx);
+
+    // Build path
+    const std::filesystem::path indexPath = std::filesystem::path(INDEX_FILE) +=
+        "_" + std::string(node);
+
+    // Overwrite the file with the current count
+    std::ofstream out(indexPath, std::ios::trunc);
+    if (!out)
+    {
+        return;
+    }
+    out << errCount;
+}
+
 template <typename PtrType>
 void createFile(const std::shared_ptr<PtrType>& data,
                 const std::string_view& errorType, uint16_t sectionCount,
                 size_t& errCount, const std::string& node)
 {
-    static std::mutex index_file_mtx;
-    std::unique_lock lock(index_file_mtx);
-
     std::string cperFileName;
     FILE* file;
 
@@ -769,26 +796,6 @@ void createFile(const std::shared_ptr<PtrType>& data,
         }
     }
     fclose(file);
-
-    errCount++;
-
-    if (errCount >= maxCperCount)
-    {
-        /*The maximum number of error files supported is 10.
-          The counter will be rotated once it reaches max count*/
-        errCount = (errCount % maxCperCount);
-    }
-
-    std::string indexFile = std::string(INDEX_FILE) + "_" + node;
-
-    file = fopen(indexFile.c_str(), "w");
-    if (file != nullptr)
-    {
-        fprintf(file, "%lu", errCount);
-        fclose(file);
-    }
-
-    lock.unlock();
 }
 
 } // namespace cper


### PR DESCRIPTION
- Add updateIndexFile() to handle error-count increment, rollover, and index-file writes with a dedicated mutex.
- Remove index update logic from createFile().
- Fix off‑by‑one by exporting errCount instead of errCount - 1.
- Call updateIndexFile() after each D-Bus export in all error paths.

Tests:
CPER info updated to the D-Bus successfully, when CPER file index is at 9.