### PR TITLE
Classify UMC MCA errors as MemoryError instead of ProcessorError

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -56,6 +56,8 @@ constexpr size_t mcaPspSynd1LoCode = 80;
 constexpr size_t mcaPspSynd1HiCode = 84;
 constexpr size_t mcaPspSynd2LoCode = 88;
 constexpr size_t mcaPspSynd2HiCode = 92;
+constexpr size_t mcaIpidHiOffset = 0x2C;
+constexpr uint32_t umcHardwareId = 0x96;
 constexpr size_t offLo1 = 0;
 constexpr size_t offHi1 = 4;
 constexpr size_t offLo2 = 8;
@@ -3247,6 +3249,7 @@ void Manager::dumpProcErrorSection(
     uint32_t mcaPspSynd1Hi = 0;
     uint32_t mcaPspSynd2Lo = 0;
     uint32_t mcaPspSynd2Hi = 0;
+    uint32_t mcaIpidHi = 0;
 
     amd::ras::config::Manager::AttributeValue apmlRetry =
         configMgr.getAttribute("ApmlRetries");
@@ -3350,6 +3353,11 @@ void Manager::dumpProcErrorSection(
                                         mcaStatusRegister;
                 }
 
+                if (dataIn.offset == mcaIpidHiOffset)
+                {
+                    mcaIpidHi = dataOut;
+                }
+
                 if (dataIn.offset == mcaPspSynd1LoCode + baseOffset)
                 {
                     mcaPspSynd1Lo = dataOut;
@@ -3401,6 +3409,15 @@ void Manager::dumpProcErrorSection(
                    &mcaPspSynd2Lo, copySize);
             memcpy(ProcPtr->SectionDescriptor[section].FruString + offHi2,
                    &mcaPspSynd2Hi, copySize);
+
+            if (category == 0 && mcaPspSynd1Lo == 0 && mcaPspSynd1Hi == 0 &&
+                mcaPspSynd2Lo == 0 && mcaPspSynd2Hi == 0 &&
+                (mcaIpidHi & 0xFFF) == umcHardwareId)
+            {
+                std::strncpy(ProcPtr->SectionDescriptor[section].FruString,
+                             "MemoryError", 19);
+                ProcPtr->SectionDescriptor[section].FruString[19] = '\0';
+            }
 
             CheckInfo[section] = 0;
             CheckInfo[section] |= ((mcaStatusRegister >> 57) & 1ULL) << 19;


### PR DESCRIPTION
In dumpProcErrorSection(), when DRAM ECC correctable errors are detected through MCA polling (category 0), the PSP syndrome data is typically all zeros, leaving FruString empty. dumpErrorDescriptor() then defaults to "ProcessorError" for all runtimeMcaErr types, even when the MCA error originated from the UMC (Unified Memory Controller), which is a memory error.

Fix this by checking the MCA IPID HardwareID field after writing syndrome data to FruString. If this is an MCA error (category 0) with zero PSP syndrome and the IPID identifies a UMC (HardwareID 0x96), explicitly set FruString to "MemoryError".

Tested:
Verified DRAM ECC correctable errors from UMC are now reported as MemoryError in CPER records.