### PR TITLE
Add x86Exception core debug dump harvesting support

### DIFF
--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -62,9 +62,9 @@ class Manager : public amd::ras::Manager
      *  RAS alerts or sets up GPIO event handling fot APML alerts based on
      *  apmlAlertFlag. If APML Alert_L is enabled, it uses the APML API to
      *  register for udev events. Otherwise, it requests GPIO events for alert
-     *  handling by binding the alert event handler to the respective GPIO lines.
-     *  The number of GPIO lines to be monitored and the flag apmlAlertFlag value
-     *  is read from the amd_ras_gpio_config.json file.
+     *  handling by binding the alert event handler to the respective GPIO
+     * lines. The number of GPIO lines to be monitored and the flag
+     * apmlAlertFlag value is read from the amd_ras_gpio_config.json file.
      */
 
     virtual void configure();
@@ -421,6 +421,19 @@ class Manager : public amd::ras::Manager
      *
      */
     void harvestDramCeccErrorCounters(struct ras_rt_valid_err_inst, uint8_t);
+
+    /** @brief Harvest x86 exception core debug dump data.
+     *
+     * @details When SBRMI::RASStatus[7] (x86 exception bit) is set, this
+     * function uses the BMC_RAS_DBG_LOG_VALIDITY_CHECK and
+     * BMC_RAS_DBG_LOG_DUMP APML commands to harvest core debug trace data
+     * from cores that encountered x86 exceptions (e.g., segmentation
+     * faults). The harvested data is stored in a Core Debug Dump CPER
+     * record.
+     *
+     * @param[in] socNum - Socket number of the processor.
+     */
+    void harvestX86ExceptionData(uint8_t socNum);
 
     /** @brief Set MCA OOB configuration.
      *

--- a/include/base_manager.hpp
+++ b/include/base_manager.hpp
@@ -71,6 +71,7 @@ class Manager
     std::shared_ptr<McaRuntimeCperRecord> mcaPtr;
     std::shared_ptr<McaRuntimeCperRecord> dramPtr;
     std::shared_ptr<PcieRuntimeCperRecord> pciePtr;
+    std::shared_ptr<CoreDebugDumpCperRecord> coreDebugDumpPtr;
     std::string node;
     std::vector<size_t> socIndex;
 

--- a/include/oem_cper.hpp
+++ b/include/oem_cper.hpp
@@ -88,3 +88,41 @@ struct PcieRuntimeCperRecord
     EFI_ERROR_SECTION_DESCRIPTOR* SectionDescriptor;
     EFI_AMD_PCIE_ERROR_DATA* PcieErrorData;
 } __attribute__((packed));
+
+constexpr size_t coreDebugDumpHeaderSize = 64;
+constexpr size_t coreDebugDumpReservedSize = 22;
+constexpr size_t instancesPerCore = 128;
+
+struct CoreDebugDumpValidBits
+{
+    uint16_t apicIdValid:1;
+    uint16_t cpuidValid:1;
+    uint16_t reserved:14;
+} __attribute__((packed));
+
+struct CoreDebugDumpHeader
+{
+    CoreDebugDumpValidBits validBits;
+    uint64_t apicId;
+    struct
+    {
+        uint64_t eax;
+        uint64_t ebx;
+        uint64_t ecx;
+        uint64_t edx;
+    } cpuidInfo;
+    uint8_t reserved[coreDebugDumpReservedSize];
+} __attribute__((packed));
+
+struct CoreDebugDumpSection
+{
+    CoreDebugDumpHeader header;
+    uint32_t* payload;
+} __attribute__((packed));
+
+struct CoreDebugDumpCperRecord
+{
+    EFI_COMMON_ERROR_RECORD_HEADER Header;
+    EFI_ERROR_SECTION_DESCRIPTOR* SectionDescriptor;
+    CoreDebugDumpSection* DebugDumpSection;
+} __attribute__((packed));

--- a/include/utils/cper.hpp
+++ b/include/utils/cper.hpp
@@ -6,6 +6,7 @@ static constexpr std::string_view runtimeMcaErr = "RUNTIME_MCA_ERROR";
 static constexpr std::string_view runtimePcieErr = "RUNTIME_PCIE_ERROR";
 static constexpr std::string_view runtimeDramErr = "RUNTIME_DRAM_ERROR";
 static constexpr std::string_view fatalErr = "FATAL";
+static constexpr std::string_view coreDebugDumpErr = "CORE_DEBUG_DUMP";
 
 namespace amd
 {
@@ -238,6 +239,19 @@ bool checkSignatureIdMatch(std::map<std::string, std::string>*,
  * otherwise.
  */
 bool calculateSeverity(uint32_t*, uint16_t, uint32_t*, const std::string_view&);
