### PR TITLE
fix CPER section indexing in FRU data population

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -3343,13 +3343,13 @@ void Manager::dumpProcErrorSection(
 
         if ((category == 0) || (category == 1))
         {
-            memcpy(ProcPtr->SectionDescriptor[socNum].FruString + offLo1,
+            memcpy(ProcPtr->SectionDescriptor[section].FruString + offLo1,
                    &mcaPspSynd1Lo, copySize);
-            memcpy(ProcPtr->SectionDescriptor[socNum].FruString + offHi1,
+            memcpy(ProcPtr->SectionDescriptor[section].FruString + offHi1,
                    &mcaPspSynd1Hi, copySize);
-            memcpy(ProcPtr->SectionDescriptor[socNum].FruString + offLo2,
+            memcpy(ProcPtr->SectionDescriptor[section].FruString + offLo2,
                    &mcaPspSynd2Lo, copySize);
-            memcpy(ProcPtr->SectionDescriptor[socNum].FruString + offHi2,
+            memcpy(ProcPtr->SectionDescriptor[section].FruString + offHi2,
                    &mcaPspSynd2Hi, copySize);
 
             CheckInfo[section] = 0;


### PR DESCRIPTION
Fix incorrect indexing of CPER section descriptors in dumpProcErrorSection().

The processor error FRU string was populated using socNum as the section index, even though CPER section descriptors are indexed by section number. This could lead to out-of-bounds access or incorrect data placement when section count does not match socket numbering.