### PR TITLE
Implement error count tracking(corr/uncorrectable)

### DIFF
--- a/include/config_manager.hpp
+++ b/include/config_manager.hpp
@@ -100,10 +100,128 @@ class Manager : public amd::ras::config::ConfigIface
      */
     void deleteAll() override;
 
+    /** @brief Load error counts from the persistent JSON file.
+     *
+     *  @details Reads error count arrays from the JSON file at
+     *  errorCountFile. If the file does not exist or fails to parse,
+     *  creates a new file with default (zero) values.
+     */
+    void loadErrorCounts();
+
+    /** @brief Save current error counts to the persistent JSON file.
+     *
+     *  @details Writes all four error count arrays (correctable/
+     *  noncorrectable CPU and other errors) to the JSON file at
+     *  errorCountFile and updates the D-Bus properties.
+     */
+    void saveErrorCounts();
+
+    /** @brief Update error count properties on the D-Bus interface.
+     *
+     *  @details Publishes the current in-memory error count arrays
+     *  to the com.amd.RAS.ErrorCount D-Bus interface properties.
+     */
+    void updateErrorCountDbus();
+
+    /** @brief Increment the correctable CPU error count for a given index.
+     *  @param[in] socNum - socket number (0 or 1).
+     *  @param[in] index - CPU error index to increment.
+     */
+    void incrementCorrectableCPUError(size_t socNum, size_t index)
+    {
+        if (socNum == 0)
+        {
+            p0CorrectableCPUErrors.at(index)++;
+        }
+        else
+        {
+            p1CorrectableCPUErrors.at(index)++;
+        }
+    }
+
+    /** @brief Increment the noncorrectable CPU error count for a given index.
+     *  @param[in] socNum - socket number (0 or 1).
+     *  @param[in] index - CPU error index to increment.
+     */
+    void incrementNoncorrectableCPUError(size_t socNum, size_t index)
+    {
+        if (socNum == 0)
+        {
+            p0NoncorrectableCPUErrors.at(index)++;
+        }
+        else
+        {
+            p1NoncorrectableCPUErrors.at(index)++;
+        }
+    }
+
+    /** @brief Get the threshold count for a given error category.
+     *
+     *  @details Checks whether thresholding is enabled for the given
+     *  category by reading the enable attribute from the config table.
+     *  If enabled, returns the configured threshold count; otherwise
+     *  returns 1.
+     *
+     *  @param[in] thresholdEnKey  - config attribute name for threshold enable
+     *  @param[in] thresholdCntKey - config attribute name for threshold count
+     *
+     *  @return threshold count if enabled, 1 otherwise.
+     */
+    uint64_t getThresholdCount(const std::string& thresholdEnKey,
+                               const std::string& thresholdCntKey);
+
+    /** @brief Increment the correctable other error count.
+     *  @param[in] socNum - socket number (0 or 1).
+     *  @param[in] thresholdCount - threshold count to increment by.
+     */
+    void incrementCorrectableOtherError(size_t socNum, uint64_t thresholdCount)
+    {
+        if (socNum == 0)
+        {
+            p0CorrectableOtherErrors += thresholdCount;
+        }
+        else
+        {
+            p1CorrectableOtherErrors += thresholdCount;
+        }
+    }
+
+    /** @brief Increment the noncorrectable other error count.
+     *  @param[in] socNum - socket number (0 or 1).
+     */
+    void incrementNoncorrectableOtherError(size_t socNum)
+    {
+        if (socNum == 0)
+        {
+            p0NoncorrectableOtherErrors++;
+        }
+        else
+        {
+            p1NoncorrectableOtherErrors++;
+        }
+    }
+
   private:
+    static constexpr size_t maxErrorIndex = 256;
+    inline static std::array<uint64_t, maxErrorIndex> p0CorrectableCPUErrors{};
+    inline static std::array<uint64_t, maxErrorIndex>
+        p0NoncorrectableCPUErrors{};
+    inline static uint64_t p0CorrectableOtherErrors{};
+    inline static uint64_t p0NoncorrectableOtherErrors{};
+    inline static std::array<uint64_t, maxErrorIndex> p1CorrectableCPUErrors{};
+    inline static std::array<uint64_t, maxErrorIndex>
+        p1NoncorrectableCPUErrors{};
+    inline static uint64_t p1CorrectableOtherErrors{};
+    inline static uint64_t p1NoncorrectableOtherErrors{};
     sdbusplus::asio::object_server& objServer;
     std::shared_ptr<sdbusplus::asio::connection>& systemBus;
     std::string node;