+
+/** @brief Populates the Core Debug Dump section header.
+ *
+ *  @details Fills in the CoreDebugDumpHeader with CPUID and APIC ID
+ *  information for an x86 exception core debug dump section.
+ *
+ *  @param[in] coreDebugPtr - Shared pointer to CoreDebugDumpCperRecord.
+ *  @param[in] sectionIdx - Index of the section being populated.
+ *  @param[in] cpuId - Unique pointer to array of CPU IDs.
+ */
+void dumpCoreDebugDumpHeader(
+    const std::shared_ptr<CoreDebugDumpCperRecord>& coreDebugPtr,
+    uint16_t sectionIdx, const std::unique_ptr<CpuId[]>& cpuId);
 
 } // namespace cper
 } // namespace util

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -47,6 +47,7 @@ constexpr size_t chipSelNumPos = 21;
 constexpr size_t mcaErrOverflow = 8;
 constexpr size_t dramCeccErrOverflow = 16;
 constexpr size_t pcieErrOverflow = 32;
+constexpr size_t x86ExceptionBit = 0x80;
 constexpr size_t base16 = 16;
 constexpr size_t byteMask = 0xFF;
 constexpr size_t cfError = 0x6;
@@ -1480,6 +1481,241 @@ void Manager::harvestBreakEvent(uint8_t socNum)
     rcd->ErrorRecord[socNum].RegisterArraySize = crashDataSize;
 }
 
