### PR TITLE
align Aifs failure interrupt messageID with OpenBMC naming

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -2275,7 +2275,7 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
                                     messageIds.begin(), messageIds.end(),
                                     [](const std::string& messageId) {
                                         return messageId ==
-                                               "AmdAifsFailureMatch";
+                                               "OpenBMC.AmdAifsFailureMatch";
                                     });
                                 if (messageIdFound)
                                 {
@@ -2694,7 +2694,7 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                                             messageIds.end(),
                                             [](const std::string& messageId) {
                                                 return messageId ==
-                                                       "AmdAifsFailureMatch";
+                                                       "OpenBMC.AmdAifsFailureMatch";
                                             });
                                         if (messageIdFound)
                                         {


### PR DESCRIPTION
Update the AmdAifsFailureMatch message ID to use the OpenBMC-prefixed namespace when decoding SOC interrupts. This ensures consistency with Redfish/OpenBMC event schemas.