+
+    std::string errorCountFile;
+    static constexpr auto errorCountPath = "/com/amd/RAS/ErrorCount";
+    static constexpr auto errorCountInterface = "com.amd.RAS.ErrorCount";
+
+    std::shared_ptr<sdbusplus::asio::dbus_interface> errorCountIface;
 };
 
 } // namespace config

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -1822,6 +1822,11 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
 
             harvestBreakEvent(socNum);
             cpuAlertProcessed.assign(cpuCount, true);
+            // TODO: Get the core number on which the error happened and update
+            // the error count
+            configMgr.incrementNoncorrectableCPUError(socNum, 0);
+            configMgr.updateErrorCountDbus();
+            configMgr.saveErrorCounts();
         }
         else if (src & resetHangErr)
         {
@@ -1835,6 +1840,9 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
                             rasErrMsg.c_str(), NULL);
 
             fchHangError = true;
+            configMgr.incrementNoncorrectableOtherError(socNum);
+            configMgr.updateErrorCountDbus();
+            configMgr.saveErrorCounts();
         }
     }
     else
@@ -1863,6 +1871,11 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
                             LOG_ERR, "REDFISH_MESSAGE_ID=%s",
                             "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
                             rasErrMsg.c_str(), NULL);
+            // TODO: Get the core number on which the error happened and update
+            // the error count
+            configMgr.incrementNoncorrectableCPUError(socNum, 0);
+            configMgr.updateErrorCountDbus();
+            configMgr.saveErrorCounts();
 
             if (false == harvestMcaValidityCheck(socNum, &errorCheck))
             {
@@ -1882,6 +1895,9 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
                             rasErrMsg.c_str(), NULL);
 
             nonMcaShutdownError = true;
+            configMgr.incrementNoncorrectableOtherError(socNum);
+            configMgr.updateErrorCountDbus();
+            configMgr.saveErrorCounts();
         }
         else
         {
@@ -1898,6 +1914,12 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
                     "REDFISH_MESSAGE_ARGS=%s", mcaErrOverflowMsg.c_str(), NULL);
 
                 runtimeError = true;
+                uint64_t thresholdCount = configMgr.getThresholdCount(
+                    "McaErrThresholdEnable", "McaErrThresholdCount");
+                configMgr.incrementCorrectableOtherError(socNum,
+                                                         thresholdCount);
+                configMgr.updateErrorCountDbus();
+                configMgr.saveErrorCounts();
             }
             if (src & dramCeccErrOverflow)
             {
@@ -1910,7 +1932,14 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
                     "MESSAGE=%s", dramErrOverlowMsg.c_str(), "PRIORITY=%i",
                     LOG_ERR, "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
                     "REDFISH_MESSAGE_ARGS=%s", dramErrOverlowMsg.c_str(), NULL);
-
+                // TODO: Get the core number on which the error happened and
+                // update the error count
+                uint64_t thresholdCount = configMgr.getThresholdCount(
+                    "DramCeccErrThresholdEnable", "DramCeccErrThresholdCount");
+                configMgr.incrementCorrectableOtherError(socNum,
+                                                         thresholdCount);
+                configMgr.updateErrorCountDbus();
+                configMgr.saveErrorCounts();
                 runtimeError = true;
             }
             if (src & pcieErrOverflow)
@@ -1926,6 +1955,12 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
                     "REDFISH_MESSAGE_ARGS=%s", pcieErrOverlowMsg.c_str(), NULL);
 
                 runtimeError = true;
+                uint64_t thresholdCount = configMgr.getThresholdCount(
+                    "PcieErrThresholdEnable", "PcieErrThresholdCount");
+                configMgr.incrementCorrectableOtherError(socNum,
+                                                         thresholdCount);
+                configMgr.updateErrorCountDbus();
+                configMgr.saveErrorCounts();
             }
         }
     }
@@ -2173,6 +2208,11 @@ bool Manager::decodeInterrupt(uint8_t socNum)
 
                     harvestBreakEvent(socNum);
                     cpuAlertProcessed.assign(cpuCount, true);
+                    // TODO: Get the core number on which the error happened and
+                    // update the error count
+                    configMgr.incrementNoncorrectableCPUError(socNum, 0);
+                    configMgr.updateErrorCountDbus();
+                    configMgr.saveErrorCounts();
                 }
                 else if (buf & resetHangErr)
                 {
@@ -2186,6 +2226,9 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                         "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
 
                     fchHangError = true;
+                    configMgr.incrementNoncorrectableOtherError(socNum);
+                    configMgr.updateErrorCountDbus();
+                    configMgr.saveErrorCounts();
                 }
             }
             else