+void Manager::harvestX86ExceptionData(uint8_t socNum)
+{
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+    uint16_t retries = 0;
+    struct ras_df_err_chk dbgLogCheck;
+    constexpr uint8_t dbgLogBlockId = 24;
+
+    amd::ras::config::Manager::AttributeValue apmlRetry =
+        configMgr.getAttribute("ApmlRetries");
+    int64_t* apmlRetryCount = std::get_if<int64_t>(&apmlRetry);
+
+    /*
+     * Step 1: Issue BMC_RAS_DBG_LOG_VALIDITY_CHECK to get the number of
+     * debug log instances for cores that detected x86 exceptions.
+     * Response format:
+     *   [24:16] = error log length in bytes per instance
+     *   [15:0]  = number of debug log instances (0..32768)
+     * Number of cores = instances / 128 (instancesPerCore)
+     */
+    while (ret != OOB_SUCCESS)
+    {
+        retries++;
+        ret =
+            read_ras_df_err_validity_check(socNum, dbgLogBlockId, &dbgLogCheck);
+
+        if (ret == OOB_SUCCESS)
+        {
+            lg2::info(
+                "Socket {SOCKET}: x86 exception debug log validity check OK. "
+                "Instances: {INST}, Log length: {LEN}",
+                "SOCKET", socNum, "INST",
+                static_cast<unsigned short>(dbgLogCheck.df_block_instances),
+                "LEN", static_cast<unsigned short>(dbgLogCheck.err_log_len));
+            break;
+        }
+
+        if (retries > *apmlRetryCount)
+        {
+            lg2::error("Socket {SOCKET}: Failed to get x86 exception debug log "
+                       "validity check",
+                       "SOCKET", socNum);
+            return;
+        }
+        sleep(1);
+    }
+
+    uint16_t totalInstances = dbgLogCheck.df_block_instances;
+    uint16_t logLenPerInstance = dbgLogCheck.err_log_len;
+
+    if (totalInstances == 0)
+    {
+        lg2::info("Socket {SOCKET}: No x86 exception instances to harvest",
+                  "SOCKET", socNum);
+        return;
+    }
+
+    /*
+     * Calculate number of affected cores.
+     * Per the spec, each core generates instancesPerCore (128) instances.
+     */
+    uint16_t numCores = totalInstances / instancesPerCore;
+    if (numCores == 0)
+    {
+        numCores = 1;
+    }
+
+    lg2::info("Socket {SOCKET}: x86 exception detected on {CORES} core(s), "
+              "total instances: {INST}, log length per instance: {LEN} bytes",
+              "SOCKET", socNum, "CORES", numCores, "INST", totalInstances,
+              "LEN", logLenPerInstance);
+
+    /*
+     * Step 2: Allocate CPER record. One section per affected core.
+     */
+    uint16_t sectionCount = numCores;
+    uint32_t payloadWordsPerInstance =
+        ((logLenPerInstance % 4) ? 1 : 0) + (logLenPerInstance >> 2);
+    uint32_t payloadBytesPerCore =
+        instancesPerCore * payloadWordsPerInstance * sizeof(uint32_t);
+
+    if (coreDebugDumpPtr == nullptr)
+    {
+        coreDebugDumpPtr = std::make_shared<CoreDebugDumpCperRecord>();
+    }
+
+    coreDebugDumpPtr->SectionDescriptor =
+        new EFI_ERROR_SECTION_DESCRIPTOR[sectionCount];
+    std::memset(coreDebugDumpPtr->SectionDescriptor, 0,
+                sectionCount * sizeof(EFI_ERROR_SECTION_DESCRIPTOR));
+
+    coreDebugDumpPtr->DebugDumpSection = new CoreDebugDumpSection[sectionCount];
+    std::memset(coreDebugDumpPtr->DebugDumpSection, 0,
+                sectionCount * sizeof(CoreDebugDumpSection));
+
+    /* Informational severity = 3 */
+    uint32_t errorSeverity = 3;
+    amd::ras::util::cper::dumpHeader(coreDebugDumpPtr, sectionCount,
+                                     errorSeverity, coreDebugDumpErr, boardId,
+                                     recordId);
+
+    uint32_t* severity = new uint32_t[sectionCount];
+    for (uint16_t i = 0; i < sectionCount; i++)
+    {
+        severity[i] = 3; // Informational
+    }
+    amd::ras::util::cper::dumpErrorDescriptor(
+        coreDebugDumpPtr, sectionCount, coreDebugDumpErr, severity, progId);
+    delete[] severity;
+
+    /*
+     * Step 3: For each core, allocate payload and harvest using
+     * BMC_RAS_DBG_LOG_DUMP (read_ras_df_err_dump).
+     * The BMC sends the dump command for each core's set of 128 instances.
+     */
+    uint32_t totalRecordLength =
+        sizeof(EFI_COMMON_ERROR_RECORD_HEADER) +
+        (sizeof(EFI_ERROR_SECTION_DESCRIPTOR) * sectionCount);
+
+    uint32_t sectionBodyOffset = totalRecordLength;
+
+    for (uint16_t coreIdx = 0; coreIdx < numCores; coreIdx++)
+    {
+        uint32_t sectionSize =
+            sizeof(CoreDebugDumpHeader) + payloadBytesPerCore;
+
+        /* Populate the section header */
+        amd::ras::util::cper::dumpCoreDebugDumpHeader(coreDebugDumpPtr, coreIdx,
+                                                      cpuId);
+
+        /* Allocate payload for this core */
+        coreDebugDumpPtr->DebugDumpSection[coreIdx].payload =
+            new uint32_t[instancesPerCore * payloadWordsPerInstance];
+        std::memset(coreDebugDumpPtr->DebugDumpSection[coreIdx].payload, 0,
+                    payloadBytesPerCore);
+
+        /* Update section descriptor offsets */
+        coreDebugDumpPtr->SectionDescriptor[coreIdx].SectionOffset =
+            sectionBodyOffset;
+        coreDebugDumpPtr->SectionDescriptor[coreIdx].SectionLength =
+            sectionSize;
+
+        sectionBodyOffset += sectionSize;
+
+        /* Harvest debug log data for this core's instances */
+        uint16_t baseInstance = coreIdx * instancesPerCore;
+        uint32_t payloadOffset = 0;
+        union ras_df_err_dump dfError = {0};
+
+        for (uint16_t inst = 0; inst < instancesPerCore; inst++)
+        {
+            bool apmlHang = false;
+
+            for (uint32_t offset = 0; offset < payloadWordsPerInstance;
+                 offset++)
+            {
+                uint32_t data = 0;
+
+                if (!apmlHang)
+                {
+                    memset(&dfError, 0, sizeof(dfError));
+                    dfError.input[0] = offset * 4;
+                    dfError.input[1] = dbgLogBlockId;
+                    dfError.input[2] = baseInstance + inst;
+
+                    ret = read_ras_df_err_dump(socNum, dfError, &data);
+
+                    if (ret != OOB_SUCCESS)
+                    {
+                        int64_t retryCount = *apmlRetryCount;
+                        while (retryCount > 0)
+                        {
+                            memset(&dfError, 0, sizeof(dfError));
+                            dfError.input[0] = offset * 4;
+                            dfError.input[1] = dbgLogBlockId;
+                            dfError.input[2] = baseInstance + inst;
+
+                            ret = read_ras_df_err_dump(socNum, dfError, &data);
+                            if (ret == OOB_SUCCESS)
+                            {
+                                break;
+                            }
+                            retryCount--;
+                            sleep(1);
+                        }
+                        if (ret != OOB_SUCCESS)
+                        {
+                            lg2::error(
+                                "Socket {SOCKET}: Failed to read x86 "
+                                "debug dump, core {CORE}, instance {INST}, "
+                                "offset {OFFSET}",
+                                "SOCKET", socNum, "CORE", coreIdx, "INST", inst,
+                                "OFFSET", offset);
+                            data = badData;
+                            apmlHang = true;
+                        }
+                    }
+                }
+
+                coreDebugDumpPtr->DebugDumpSection[coreIdx]
+                    .payload[payloadOffset++] = data;
+            }
+        }
+    }
+
+    /* Update total record length in header */
+    coreDebugDumpPtr->Header.RecordLength = sectionBodyOffset;
+
+    /* Step 4: Create the CPER file and export to D-Bus */
+    amd::ras::util::cper::createFile(coreDebugDumpPtr, coreDebugDumpErr,
+                                     sectionCount, errCount, node);
+
+    amd::ras::util::cper::exportToDBus(errCount,
+                                       coreDebugDumpPtr->Header.TimeStamp,
+                                       objectServer, systemBus, node);
+    amd::ras::util::cper::updateIndexFile(errCount, node);
+
+    std::string rasErrMsg =
+        "x86 exception core debug dump harvested successfully";
+    sd_journal_send("MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_INFO,
+                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
+                    "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+
+    /* Step 5: Cleanup */
+    for (uint16_t i = 0; i < sectionCount; i++)
+    {
+        delete[] coreDebugDumpPtr->DebugDumpSection[i].payload;
+        coreDebugDumpPtr->DebugDumpSection[i].payload = nullptr;
+    }
+    delete[] coreDebugDumpPtr->DebugDumpSection;
+    coreDebugDumpPtr->DebugDumpSection = nullptr;
+    delete[] coreDebugDumpPtr->SectionDescriptor;
+    coreDebugDumpPtr->SectionDescriptor = nullptr;
+    coreDebugDumpPtr = nullptr;
+}
+
 void Manager::harvestMcaDataBanks(uint8_t socNum,
                                   struct ras_df_err_chk errorCheck)
 {
@@ -1962,6 +2198,20 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
                 configMgr.updateErrorCountDbus();
                 configMgr.saveErrorCounts();
             }
+            if (src & x86ExceptionBit)
+            {
+                std::string x86ErrMsg =
+                    "x86 exception detected (e.g. segmentation fault). "
+                    "Harvesting core debug dump traces.";
+
+                sd_journal_send(
+                    "MESSAGE=%s", x86ErrMsg.c_str(), "PRIORITY=%i", LOG_INFO,
+                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
+                    "REDFISH_MESSAGE_ARGS=%s", x86ErrMsg.c_str(), NULL);
+
+                harvestX86ExceptionData(socNum);
+                runtimeError = true;
+            }
         }
     }
 
