### PR TITLE
add PLDM RAS support and refactor base manager responsibilities

### DIFF
--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -54,20 +54,26 @@ class Manager : public amd::ras::Manager
      *  configures PCIE settings, and clears the SbrmiAlertMask register for
      *  crashdump readiness.
      */
-    virtual void init();
+    void init() override;
+
+    /** @brief Configure APML RAS settings.
+     *
+     *  @details This function reads the gpio configuration from the
+     *  amd_ras_gpio_config.json file including alert handle mode and
+     *  GPIO alert line names.
+     */
+    void configure() override;
 
     /** @brief Register udev or request GPIO event for APML alert handling.
      *
      *  @details This function registers for udev events from Alertl_L driver on
-     *  RAS alerts or sets up GPIO event handling fot APML alerts based on
+     *  RAS alerts or sets up GPIO event handling for APML alerts based on
      *  apmlAlertFlag. If APML Alert_L is enabled, it uses the APML API to
      *  register for udev events. Otherwise, it requests GPIO events for alert
      *  handling by binding the alert event handler to the respective GPIO
-     * lines. The number of GPIO lines to be monitored and the flag
-     * apmlAlertFlag value is read from the amd_ras_gpio_config.json file.
+     *  lines.
      */
-
-    virtual void configure();
+    void registerEventHandler() override;
 
     /** @brief Unregister the APML Alert_L udev events.
      *
@@ -90,14 +96,11 @@ class Manager : public amd::ras::Manager
     sdbusplus::asio::object_server& objectServer;
     std::shared_ptr<sdbusplus::asio::connection>& systemBus;
 
-    size_t whFamilyId;
-    size_t whModel;
     uint8_t progId;
     size_t contextType;
     uint64_t recordId;
     size_t watchdogTimerCounter;
     boost::asio::io_context& io;
-    std::vector<uint8_t> blockId;
     bool apmlInitialized;
     bool platformInitialized;
     bool runtimeErrPollingSupported;
@@ -113,6 +116,7 @@ class Manager : public amd::ras::Manager
     std::vector<gpiod::line> gpioLines;
     std::vector<apml_udev_monitor> ud;
     std::string alertHandleMode;
+    std::vector<std::string> socketNames;
 
     /**
      * @brief Handler for alert events.
@@ -244,12 +248,15 @@ class Manager : public amd::ras::Manager
      */
     void clearSbrmiAlertMask(uint8_t socNum);
 
-    /** @brief Monitors the current host power state.
+    /** @brief Called when the host power state changes.
      *
-     *  @details This API monitors the current host power state using
-     *  xyz.openbmc_project.State.Host D-bus Interface.
+     *  @details Performs APML-specific actions on host state transitions,
+     *  such as waiting for OOB config readiness and triggering platform
+     *  initialization.
+     *
+     *  @param[in] hostOff - true if the host transitioned to Off state.
      */
-    void currentHostStateMonitor();
+    void onHostStateChanged(bool hostOff) override;
 
     /** @brief Initializes platform-specific settings.
      *

--- a/include/base_manager.hpp
+++ b/include/base_manager.hpp
@@ -52,10 +52,19 @@ class Manager
 
      * @details This pure virtual function must be overridden by any derived
      class. It is intended to perform any necessary configuration specific to
-     the derived class.
+     the derived class such as setting thresholds from a JSON file.
      *
      */
     virtual void configure() = 0;
+
+    /** @brief Registers event handlers for RAS alert handling.
+
+     * @details This pure virtual function must be overridden by any derived
+     class. It is intended to set up the event handling mechanism for
+     receiving RAS notifications.
+     *
+     */
+    virtual void registerEventHandler() = 0;
 
   protected:
     size_t errCount;
@@ -74,6 +83,9 @@ class Manager
     std::shared_ptr<CoreDebugDumpCperRecord> coreDebugDumpPtr;
     std::string node;
     std::vector<size_t> socIndex;