@@ -2215,7 +2258,11 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                         "MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
                         "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
                         "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
-
+                    // TODO: Get the core number on which the error happened and
+                    // update the error count
+                    configMgr.incrementNoncorrectableCPUError(socNum, 0);
+                    configMgr.updateErrorCountDbus();
+                    configMgr.saveErrorCounts();
                     if (false == harvestMcaValidityCheck(socNum, &errorCheck))
                     {
                         lg2::info(
@@ -2234,6 +2281,9 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                         "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
 
                     nonMcaShutdownError = true;
+                    configMgr.incrementNoncorrectableOtherError(socNum);
+                    configMgr.updateErrorCountDbus();
+                    configMgr.saveErrorCounts();
                 }
                 else
                 {
@@ -2251,6 +2301,12 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                             mcaErrOverflowMsg.c_str(), NULL);
 
                         runtimeError = true;
+                        uint64_t thresholdCount = configMgr.getThresholdCount(
+                            "McaErrThresholdEnable", "McaErrThresholdCount");
+                        configMgr.incrementCorrectableOtherError(
+                            socNum, thresholdCount);
+                        configMgr.updateErrorCountDbus();
+                        configMgr.saveErrorCounts();
                     }
                     if (buf & dramCeccErrOverflow)
                     {
@@ -2264,7 +2320,13 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                             "PRIORITY=%i", LOG_ERR, "REDFISH_MESSAGE_ID=%s",
                             "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
                             dramErrOverlowMsg.c_str(), NULL);
-
+                        uint64_t thresholdCount = configMgr.getThresholdCount(
+                            "DramCeccErrThresholdEnable",
+                            "DramCeccErrThresholdCount");
+                        configMgr.incrementCorrectableOtherError(
+                            socNum, thresholdCount);
+                        configMgr.updateErrorCountDbus();
+                        configMgr.saveErrorCounts();
                         runtimeError = true;
                     }
                     if (buf & pcieErrOverflow)
@@ -2281,6 +2343,12 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                             pcieErrOverlowMsg.c_str(), NULL);
 
                         runtimeError = true;
+                        uint64_t thresholdCount = configMgr.getThresholdCount(
+                            "PcieErrThresholdEnable", "PcieErrThresholdCount");
+                        configMgr.incrementCorrectableOtherError(
+                            socNum, thresholdCount);
+                        configMgr.updateErrorCountDbus();
+                        configMgr.saveErrorCounts();
                     }
                 }
             }

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -178,9 +178,9 @@ void Manager::updateConfigToDbus()
             {
                 lg2::error("Failed to create directory: {DIR}, ec={EC}", "DIR",
                            destDir.string(), "EC", ec.message());
-                throw std::runtime_error("Failed to create directory: " +
-                                         destDir.string() + " (" +
-                                         ec.message() + ")");
+                throw std::runtime_error(
+                    "Failed to create directory: " + destDir.string() + " (" +
+                    ec.message() + ")");
             }
         }
 
@@ -214,7 +214,7 @@ void Manager::updateConfigToDbus()
     for (const auto& item : data["Configuration"])
     {
         AttributeType attributeType = sdbusplus::common::com::amd::ras::
-                     Configuration::AttributeType::Boolean;
+            Configuration::AttributeType::Boolean;
         std::string key;
         std::string description;
         std::variant<bool, std::string, int64_t, std::vector<std::string>,
@@ -337,13 +337,177 @@ void Manager::deleteAll()
     amd::ras::util::cper::deleteCrashdumpInterface();
 }
 