@@ -2350,6 +2600,21 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                             socNum, thresholdCount);
                         configMgr.updateErrorCountDbus();
                         configMgr.saveErrorCounts();
+                    }
+                    if (buf & x86ExceptionBit)
+                    {
+                        std::string x86ErrMsg =
+                            "x86 exception detected (e.g. segmentation fault)."
+                            " Harvesting core debug dump traces.";
+
+                        sd_journal_send(
+                            "MESSAGE=%s", x86ErrMsg.c_str(), "PRIORITY=%i",
+                            LOG_INFO, "REDFISH_MESSAGE_ID=%s",
+                            "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
+                            x86ErrMsg.c_str(), NULL);
+
+                        harvestX86ExceptionData(socNum);
+                        runtimeError = true;
                     }
                 }
             }

--- a/src/base_manager.cpp
+++ b/src/base_manager.cpp
@@ -142,7 +142,7 @@ void Manager::getCpuSocketInfo()
 
 Manager::Manager(amd::ras::config::Manager& manager, std::string& node) :
     errCount(0), configMgr(manager), rcd(nullptr), mcaPtr(nullptr),
-    dramPtr(nullptr), pciePtr(nullptr), node(node)
+    dramPtr(nullptr), pciePtr(nullptr), coreDebugDumpPtr(nullptr), node(node)
 {}
 
 } // namespace ras

