### PR TITLE
update harvesting x86Exception to new APML APIs

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -1417,7 +1417,7 @@ void Manager::harvestX86ExceptionData(uint8_t socNum)
 {
     oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
     uint16_t retries = 0;
-    struct ras_df_err_chk dbgLogCheck;
+    struct ras_dbg_log_chk_out dbgLogCheck;
     constexpr uint8_t dbgLogBlockId = 24;
 
     amd::ras::config::Manager::AttributeValue apmlRetry =
@@ -1436,16 +1436,16 @@ void Manager::harvestX86ExceptionData(uint8_t socNum)
     {
         retries++;
         ret =
-            read_ras_df_err_validity_check(socNum, dbgLogBlockId, &dbgLogCheck);
+            bmc_ras_dbg_log_validity_check(socNum, dbgLogBlockId, &dbgLogCheck);
 
         if (ret == OOB_SUCCESS)
         {
+            uint16_t errLogLen = dbgLogCheck.err_log_len;
             lg2::info(
                 "Socket {SOCKET}: x86 exception debug log validity check OK. "
                 "Instances: {INST}, Log length: {LEN}",
-                "SOCKET", socNum, "INST",
-                static_cast<unsigned short>(dbgLogCheck.df_block_instances),
-                "LEN", static_cast<unsigned short>(dbgLogCheck.err_log_len));
+                "SOCKET", socNum, "INST", dbgLogCheck.num_instances, "LEN",
+                errLogLen);
             break;
         }
 
@@ -1459,7 +1459,7 @@ void Manager::harvestX86ExceptionData(uint8_t socNum)
         sleep(1);
     }
 
-    uint16_t totalInstances = dbgLogCheck.df_block_instances;
+    uint16_t totalInstances = dbgLogCheck.num_instances;
     uint16_t logLenPerInstance = dbgLogCheck.err_log_len;
 
     if (totalInstances == 0)
@@ -1559,7 +1559,7 @@ void Manager::harvestX86ExceptionData(uint8_t socNum)
         /* Harvest debug log data for this core's instances */
         uint16_t baseInstance = coreIdx * instancesPerCore;
         uint32_t payloadOffset = 0;
-        union ras_df_err_dump dfError = {0};
+        struct ras_dbg_log_in dfError = {0, 0, 0};
 
         for (uint16_t inst = 0; inst < instancesPerCore; inst++)
         {
@@ -1573,11 +1573,11 @@ void Manager::harvestX86ExceptionData(uint8_t socNum)
                 if (!apmlHang)
                 {
                     memset(&dfError, 0, sizeof(dfError));
-                    dfError.input[0] = offset * 4;
-                    dfError.input[1] = dbgLogBlockId;
-                    dfError.input[2] = baseInstance + inst;
+                    dfError.offset = offset * 4;
+                    dfError.dbg_log_block_id = dbgLogBlockId;
+                    dfError.instance_index = baseInstance + inst;
 
-                    ret = read_ras_df_err_dump(socNum, dfError, &data);
+                    ret = bmc_ras_dbg_log_dump(socNum, dfError, &data);
 
                     if (ret != OOB_SUCCESS)
                     {
@@ -1585,11 +1585,11 @@ void Manager::harvestX86ExceptionData(uint8_t socNum)
                         while (retryCount > 0)
                         {
                             memset(&dfError, 0, sizeof(dfError));
-                            dfError.input[0] = offset * 4;
-                            dfError.input[1] = dbgLogBlockId;
-                            dfError.input[2] = baseInstance + inst;
+                            dfError.offset = offset * 4;
+                            dfError.dbg_log_block_id = dbgLogBlockId;
+                            dfError.instance_index = baseInstance + inst;
 
-                            ret = read_ras_df_err_dump(socNum, dfError, &data);
+                            ret = bmc_ras_dbg_log_dump(socNum, dfError, &data);
                             if (ret == OOB_SUCCESS)
                             {
                                 break;
@@ -2544,6 +2544,9 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                             LOG_INFO, "REDFISH_MESSAGE_ID=%s",
                             "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
                             x86ErrMsg.c_str(), NULL);
+                        // adding sleep of 1 sec to increase the window time for
+                        // core exception for both iods.
+                        sleep(1);
 
                         harvestX86ExceptionData(socNum);
                         runtimeError = true;


### PR DESCRIPTION
Update x86 exception debug log harvesting to use the new APML APIs and data structures.

This change replaces legacy DF error validity and dump handling with the newer debug log–specific APIs, improving clarity and correctness of instance and log length handling.

The update includes:
- Switching to ras_dbg_log_chk_out for validity checks
- Using bmc_ras_dbg_log_validity_check() for debug log discovery
- Replacing ras_df_err_dump with ras_dbg_log_in for dump requests
- Using explicit fields (offset, block ID, instance index) instead of raw input arrays