+    size_t whFamilyId;
+    size_t whModel;
+    std::vector<uint8_t> blockId;
 
     /** @brief Get the CPU socket information.
      *
@@ -82,6 +94,31 @@ class Manager
      *
      */
     void getCpuSocketInfo();
+
+    /** @brief Load platform configuration from JSON.
+     *
+     *  @details This API reads the platform configuration JSON file
+     *  and populates Model, FamilyID, and DebugLogID fields.
+     */
+    void loadPlatformConfig();
+
+    /** @brief Monitors the current host power state.
+     *
+     *  @details This API monitors the current host power state using
+     *  xyz.openbmc_project.State.Host D-bus Interface. When the host
+     *  state changes, it calls onHostStateChanged() which derived
+     *  classes override for transport-specific behavior.
+     */
+    void currentHostStateMonitor();
+
+    /** @brief Called when the host power state changes.
+     *
+     *  @details Derived classes override this to perform
+     *  transport-specific actions on host state transitions.
+     *
+     *  @param[in] hostOff - true if the host transitioned to Off state.
+     */
+    virtual void onHostStateChanged(bool hostOff) = 0;
 };
 
 } // namespace ras

--- a/include/pldm_manager.hpp
+++ b/include/pldm_manager.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "base_manager.hpp"
+
+#include <boost/asio/deadline_timer.hpp>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+
+namespace amd
+{
+namespace ras
+{
+namespace pldm
+{
+/** @brief Manages RAS (Reliability, Availability, and Serviceability)
+ * operations for PLDM.
+ *
+ *  @details This class is responsible for initializing and configuring RAS
+ * operations specific to PLDM. It inherits from the base `amd::ras::Manager`
+ * class and provides additional functionality tailored to PLDM.
+ *
+ *  @param[in] manager - Reference to the configuration manager.
+ *  @param[in] objectServer - The D-Bus object server.
+ *  @param[in] systemBus - Shared pointer to the D-Bus system bus connection.
+ *  @param[in] io - Boost ASIO I/O context for asynchronous operations.
+ *  @param[in] node - host node number to determine single or multi host.
+ */
+class Manager : public amd::ras::Manager
+{
+  public:
+    Manager() = delete;
+    Manager(const Manager&) = delete;
+    Manager& operator=(const Manager&) = delete;
+    Manager(Manager&&) = delete;
+    Manager& operator=(Manager&&) = delete;
+    ~Manager() = default;
+
+    Manager(amd::ras::config::Manager&, sdbusplus::asio::object_server&,
+            std::shared_ptr<sdbusplus::asio::connection>&,
+            boost::asio::io_context&, std::string&);
+
+    /** @brief Perform initialization for the error monitoring via PLDM.
+     *
+     *  @details It initializes the PLDM RAS Manager by setting up platform
+     *  and watchdog state monitoring for bios post complete. It reads CPU
+     *  IDs, configures PCIE settings using PLDM transport.
+     */
+    void init() override;
+
+    /** @brief Configure PLDM RAS settings.
+     *
+     *  @details This function configures PLDM RAS settings such as
+     *  thresholds from the JSON configuration file.
+     */
+    void configure() override;
+
+    /** @brief Register for PLDM event handling.
+     *
+     *  @details This function registers for PLDM events on RAS alerts.
+     *  It sets up the event handling mechanism for receiving PLDM-based
+     *  RAS notifications from the processor.
+     */
+    void registerEventHandler() override;
+
+  private:
+    sdbusplus::asio::object_server& objectServer;
+    std::shared_ptr<sdbusplus::asio::connection>& systemBus;
+    boost::asio::io_context& io;
+
+    // Indicates whether the PLDM subsystem has been initialized
+    bool pldmInitialized;
+    // Indicates whether the platform-specific setup is complete
+    bool platformInitialized;
+    // Indicates whether runtime error polling is supported for PLDM
+    bool runtimeErrPollingSupported;
+
+    /** @brief Called when the host power state changes.
+     *
+     *  @details Performs PLDM-specific actions on host state transitions,
+     *  such as triggering platform initialization.
+     *
+     *  @param[in] hostOff - true if the host transitioned to Off state.
+     */
+    void onHostStateChanged(bool hostOff) override;
+
+    /** @brief Initializes platform-specific settings.
+     *
+     *  @details It initializes the platform based on the family ID.
+     *  It sets up the necessary configurations for PLDM-based RAS
+     *  error reporting.
+     */
+    void platformInitialize();
+};
+
+} // namespace pldm
+} // namespace ras
+} // namespace amd

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,7 @@ cpp_args = [
     '-DINDEX_FILE="' + index_file + '"',
     '-DSRC_CONFIG_FILE="' + src_config_file + '"',
     '-DRAS_DIR="' + ras_dir + '"',
+    '-DAPML',
 ]
 
 libdir = meson.current_source_dir() + './lib/'