--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -81,6 +81,18 @@ EFI_GUID gEfiEventNotificationTypeMceGuid = {
     0x4cc5,
     {0xBA, 0x88, 0x65, 0xAB, 0xE1, 0x49, 0x13, 0xBB}};
 
+EFI_GUID gEfiCoreDebugDumpSectionGuid = {
+    0xFDBE4ADF,
+    0x86EC,
+    0x47E3,
+    {0x89, 0xBE, 0x69, 0x30, 0x61, 0xA0, 0xF4, 0x68}};
+
+EFI_GUID gEfiEventNotificationTypeCoreDebugDumpGuid = {
+    0xF2AE518B,
+    0xF661,
+    0x434B,
+    {0xBD, 0xD8, 0x54, 0x69, 0x9B, 0x7B, 0xEC, 0x81}};
+
 std::mutex indexFileMtx;
 
 std::map<int, std::unique_ptr<CrashdumpInterface>> managers;
@@ -100,6 +112,11 @@ template void dumpHeader(const std::shared_ptr<PcieRuntimeCperRecord>& data,
                          const std::string_view& errorType, uint32_t boardId,
                          uint64_t& recordId);
 
+template void dumpHeader(const std::shared_ptr<CoreDebugDumpCperRecord>& data,
+                         uint16_t sectionCount, uint32_t errorSeverity,
+                         const std::string_view& errorType, uint32_t boardId,
+                         uint64_t& recordId);
+
 template void dumpErrorDescriptor(const std::shared_ptr<FatalCperRecord>&,
                                   uint16_t, const std::string_view&, uint32_t*,
                                   uint8_t);
@@ -112,6 +129,10 @@ template void dumpErrorDescriptor(const std::shared_ptr<PcieRuntimeCperRecord>&,
                                   uint16_t, const std::string_view&, uint32_t*,
                                   uint8_t);
 
