### PR TITLE
fix CPU udev alert handler to use socIndex

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -597,9 +597,9 @@ void Manager::configure()
                 return;
             }
             lg2::debug("Register to udev event is successful {CPU}\n", "CPU",
-                       i);
+                       socIndex[i]);
 
-            alertSrcHandler(&ud[i], i);
+            alertSrcHandler(&ud[i], socIndex[i]);
         }
     }
     else


### PR DESCRIPTION
Update CPU udev alert handler registration to use the SoC index instead of the loop index.

Tests:
Verified the error alerts generation successfully