@@ -44,17 +45,8 @@ deps = [
     dependency('sdbusplus'),
     dependency('libsystemd'),
     dependency('nlohmann_json', include_type: 'system'),
+    apml_dep,
 ]
-
-apml = get_option('apml-interface')
-if apml
-    add_project_arguments('-DAPML', language: 'cpp')
-endif
-
-pldm = get_option('pldm-interface')
-if pldm
-    add_project_arguments('-DPLDM', language: 'cpp')
-endif
 
 apml_nda = get_option('apml-nda')
 if apml_nda
@@ -66,15 +58,11 @@ sources = [
     'src/main.cpp',
     'src/base_manager.cpp',
     'src/apml_manager.cpp',
+    'src/pldm_manager.cpp',
     'src/utils/util.cpp',
     'src/utils/cper.cpp',
     'src/crashdump_manager.cpp',
 ]
-
-if apml
-    sources += 'src/apml_manager.cpp'
-    deps += apml_dep
-endif
 
 executable(
     'amd-ras-manager',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,4 @@
-option('apml-interface', type: 'boolean', value: true, description: 'Enable APML interface')
 option('apml-nda', type: 'boolean', value: true, description: 'Build the RAS application with APML NDA library')
-option('pldm-interface', type: 'boolean', value: false, description: 'Enable PLDM interface')
 option('config_file', type: 'string', value: '/var/lib/amd-bmc-ras/ras_config', description: 'Path to the RAS config file')
 option('platform_default_file', type: 'string', value: '/var/lib/amd-bmc-ras/platform_default.json', description: 'Path to the default platform configuration file')
 option('src_config_file', type: 'string', value: '/usr/share/amd-bmc-ras/ras_config.json', description: 'Path to the source RAS config file')

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -122,81 +122,39 @@ Manager::Manager(amd::ras::config::Manager& manager,
     pcieErrorHarvestMtx()
 {}
 
-void Manager::currentHostStateMonitor()
+void Manager::onHostStateChanged(bool hostOff)
 {
-    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
-    boost::system::error_code ec;
+    apmlInitialized = false;
 
-    static auto match = sdbusplus::bus::match::match(
-        bus,
-        "type='signal',member='PropertiesChanged', "
-        "interface='org.freedesktop.DBus.Properties', "
-        "arg0='xyz.openbmc_project.State.Host'",
-        [this](sdbusplus::message::message& message) {
-            oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
-            std::string intfName;
-            std::map<std::string, std::variant<std::string>> properties;
+    if (!hostOff)
+    {
+        lg2::info("Current host state monitor changed");
+        oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+        uint32_t dataOut = 0;
 
-            try
+        while (ret != OOB_SUCCESS)
+        {
+            ret = get_bmc_ras_oob_config(0, &dataOut);
+
+            if (ret == OOB_SUCCESS)
             {
-                message.read(intfName, properties);
+                platformInitialize();
+                watchdogTimerCounter = 0;
+                break;
             }
-            catch (std::exception& e)
-            {
-                lg2::info("Unable to read host state");
-                return;
-            }
-            if (properties.empty())
-            {
-                lg2::error("ERROR: Empty PropertiesChanged signal received");
-                return;
-            }
-
-            // We only want to check for currentHostState
-            if (properties.begin()->first != "CurrentHostState")
-            {
-                return;
-            }
-            std::string* currentHostState =
-                std::get_if<std::string>(&(properties.begin()->second));
-            if (currentHostState == nullptr)
-            {
-                lg2::error("currentHostState Property invalid");
-                return;
-            }
-
-            apmlInitialized = false;
-
-            if (*currentHostState !=
-                "xyz.openbmc_project.State.Host.HostState.Off")
-            {
-                lg2::info("Current host state monitor changed");
-                uint32_t dataOut = 0;
-
-                while (ret != OOB_SUCCESS)
-                {
-                    ret = get_bmc_ras_oob_config(0, &dataOut);
-
-                    if (ret == OOB_SUCCESS)
-                    {
-                        platformInitialize();
-                        watchdogTimerCounter = 0;
-                        break;
-                    }
-                    sleep(1);
-                }
-            }
-        });
+            sleep(1);
+        }
+    }
 }
 
 void Manager::platformInitialize()
 {
+    lg2::info("Initializing Platform over APML transport");
     oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
     struct processor_info platInfo[1];
 
     if (platformInitialized == false)
     {
-        lg2::debug("Initializing Platfrom...");
         while (ret != OOB_SUCCESS)
         {
             uint8_t socNum = 0;
@@ -402,37 +360,7 @@ void Manager::init()
         sleep(1);
     }
 
-    lg2::info("PLATFORM INIT");
-
-    std::ifstream file("/var/lib/platform-config/platform.json");
-    if (!file.is_open())
-    {
-        file.open(PLATFORM_DEFAULT_FILE);
-    }
-
-    nlohmann::json jsonData = nlohmann::json::parse(file);
-
-    if (jsonData.contains("Model"))
-    {
-        std::string modelStr = jsonData["Model"];
-        whModel = std::stoi(modelStr, nullptr, 16);
-    }
-
-    if (jsonData.contains("FamilyID"))
-    {
-        std::string familyIdStr = jsonData["FamilyID"];
-        whFamilyId = std::stoi(familyIdStr, nullptr, 16);
-    }
-
-    if (jsonData.contains("DebugLogID"))
-    {
-        for (const auto& id : jsonData["DebugLogID"])
-        {
-            blockId.push_back(static_cast<uint8_t>(id));
-        }
-    }
-
-    file.close();
+    loadPlatformConfig();
 
     platformInitialize();
 
@@ -525,9 +453,6 @@ void Manager::init()
 
 void Manager::configure()
 {
-    std::vector<std::string> socketNames;
-    amd::ras::util::cper::createRecord(objectServer, systemBus, node);
-
     std::string gpioConfigFile =
         "/var/lib/amd-bmc-ras/amd_ras_gpio_config" + node + ".json";
 
@@ -578,6 +503,11 @@ void Manager::configure()
     {
         throw std::runtime_error("Invalid mode of Alert handling");
     }
+}
+
+void Manager::registerEventHandler()
+{
+    amd::ras::util::cper::createRecord(objectServer, systemBus, node);
 
     if (alertHandleMode == "UEVENT")
     {
@@ -2977,7 +2907,7 @@ void Manager::runTimeErrorPolling()
 {
     oob_status_t ret;
 
-    lg2::info("Setting MCA and DRAM OOB Config");
+    lg2::info("runTimeErrorPolling: Setting MCA and DRAM OOB Config");
 
     ret = setMcaOobConfig();
 
@@ -2986,7 +2916,7 @@ void Manager::runTimeErrorPolling()
       is supported for the platform*/
     if (ret != OOB_MAILBOX_CMD_UNKNOWN)
     {
-        lg2::info("Setting PCIE OOB Config");
+        lg2::info("runTimeErrorPolling: Setting PCIE OOB Config");
 
         setPcieOobConfig();
 

--- a/src/base_manager.cpp
+++ b/src/base_manager.cpp
@@ -6,6 +6,7 @@
 #include <boost/asio/io_context.hpp>
 #include <nlohmann/json.hpp>
 #include <phosphor-logging/lg2.hpp>
+#include <sdbusplus/bus/match.hpp>
 
 #include <fstream>
 
@@ -142,8 +143,89 @@ void Manager::getCpuSocketInfo()
 
 Manager::Manager(amd::ras::config::Manager& manager, std::string& node) :
     errCount(0), configMgr(manager), rcd(nullptr), mcaPtr(nullptr),
-    dramPtr(nullptr), pciePtr(nullptr), coreDebugDumpPtr(nullptr), node(node)
+    dramPtr(nullptr), pciePtr(nullptr), coreDebugDumpPtr(nullptr), node(node),
+    whFamilyId(0), whModel(0)
 {}
+
+void Manager::loadPlatformConfig()
+{
+    std::ifstream file("/var/lib/platform-config/platform.json");
+    if (!file.is_open())
+    {
+        file.open(PLATFORM_DEFAULT_FILE);
+    }
+
+    nlohmann::json jsonData = nlohmann::json::parse(file);
+
+    if (jsonData.contains("Model"))
+    {
+        std::string modelStr = jsonData["Model"];
+        whModel = std::stoi(modelStr, nullptr, 16);
+    }
+
+    if (jsonData.contains("FamilyID"))
+    {
+        std::string familyIdStr = jsonData["FamilyID"];
+        whFamilyId = std::stoi(familyIdStr, nullptr, 16);
+    }
+
+    if (jsonData.contains("DebugLogID"))
+    {
+        for (const auto& id : jsonData["DebugLogID"])
+        {
+            blockId.push_back(static_cast<uint8_t>(id));
+        }
+    }
+
+    file.close();
+}
+
+void Manager::currentHostStateMonitor()
+{
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+
+    static auto match = sdbusplus::bus::match::match(
+        bus,
+        "type='signal',member='PropertiesChanged', "
+        "interface='org.freedesktop.DBus.Properties', "
+        "arg0='xyz.openbmc_project.State.Host'",
+        [this](sdbusplus::message::message& message) {
+            std::string intfName;
+            std::map<std::string, std::variant<std::string>> properties;
+
+            try
+            {
+                message.read(intfName, properties);
+            }
+            catch (std::exception& e)
+            {
+                lg2::info("Unable to read host state");
+                return;
+            }
+            if (properties.empty())
+            {
+                lg2::error("ERROR: Empty PropertiesChanged signal received");
+                return;
+            }
+
+            // We only want to check for currentHostState
+            if (properties.begin()->first != "CurrentHostState")
+            {
+                return;
+            }
+            std::string* currentHostState =
+                std::get_if<std::string>(&(properties.begin()->second));
+            if (currentHostState == nullptr)
+            {
+                lg2::error("currentHostState Property invalid");
+                return;
+            }
+
+            bool hostOff = (*currentHostState ==
+                            "xyz.openbmc_project.State.Host.HostState.Off");
+            onHostStateChanged(hostOff);
+        });
+}
 
 } // namespace ras
 } // namespace amd

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,26 @@
-#include "config_manager.hpp"
-#ifdef APML
 #include "apml_manager.hpp"
-#endif
 #include "base_manager.hpp"
+#include "config_manager.hpp"
+#include "pldm_manager.hpp"
+#include "utils/util.hpp"
 
 #include <boost/asio.hpp>
+#include <memory>
 #include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/asio/connection.hpp>
 #include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/bus.hpp>
+
+static constexpr auto settingsService = "xyz.openbmc_project.Settings";
+static constexpr auto miscSettingsPath =
+    "/xyz/openbmc_project/control/AmdMiscSettings";
+static constexpr auto miscSettingsIface = "com.amd.AmdMiscSettings";
+static constexpr auto mgmtModeProperty = "OobSbrmiMgmtMode";
+
+static constexpr auto apmlModeValue =
+    "com.amd.AmdMiscSettings.OobSbrmiMgmtModes.apml";
+static constexpr auto pldmModeValue =
+    "com.amd.AmdMiscSettings.OobSbrmiMgmtModes.pldm";
 
 int main(int argc, char* argv[])
 {
@@ -21,6 +34,22 @@ int main(int argc, char* argv[])
     node = argv[1];
 
     lg2::info("Start amd ras service for host : {NODE}", "NODE", node);
+
+    // Read the OOB management mode from D-Bus to determine APML or PLDM
+    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+    std::string mgmtMode = amd::ras::util::getProperty<std::string>(
+        bus, settingsService, miscSettingsPath, miscSettingsIface,
+        mgmtModeProperty);
+
+    lg2::info("OobSbrmiMgmtMode: {MODE}", "MODE", mgmtMode);
+
+    bool isPldmMode = (mgmtMode == pldmModeValue);
+
+    if (mgmtMode != apmlModeValue && !isPldmMode)
+    {
+        lg2::error("Unknown OobSbrmiMgmtMode: {MODE}, defaulting to APML",
+                   "MODE", mgmtMode);
+    }
 
     // Setup connection to D-Bus
     boost::asio::io_context io;
@@ -39,28 +68,34 @@ int main(int argc, char* argv[])
 
     amd::ras::config::Manager manager(objectServer, systemBus, node);
 
-#ifdef APML
-    amd::ras::Manager* errorMgr =
-        new amd::ras::apml::Manager(manager, objectServer, systemBus, io, node);
+    // Factory: create the appropriate manager based on the mode
+    std::unique_ptr<amd::ras::Manager> errorMgr;
+    if (isPldmMode)
+    {
+        errorMgr = std::make_unique<amd::ras::pldm::Manager>(
+            manager, objectServer, systemBus, io, node);
+    }
+    else
+    {
+        errorMgr = std::make_unique<amd::ras::apml::Manager>(
+            manager, objectServer, systemBus, io, node);
+    }
 
     errorMgr->init();
-
     errorMgr->configure();
-#endif
-
-#ifdef PLDM
-    // Log an error message if PLDM capabilities are not enabled
-    lg2::error("TODO: PLDM RAS capabilities are yet to be enabled");
-#endif
+    errorMgr->registerEventHandler();
 
     io.run();
-#ifdef APML
-    auto* apmlMgr = dynamic_cast<amd::ras::apml::Manager*>(errorMgr);
-    if (apmlMgr && apmlMgr->getAlertHandleMode() == "UEVENT")
+
+    if (!isPldmMode)
     {
-        apmlMgr->releaseUdevReSrc();
+        auto* apmlMgr =
+            dynamic_cast<amd::ras::apml::Manager*>(errorMgr.get());
+        if (apmlMgr && apmlMgr->getAlertHandleMode() == "UEVENT")
+        {
+            apmlMgr->releaseUdevReSrc();
+        }
     }
-#endif
 
     return 0;
 }

--- a/src/pldm_manager.cpp
+++ b/src/pldm_manager.cpp
@@ -1,0 +1,125 @@
+#include "pldm_manager.hpp"
+
+#include "config_manager.hpp"
+#include "utils/cper.hpp"
+#include "utils/util.hpp"
+
+extern "C"
+{
+#include "esmi_cpuid_msr.h"
+#include "esmi_mailbox.h"
+}
+
+#include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <phosphor-logging/log.hpp>
+
+namespace amd
+{
+namespace ras
+{
+namespace pldm
+{
+
+Manager::Manager(amd::ras::config::Manager& manager,
+                 sdbusplus::asio::object_server& objectServer,
+                 std::shared_ptr<sdbusplus::asio::connection>& systemBus,
+                 boost::asio::io_context& io, std::string& node) :
+    amd::ras::Manager(manager, node), objectServer(objectServer),
+    systemBus(systemBus), io(io), pldmInitialized(false),
+    platformInitialized(false), runtimeErrPollingSupported(false)
+{}
+
+void Manager::onHostStateChanged(bool hostOff)
+{
+    pldmInitialized = false;
+
+    if (!hostOff)
+    {
+        lg2::info("Current host state monitor changed");
+        platformInitialize();
+    }
+}
+
+void Manager::platformInitialize()
+{
+    lg2::info("Initializing Platform over PLDM transport");
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+    struct processor_info platInfo[1];
+
+    if (platformInitialized == false)
+    {
+        while (ret != OOB_SUCCESS)
+        {
+            uint8_t socNum = 0;
+            ret = esmi_get_processor_info(socNum, platInfo);
+
+            if (ret == OOB_SUCCESS)
+            {
+                familyId = platInfo->family;
+                break;
+            }
+            lg2::error("Failed to get processor info. RET: {RET}", "RET", ret);
+            sleep(1);
+        }
+
+        if ((platInfo->family == whFamilyId) && (platInfo->model == whModel))
+        {
+            currentHostStateMonitor();
+
+            // TODO: Add support for runtime error polling for PLDM when the API
+            // is available.
+            runtimeErrPollingSupported = true;
+        }
+        else
+        {
+            throw std::runtime_error(std::format(
+                "This program is not supported for the family = 0x{:x} model = 0x{:x}\n",
+                platInfo->family, platInfo->model));
+        }
+
+        platformInitialized = true;
+        pldmInitialized = true;
+    }
+    else
+    {
+        pldmInitialized = true;
+        if (runtimeErrPollingSupported == true)
+        {
+            lg2::info("Setting MCA and DRAM OOB Config");
+            // TODO: Add support for setting MCA and DRAM OOB config for PLDM
+            // when the API is available.
+
+            lg2::info("Setting MCA and DRAM Error threshold");
+            // TODO: Add support for setting MCA and DRAM error threshold for
+            // PLDM when the API is available.
+        }
+    }
+}
+
+void Manager::init()
+{
+    lg2::info("PLDM MANAGER INIT");
+
+    getCpuSocketInfo();
+
+    loadPlatformConfig();
+
+    platformInitialize();
+}
+
+void Manager::configure()
+{
+    lg2::info("PLDM MANAGER CONFIGURE");
+}
+
+void Manager::registerEventHandler()
+{
+    lg2::info("PLDM MANAGER REGISTER EVENT HANDLER");
+
+    amd::ras::util::cper::createRecord(objectServer, systemBus, node);
+}
+
+} // namespace pldm
+} // namespace ras
+} // namespace amd


### PR DESCRIPTION
This change introduces PLDM-based RAS support and refactors common RAS infrastructure to better separate transport-specific logic from shared core functionality.

Key changes include:
- Move platform identification fields (FamilyID, Model, DebugLogID) and platform configuration parsing into the base RAS manager.
- Add loadPlatformConfig() to centralize platform JSON handling.
- Refactor host power state monitoring into the base manager and introduce onHostStateChanged() as a virtual callback for transport-specific behavior.
- Introduce a new PLDM RAS manager with initialization and configuration flows aligned to PLDM transport.
- Select APML or PLDM RAS manager at runtime based on OobSbrmiMgmtMode read from D-Bus settings.
- Simplify Meson build configuration by removing conditional interface options and always building APML/PLDM components.