+template void
+    dumpErrorDescriptor(const std::shared_ptr<CoreDebugDumpCperRecord>&,
+                        uint16_t, const std::string_view&, uint32_t*, uint8_t);
+
 template void createFile(const std::shared_ptr<FatalCperRecord>&,
                          const std::string_view&, uint16_t, size_t&,
                          const std::string&);
@@ -121,6 +142,10 @@ template void createFile(const std::shared_ptr<McaRuntimeCperRecord>&,
                          const std::string&);
 
 template void createFile(const std::shared_ptr<PcieRuntimeCperRecord>&,
+                         const std::string_view&, uint16_t, size_t&,
+                         const std::string&);
+
+template void createFile(const std::shared_ptr<CoreDebugDumpCperRecord>&,
                          const std::string_view&, uint16_t, size_t&,
                          const std::string&);
 
@@ -531,6 +556,17 @@ void dumpHeader(const std::shared_ptr<PtrType>& data, uint16_t sectionCount,
         memcpy(&data->Header.NotificationType,
                &gEfiEventNotificationTypeMceGuid, sizeof(EFI_GUID));
     }
+    else if (errorType == coreDebugDumpErr)
+    {
+        /* RecordLength will be updated by the caller after payload sizes
+           are known. Initialize with header + descriptors only. */
+        data->Header.RecordLength =
+            sizeof(EFI_COMMON_ERROR_RECORD_HEADER) +
+            (sizeof(EFI_ERROR_SECTION_DESCRIPTOR) * sectionCount);
+
+        memcpy(&data->Header.NotificationType,
+               &gEfiEventNotificationTypeCoreDebugDumpGuid, sizeof(EFI_GUID));
+    }
 
     /*TimeStamp when OOB controller received the event*/
     calculateTimestamp(data);
@@ -617,6 +653,23 @@ void dumpErrorDescriptor(const std::shared_ptr<PtrType>& data,
 
             std::strcpy(data->SectionDescriptor[i].FruString, "PcieError");
         }
+        else if (errorType == coreDebugDumpErr)
+        {
+            /* SectionOffset and SectionLength will be updated by the
+               caller after payload sizes are determined. */
+            data->SectionDescriptor[i].SectionOffset = 0;
+            data->SectionDescriptor[i].SectionLength = 0;
+
+            memcpy(&data->SectionDescriptor[i].SectionType,
+                   &gEfiCoreDebugDumpSectionGuid, sizeof(EFI_GUID));
+
+            /* Informational severity = 3 */
+            data->SectionDescriptor[i].Severity = 3;
+
+            std::strncpy(data->SectionDescriptor[i].FruString, "CoreDebugDump",
+                         nineteen);
+            data->SectionDescriptor[i].FruString[nineteen] = '\0';
+        }
 
         data->SectionDescriptor[i].Revision = singleBit; // 1 = EPYC
 
