### PR TITLE
Remove the APML NDA headers and functions to use esmi_oob_library

### DIFF
--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -334,20 +334,6 @@ class Manager : public amd::ras::Manager
     void harvestDebugLogDump(const std::shared_ptr<FatalCperRecord>&, uint8_t,
                              uint8_t, int64_t*, uint16_t&);
 
-    /** @brief Harvests uncore IFT dump data
-     *
-     * @details This function harvests the dump data for debug log ID 25
-     *
-     * @param[in] fatalPtr - Shared pointer to a FatalCperRecord object.
-     * @param[in] socNum - The SoC number.
-     * @param[in] apmlRetryCount - Pointer to the APML retry count.
-     * @param[out] debugLogIdOffset - Reference to the debug log ID offset.
-     *
-     */
-    void harvestUncoreIftDump(const std::shared_ptr<FatalCperRecord>& fatalPtr,
-                              uint8_t socNum, int64_t* apmlRetryCount,
-                              uint16_t& debugLogIdOffset);
-
     /** @brief Dumps the processor error section of the CPER record
      *
      * @details This function dumps the processor error section for

--- a/include/config_manager.hpp
+++ b/include/config_manager.hpp
@@ -70,7 +70,7 @@ class Manager
      */
     AttributeValue getAttribute(AttributeName attribute);
 
-    /** @brief Update RAS configuration parameters to D-Bus interface
+    /** @brief Initialize RAS configuration parameters
      *
      * @details Creates Config File in /var/lib/amd-bmc-ras and the
      * config file values are uploaded to the D-Bus interface.

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -8,9 +8,6 @@
 extern "C"
 {
 #include "esmi_cpuid_msr.h"
-#ifdef APML_NDA
-#include "esmi_mailbox_nda.h"
-#endif
 #include "esmi_rmi.h"
 }
 
@@ -1042,137 +1039,6 @@ void Manager::getLastTransAddr(const std::shared_ptr<FatalCperRecord>& fatalPtr,
     }
 }
 
-inline bool retryUncoreDump(
-    uint8_t socNum, uint16_t instanceNum, int64_t* apmlRetryCount,
-    uncore_ift_validity_check& resp, uncore_dbg_log_dump_din& dataIn,
-    uncore_dbg_log_dump_dout& dataOut)
-{
-    uint16_t retryCount = *apmlRetryCount;
-
-    while (retryCount > 0)
-    {
-        memset(&dataIn, 0, sizeof(dataIn));
-
-        dataIn.offsets = resp.bytes / BIT(2);
-        dataIn.index = instanceNum;
-
-        int ret = get_ras_uncore_dbg_log_dump(socNum, dataIn, &dataOut);
-
-        if (ret == OOB_SUCCESS)
-        {
-            return true;
-        }
-
-        retryCount--;
-        usleep(1);
-    }
-
-    return false;
-}
-
-void Manager::harvestUncoreIftDump(
-    const std::shared_ptr<FatalCperRecord>& fatalPtr, uint8_t socNum,
-    int64_t* apmlRetryCount, uint16_t& debugLogIdOffset)
-{
-    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
-    uint16_t retries = 0;
-    uint16_t instanceNum = 0;
-    struct uncore_ift_validity_check resp;
-    struct uncore_dbg_log_dump_din dataIn;
-    struct uncore_dbg_log_dump_dout dataOut;
-
-    while (ret != OOB_SUCCESS)
-    {
-        retries++;
-
-        ret = get_bmc_ras_uncore_ift_validity_check(socNum, &resp);
-
-        if (ret == OOB_SUCCESS)
-        {
-            lg2::info("Socket: {SOCKET},Debug Log ID : {ID} read successful,"
-                      "Block instance : {INST} , Err log length : {LEN}",
-                      "SOCKET", socNum, "ID", blockId25, "INST", resp.instances,
-                      "LEN", resp.bytes);
-            break;
-        }
-
-        if (retries > *apmlRetryCount)
-        {
-            lg2::error("Socket: {SOCKET},Debug Log ID : {ID} read failed", "ID",
-                       blockId25, "SOCKET", socNum);
-
-            /*If 5Bh command fails ,0xBAADDA7A is written thrice in the PCIE
-             * dump region*/
-            fatalPtr->ErrorRecord[socNum].DebugLogIdData[debugLogIdOffset++] =
-                blockId25;
-            fatalPtr->ErrorRecord[socNum].DebugLogIdData[debugLogIdOffset++] =
-                badData;
-            fatalPtr->ErrorRecord[socNum].DebugLogIdData[debugLogIdOffset++] =
-                badData;
-            fatalPtr->ErrorRecord[socNum].DebugLogIdData[debugLogIdOffset++] =
-                badData;
-
-            break;
-        }
-    }
-    if (ret == OOB_SUCCESS)
-    {
-        if (resp.instances != 0)
-        {
-            uint32_t debugLogIdHeader =
-                (static_cast<uint32_t>(resp.bytes) << 16) |
-                (static_cast<uint32_t>(resp.instances) << 8) |
-                static_cast<uint32_t>(blockId25);
-
-            fatalPtr->ErrorRecord[socNum].DebugLogIdData[debugLogIdOffset++] =
-                debugLogIdHeader;
-
-            while (instanceNum < resp.instances)
-            {
-                memset(&dataIn, 0, sizeof(dataIn));
-
-                // Convert bytes to 32-bit word offsets (BIT(2) = 4)
-                dataIn.offsets = resp.bytes / BIT(2);
-                /* DF block ID instance */
-                dataIn.index = instanceNum;
-
-                std::unique_ptr<uint32_t[]> offsets_data_ptr(
-                    new uint32_t[dataIn.offsets]);
-                dataOut.offsets_data = offsets_data_ptr.get();
-
-                ret = get_ras_uncore_dbg_log_dump(socNum, dataIn, &dataOut);
-
-                if (ret)
-                {
-                    bool success =
-                        retryUncoreDump(socNum, instanceNum, apmlRetryCount,
-                                        resp, dataIn, dataOut);
-
-                    if (!success)
-                    {
-                        lg2::error("Failed to read debug log dump for "
-                                   "debug log ID : 25");
-
-                        for (size_t i = 0; i < dataIn.offsets; i++)
-                        {
-                            dataOut.offsets_data[i] = badData;
-                        }
-                    }
-                }
-
-                for (size_t i = 0; i < dataIn.offsets; i++)
-                {
-                    fatalPtr->ErrorRecord[socNum]
-                        .DebugLogIdData[debugLogIdOffset++] =
-                        dataOut.offsets_data[i];
-                }
-
-                instanceNum++;
-            }
-        }
-    }
-}
-
 void Manager::harvestDebugLogDump(
     const std::shared_ptr<FatalCperRecord>& fatalPtr, uint8_t socNum,
     uint8_t blkId, int64_t* apmlRetryCount, uint16_t& debugLogIdOffset)