+uint64_t Manager::getThresholdCount(const std::string& thresholdEnKey,
+                                    const std::string& thresholdCntKey)
+{
+    const auto configMap = rasConfigTable();
+
+    // Check if thresholding is enabled
+    auto enIt = configMap.find(thresholdEnKey);
+    if (enIt != configMap.end())
+    {
+        const auto& enValue = std::get<2>(enIt->second);
+        if (std::holds_alternative<bool>(enValue) && std::get<bool>(enValue))
+        {
+            // Threshold enabled, return the configured count
+            auto cntIt = configMap.find(thresholdCntKey);
+            if (cntIt != configMap.end())
+            {
+                const auto& cntValue = std::get<2>(cntIt->second);
+                if (std::holds_alternative<int64_t>(cntValue))
+                {
+                    auto count = std::get<int64_t>(cntValue);
+                    return (count > 0) ? static_cast<uint64_t>(count) : 1;
+                }
+            }
+        }
+    }
+
+    return 1;
+}
+
+void Manager::loadErrorCounts()
+{
+    std::ifstream file(errorCountFile);
+    if (file.is_open())
+    {
+        try
+        {
+            nlohmann::json data = nlohmann::json::parse(file);
+            for (size_t i = 0; i < maxErrorIndex; ++i)
+            {
+                p0CorrectableCPUErrors[i] =
+                    data["p0CorrectableCPUErrors"][i].get<uint64_t>();
+                p0NoncorrectableCPUErrors[i] =
+                    data["p0NoncorrectableCPUErrors"][i].get<uint64_t>();
+                p1CorrectableCPUErrors[i] =
+                    data["p1CorrectableCPUErrors"][i].get<uint64_t>();
+                p1NoncorrectableCPUErrors[i] =
+                    data["p1NoncorrectableCPUErrors"][i].get<uint64_t>();
+            }
+            p0CorrectableOtherErrors =
+                data["p0CorrectableOtherErrors"].get<uint64_t>();
+            p0NoncorrectableOtherErrors =
+                data["p0NoncorrectableOtherErrors"].get<uint64_t>();
+            p1CorrectableOtherErrors =
+                data["p1CorrectableOtherErrors"].get<uint64_t>();
+            p1NoncorrectableOtherErrors =
+                data["p1NoncorrectableOtherErrors"].get<uint64_t>();
+            lg2::info("Error counts loaded from {FILE}", "FILE",
+                      errorCountFile);
+            updateErrorCountDbus();
+        }
+        catch (const nlohmann::json::exception& e)
+        {
+            lg2::error("Failed to parse {FILE}: {ERR}", "FILE", errorCountFile,
+                       "ERR", e.what());
+            saveErrorCounts();
+        }
+    }
+    else
+    {
+        lg2::info("{FILE} not found, creating with defaults", "FILE",
+                  errorCountFile);
+        saveErrorCounts();
+    }
+}
+
+void Manager::saveErrorCounts()
+{
+    std::filesystem::create_directories(
+        std::filesystem::path(errorCountFile).parent_path());
+
+    nlohmann::json data;
+    data["p0CorrectableCPUErrors"] = p0CorrectableCPUErrors;
+    data["p0NoncorrectableCPUErrors"] = p0NoncorrectableCPUErrors;
+    data["p0CorrectableOtherErrors"] = p0CorrectableOtherErrors;
+    data["p0NoncorrectableOtherErrors"] = p0NoncorrectableOtherErrors;
+    data["p1CorrectableCPUErrors"] = p1CorrectableCPUErrors;
+    data["p1NoncorrectableCPUErrors"] = p1NoncorrectableCPUErrors;
+    data["p1CorrectableOtherErrors"] = p1CorrectableOtherErrors;
+    data["p1NoncorrectableOtherErrors"] = p1NoncorrectableOtherErrors;
+
+    std::ofstream file(errorCountFile);
+    if (!file.is_open())
+    {
+        lg2::error("Failed to open {FILE} for writing", "FILE", errorCountFile);
+        return;
+    }
+    file << data.dump(4);
+    updateErrorCountDbus();
+}
+
+void Manager::updateErrorCountDbus()
+{
+    if (!errorCountIface)
+    {
+        return;
+    }
+
+    errorCountIface->set_property(
+        "P0CorrectableCPUErrors",
+        std::vector<uint64_t>(p0CorrectableCPUErrors.begin(),
+                              p0CorrectableCPUErrors.end()));
+    errorCountIface->set_property(
+        "P0NoncorrectableCPUErrors",
+        std::vector<uint64_t>(p0NoncorrectableCPUErrors.begin(),
+                              p0NoncorrectableCPUErrors.end()));
+    errorCountIface->set_property("P0CorrectableOtherErrors",
+                                  p0CorrectableOtherErrors);
+    errorCountIface->set_property("P0NoncorrectableOtherErrors",
+                                  p0NoncorrectableOtherErrors);
+    errorCountIface->set_property(
+        "P1CorrectableCPUErrors",
+        std::vector<uint64_t>(p1CorrectableCPUErrors.begin(),
+                              p1CorrectableCPUErrors.end()));
+    errorCountIface->set_property(
+        "P1NoncorrectableCPUErrors",
+        std::vector<uint64_t>(p1NoncorrectableCPUErrors.begin(),
+                              p1NoncorrectableCPUErrors.end()));
+    errorCountIface->set_property("P1CorrectableOtherErrors",
+                                  p1CorrectableOtherErrors);
+    errorCountIface->set_property("P1NoncorrectableOtherErrors",
+                                  p1NoncorrectableOtherErrors);
+}
+
 Manager::Manager(sdbusplus::asio::object_server& objectServer,
                  std::shared_ptr<sdbusplus::asio::connection>& systemBus,
                  std::string& node) :
     amd::ras::config::ConfigIface(*systemBus, objectPath),