@@ -672,6 +725,7 @@ void createFile(const std::shared_ptr<PtrType>& data,
     std::shared_ptr<McaRuntimeCperRecord> procPtr;
     std::shared_ptr<PcieRuntimeCperRecord> pciePtr;
     std::shared_ptr<FatalCperRecord> fatalPtr;
+    std::shared_ptr<CoreDebugDumpCperRecord> coreDebugPtr;
 
     if constexpr (std::is_same_v<PtrType, McaRuntimeCperRecord>)
     {
@@ -684,6 +738,10 @@ void createFile(const std::shared_ptr<PtrType>& data,
     if constexpr (std::is_same_v<PtrType, FatalCperRecord>)
     {
         fatalPtr = std::static_pointer_cast<FatalCperRecord>(data);
+    }
+    if constexpr (std::is_same_v<PtrType, CoreDebugDumpCperRecord>)
+    {
+        coreDebugPtr = std::static_pointer_cast<CoreDebugDumpCperRecord>(data);
     }
 
     cperFileName = getCperFilename(errCount);
@@ -699,6 +757,10 @@ void createFile(const std::shared_ptr<PtrType>& data,
     else if (errorType == runtimePcieErr)
     {
         cperFileName = "pcie-runtime-" + cperFileName;
+    }
+    else if (errorType == coreDebugDumpErr)
+    {
+        cperFileName = "core-debug-dump-" + cperFileName;
     }
 
     if (node == "1" || node == "2")
@@ -795,10 +857,64 @@ void createFile(const std::shared_ptr<PtrType>& data,
                             "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
         }
     }
+    else if (errorType == coreDebugDumpErr)
+    {
+        if ((coreDebugPtr) && (file != nullptr))
+        {
+            fwrite(&coreDebugPtr->Header,
+                   sizeof(EFI_COMMON_ERROR_RECORD_HEADER), singleBit, file);
+
+            fwrite(coreDebugPtr->SectionDescriptor,
+                   sizeof(EFI_ERROR_SECTION_DESCRIPTOR) * sectionCount,
+                   singleBit, file);
+
+            for (uint16_t i = 0; i < sectionCount; i++)
+            {
+                fwrite(&coreDebugPtr->DebugDumpSection[i].header,
+                       sizeof(CoreDebugDumpHeader), singleBit, file);
+
+                uint32_t payloadSize =
+                    coreDebugPtr->SectionDescriptor[i].SectionLength -
+                    sizeof(CoreDebugDumpHeader);
+                if (payloadSize > 0 &&
+                    coreDebugPtr->DebugDumpSection[i].payload != nullptr)
+                {
+                    fwrite(coreDebugPtr->DebugDumpSection[i].payload,
+                           payloadSize, singleBit, file);
+                }
+            }
+
+            std::string rasErrMsg = "Generated Core Debug Dump CPER file : ";
+            rasErrMsg.append(cperFilePath);
+
+            sd_journal_send("MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i",
+                            LOG_INFO, "REDFISH_MESSAGE_ID=%s",
+                            "OpenBMC.0.1.AtScaleDebugConnected",
+                            "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+        }
+    }
     fclose(file);
 }
 
 } // namespace cper
+
+void cper::dumpCoreDebugDumpHeader(
+    const std::shared_ptr<CoreDebugDumpCperRecord>& coreDebugPtr,
+    uint16_t sectionIdx, const std::unique_ptr<CpuId[]>& cpuId)
+{
+    CoreDebugDumpHeader& hdr =
+        coreDebugPtr->DebugDumpSection[sectionIdx].header;
+    std::memset(&hdr, 0, sizeof(CoreDebugDumpHeader));
+
+    hdr.validBits.apicIdValid = 1;
+    hdr.validBits.cpuidValid = 1;
+    hdr.apicId = ((cpuId[0].ebx >> 24) & 0xFF);
+    hdr.cpuidInfo.eax = cpuId[0].eax;
+    hdr.cpuidInfo.ebx = cpuId[0].ebx;
+    hdr.cpuidInfo.ecx = cpuId[0].ecx;
+    hdr.cpuidInfo.edx = cpuId[0].edx;
+}
+
 } // namespace util
 } // namespace ras
 } // namespace amd


### PR DESCRIPTION
Implement harvesting of core debug dump data when an x86 exception (e.g. segmentation fault) is detected via SBRMI::RASStatus[7].

- Add harvestX86ExceptionData() to issue BMC_RAS_DBG_LOG_VALIDITY_CHECK and BMC_RAS_DBG_LOG_DUMP APML commands to collect per-core debug trace data from cores that encountered x86 exceptions
- Define CoreDebugDumpCperRecord, CoreDebugDumpHeader, and CoreDebugDumpSection structures in oem_cper.hpp for the new CPER record type
- Add CPER helper support: dumpCoreDebugDumpHeader(), template instantiations for dumpHeader/dumpErrorDescriptor/createFile, and new GUIDs for core debug dump section and notification types
- Wire x86 exception detection into both decodeInterrupt() overloads by checking the x86ExceptionBit (0x80) in RAS status

Tests:
Vewrified CPER creation for x86 exception successfully.