@@ -1430,15 +1296,8 @@ void Manager::harvestMcaDataBanks(uint8_t socNum,
 
     for (blkId = 0; blkId < blockId.size(); blkId++)
     {
-        if (blockId[blkId] == blockId25)
-        {
-            harvestUncoreIftDump(rcd, socNum, apmlRetryCount, debugLogIdOffset);
-        }
-        else
-        {
-            harvestDebugLogDump(rcd, socNum, blockId[blkId], apmlRetryCount,
-                                debugLogIdOffset);
-        }
+        harvestDebugLogDump(rcd, socNum, blockId[blkId], apmlRetryCount,
+                            debugLogIdOffset);
     }
 
     syndOffsetLo = std::stoul((*sigIDOffset)[0], nullptr, base16);


### PR DESCRIPTION
***Description***
We are not going to use the APML NDA repo to build AMD_APML https://github.com/amd/apml_library
instead, we will be moving to using the public APML repo https://github.com/amd/esmi_oob_library/tree/sp7-dev, to accommodate this we need to make some source code changes in RAS to compile.

***Changes***
1. Removed the inclusion of `esmi_mailbox_nda` header in `amd-bmc-ras` source code due to the usage of public APML library.
2. Removed `retryUncoreDump()` and `harvestUncoreIftDump()` which are supported only by the NDA APML library.
3. Use existing `harvestDebugLogDump()` func to handle the blkId.

***Testing***
root@bmc:/var/lib/amd-bmc-ras# journalctl | grep -i amd-ras-manager | tail -n 10
Mar 17 15:38:22 bmc amd-ras-manager[797]: Start amd ras service for host : 0
Mar 17 15:38:22 bmc amd-ras-manager[797]: PARSE CONFIGURATION
Mar 17 15:38:22 bmc amd-ras-manager[797]: APML MANAGER INIT
Mar 17 15:50:26 bmc amd-ras-manager[797]: PLATFORM INIT
Mar 17 15:50:26 bmc amd-ras-manager[797]: Setting MCA and DRAM OOB Config
Mar 17 15:50:26 bmc amd-ras-manager[797]: BMC RAS oob configuration set successfully for the processor P0
Mar 17 15:50:26 bmc amd-ras-manager[797]: Setting PCIE OOB Config
Mar 17 15:50:26 bmc amd-ras-manager[797]: Starting seprate threads to perform runtime error polling as per user settings
Mar 17 16:02:05 bmc amd-ras-manager[797]: Harvesting errors for category 0
Mar 17 16:02:05 bmc amd-ras-manager[797]: Generated runtime CPER file : /var/lib/amd-bmc-ras/mca-runtime-ras-error0.cper
root@bmc:/var/lib/amd-bmc-ras# ls
amd_ras_gpio_config0.json    mca-runtime-ras-error0.cper  platform_default.json
current_index_0              mca-runtime-ras-error1.cper  ras_config0.json
root@bmc:/var/lib/amd-bmc-ras# journalctl | grep -i amd-ras-manager | tail -n 10
Mar 17 15:38:22 bmc amd-ras-manager[797]: APML MANAGER INIT
Mar 17 15:50:26 bmc amd-ras-manager[797]: PLATFORM INIT
Mar 17 15:50:26 bmc amd-ras-manager[797]: Setting MCA and DRAM OOB Config
Mar 17 15:50:26 bmc amd-ras-manager[797]: BMC RAS oob configuration set successfully for the processor P0
Mar 17 15:50:26 bmc amd-ras-manager[797]: Setting PCIE OOB Config
Mar 17 15:50:26 bmc amd-ras-manager[797]: Starting seprate threads to perform runtime error polling as per user settings
Mar 17 16:02:05 bmc amd-ras-manager[797]: Harvesting errors for category 0
Mar 17 16:02:05 bmc amd-ras-manager[797]: Generated runtime CPER file : /var/lib/amd-bmc-ras/mca-runtime-ras-error0.cper
Mar 17 16:04:39 bmc amd-ras-manager[797]: Harvesting errors for category 0
Mar 17 16:04:39 bmc amd-ras-manager[797]: Generated runtime CPER file : /var/lib/amd-bmc-ras/mca-runtime-ras-error1.cper

***CPER Files***
[cpers.zip](https://github.com/user-attachments/files/26071935/cpers.zip)

***CE Decodes***
[CPER_decodes.zip](https://github.com/user-attachments/files/26071997/CPER_decodes.zip)

*****Reference PR this change was based upon that used the NDA APML*****
https://github.com/AMDESE/amd-bmc-ras/pull/140 