### PR TITLE
[Helios] Add DramCeccOobEcMode and DramCeccLeakRate into the ras_config.json

### DIFF
--- a/config/ras_config.json
+++ b/config/ras_config.json
@@ -77,21 +77,21 @@
         {
             "DramCeccOobEcMode": {
                 "Description": "DRAM CECC OOB error counter mode: 0=disabled, 1=no-leak mode, 2=leaky bucket mode",
-                "Value": 1,
+                "Value": 2,
                 "MaxBoundLimit": 2
             }
         },
         {
             "DramCeccLeakRate": {
                 "Description": "DRAM CECC leaky bucket leak rate (0x00-0x1F). Only used when DramCeccOobEcMode=2",
-                "Value": 0,
+                "Value": 20,
                 "MaxBoundLimit": 31
             }
         },
         {
             "DramCeccThresholdEn": {
                 "Description": "If this field is true, error thresholding for DRAM ECC correctable errors will be enabled",
-                "Value": false
+                "Value": true
             }
         },
         {
@@ -103,7 +103,7 @@
         {
             "DramCeccErrThresholdCnt": {
                 "Description": "Error threshold count for DRAM ECC correctable errors",
-                "Value": 1
+                "Value": 2
             }
         },
         {

--- a/config/ras_config.json
+++ b/config/ras_config.json
@@ -75,6 +75,20 @@
             }
         },
         {
+            "DramCeccOobEcMode": {
+                "Description": "DRAM CECC OOB error counter mode: 0=disabled, 1=no-leak mode, 2=leaky bucket mode",
+                "Value": 1,
+                "MaxBoundLimit": 2
+            }
+        },
+        {
+            "DramCeccLeakRate": {
+                "Description": "DRAM CECC leaky bucket leak rate (0x00-0x1F). Only used when DramCeccOobEcMode=2",
+                "Value": 0,
+                "MaxBoundLimit": 31
+            }
+        },
+        {
             "DramCeccThresholdEn": {
                 "Description": "If this field is true, error thresholding for DRAM ECC correctable errors will be enabled",
                 "Value": false

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -2029,7 +2029,20 @@ oob_status_t Manager::setMcaErrThreshold()
 
         getOobRegisters(&oob_config);
 
-        oob_config.dram_cecc_oob_ec_mode = 1;
+        amd::ras::config::Manager::AttributeValue dramCeccOobEcModeVal =
+            configMgr.getAttribute("DramCeccOobEcMode");
+        int64_t* dramCeccOobEcMode =
+            std::get_if<int64_t>(&dramCeccOobEcModeVal);
+
+        amd::ras::config::Manager::AttributeValue dramCeccLeakRateVal =
+            configMgr.getAttribute("DramCeccLeakRate");
+        int64_t* dramCeccLeakRate =
+            std::get_if<int64_t>(&dramCeccLeakRateVal);
+
+        oob_config.dram_cecc_oob_ec_mode =
+            static_cast<uint8_t>(*dramCeccOobEcMode);
+        oob_config.dram_cecc_leak_rate =
+            static_cast<uint8_t>(*dramCeccLeakRate);
         oob_config.mca_oob_misc0_ec_enable = 1;
 
         ret = setRasOobConfig(oob_config);
@@ -2148,8 +2161,21 @@ oob_status_t Manager::setMcaOobConfig()
     if (*dramCeccPollingEn == true)
     {
         /* DRAM CECC OOB Error Counter Mode */
+        amd::ras::config::Manager::AttributeValue dramCeccOobEcModeVal =
+            configMgr.getAttribute("DramCeccOobEcMode");
+        int64_t* dramCeccOobEcMode =
+            std::get_if<int64_t>(&dramCeccOobEcModeVal);
+
+        amd::ras::config::Manager::AttributeValue dramCeccLeakRateVal =
+            configMgr.getAttribute("DramCeccLeakRate");
+        int64_t* dramCeccLeakRate =
+            std::get_if<int64_t>(&dramCeccLeakRateVal);
+
         oob_config.core_mca_err_reporting_en = 1;
-        oob_config.dram_cecc_oob_ec_mode = 1; /*Enabled in No leak mode*/
+        oob_config.dram_cecc_oob_ec_mode =
+            static_cast<uint8_t>(*dramCeccOobEcMode);
+        oob_config.dram_cecc_leak_rate =
+            static_cast<uint8_t>(*dramCeccLeakRate);
     }
 
     ret = setRasOobConfig(oob_config);


### PR DESCRIPTION
***Description***
Add DramCeccOobEcMode and DramCeccLeakRate into the ras_config.json for user settings.


***Change Description***
- With this change the leak mode and leak rate can be adjusted on build time and run time if needed as opposed to the older hardcoded no leak mode setting within the code.

***Testing***
- Compile time build and run time CPER generation is tested and made sure it doesn't break the functionalities.

<img width="354" height="238" alt="image" src="https://github.com/user-attachments/assets/bb4f5c53-f8ac-470a-8327-355f3bab62a1" />
<img width="943" height="247" alt="image" src="https://github.com/user-attachments/assets/a456103f-c880-4bf6-89dc-d0f53d4b2e62" />