-    objServer(objectServer), systemBus(systemBus), node(node)
+    objServer(objectServer), systemBus(systemBus), node(node),
+    errorCountFile("/var/lib/amd-bmc-ras/error_count" + node + ".json")
 {
     updateConfigToDbus();
+    loadErrorCounts();
+
+    errorCountIface =
+        objServer.add_interface(errorCountPath, errorCountInterface);
+
+    std::vector<uint64_t> p0CorCPU(p0CorrectableCPUErrors.begin(),
+                                   p0CorrectableCPUErrors.end());
+    std::vector<uint64_t> p0NoncorCPU(p0NoncorrectableCPUErrors.begin(),
+                                      p0NoncorrectableCPUErrors.end());
+    std::vector<uint64_t> p1CorCPU(p1CorrectableCPUErrors.begin(),
+                                   p1CorrectableCPUErrors.end());
+    std::vector<uint64_t> p1NoncorCPU(p1NoncorrectableCPUErrors.begin(),
+                                      p1NoncorrectableCPUErrors.end());
+
+    errorCountIface->register_property("P0CorrectableCPUErrors", p0CorCPU);
+    errorCountIface->register_property("P0NoncorrectableCPUErrors",
+                                       p0NoncorCPU);
+    errorCountIface->register_property("P0CorrectableOtherErrors",
+                                       p0CorrectableOtherErrors);
+    errorCountIface->register_property("P0NoncorrectableOtherErrors",
+                                       p0NoncorrectableOtherErrors);
+    errorCountIface->register_property("P1CorrectableCPUErrors", p1CorCPU);
+    errorCountIface->register_property("P1NoncorrectableCPUErrors",
+                                       p1NoncorCPU);
+    errorCountIface->register_property("P1CorrectableOtherErrors",
+                                       p1CorrectableOtherErrors);
+    errorCountIface->register_property("P1NoncorrectableOtherErrors",
+                                       p1NoncorrectableOtherErrors);
+
+    errorCountIface->initialize();
 }
 
 } // namespace config

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,12 +28,11 @@ int main(int argc, char* argv[])
     // Create a shared connection to the system bus
     auto systemBus = std::make_shared<sdbusplus::asio::connection>(io);
 
-    const char* rasService =
-        (std::string(amd::ras::config::service) + node).c_str();
+    std::string rasService = std::string(amd::ras::config::service) + node;
 
     lg2::info("Ras service {SER}", "SER", rasService);
     // Request a unique name on the D-Bus
-    systemBus->request_name(rasService);
+    systemBus->request_name(rasService.c_str());
 
     // Create an object server for managing D-Bus objects
     sdbusplus::asio::object_server objectServer(systemBus);


### PR DESCRIPTION

Add support for tracking correctable and noncorrectable error counts
per socket with a new com.amd.RAS.ErrorCount D-Bus interface hosted
on /com/amd/RAS/ErrorCount.

The interface exposes eight properties:
  - P0CorrectableCPUErrors / P1CorrectableCPUErrors (256-entry arrays)
  - P0NoncorrectableCPUErrors / P1NoncorrectableCPUErrors (256-entry arrays)
  - P0CorrectableOtherErrors / P1CorrectableOtherErrors (scalar counters)
  - P0NoncorrectableOtherErrors / P1NoncorrectableOtherErrors (scalar counters)

Error counts are persisted to /var/lib/amd-bmc-ras/error_count.json
and restored on service startup. The config_manager is extended with
loadErrorCounts(), saveErrorCounts(), and updateErrorCountDbus()
methods, along with per-category increment helpers that accept a
socNum parameter to route to the correct socket counter.

Add getThresholdCount() to read threshold enable/count from the RAS
config table. Correctable other-error overflow paths (MCA, DRAM CECC,
PCIe) increment by the configured threshold count when thresholding is
enabled, or by 1 otherwise.

Both decodeInterrupt() overloads now update error counters, publish
to D-Bus, and persist to disk when fatal, non-MCA, or overflow errors
are detected.

Fix a dangling-pointer bug in main.cpp where a temporary std::string
was converted to c_str() and used after destruction; the service name
is now kept in a std::string that outlives its use.

Tested:
Build and verified error counts persist across restarts and
are accessible via D-Bus.