### PR TITLE
Add support for MPX TraceLogs with TBAI service

### DIFF
--- a/config/ras_config.json
+++ b/config/ras_config.json
@@ -11,14 +11,21 @@
             "SystemRecoveryMode": {
                 "Description": "System recovery mode",
                 "Value": "NO_RESET",
-                "ValidOptions": ["COLD_RESET", "WARM_RESET", "NO_RESET"]
+                "ValidOptions": [
+                    "COLD_RESET",
+                    "WARM_RESET",
+                    "NO_RESET"
+                ]
             }
         },
         {
             "ResetSignalType": {
                 "Description": "Reset Signal Type",
                 "Value": "SYS_RST",
-                "ValidOptions": ["SYS_RST", "RSMRST"]
+                "ValidOptions": [
+                    "SYS_RST",
+                    "RSMRST"
+                ]
             }
         },
         {
@@ -144,6 +151,24 @@
             "PcieAerErrThresholdCnt": {
                 "Description": "Error threshold count for PCIE AER errors",
                 "Value": 1
+            }
+        },
+        {
+            "Soc0MPList": {
+                "Description": "List of Socket 0 MP's where tracelogs are enabled",
+                "Value": [
+                    "IOD0_MPART",
+                    "IOD0_MPASP"
+                ]
+            }
+        },
+        {
+            "Soc1MPList": {
+                "Description": "List of Socket 1 MP's where tracelogs are enabled",
+                "Value": [
+                    "IOD0_MPART",
+                    "IOD0_MPASP"
+                ]
             }
         }
     ]

--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -277,6 +277,12 @@ class Manager : public amd::ras::Manager
     bool decodeInterrupt(uint8_t, uint32_t);
     bool decodeInterrupt(uint8_t);
 
+    /** @brief Merge autonomous MP trace data from amd-traces service into CPER.
+     *
+     *  @param[in] fullPath - Full path to the CPER file to merge into.
+     */
+     void mergeAutonomousTraceData(const std::string& fullPath);
+
     /** @brief Check the validity of MCA banks.
      *
      * @details This function performs a validity check on the MCA banks.

--- a/include/utils/cper.hpp
+++ b/include/utils/cper.hpp
@@ -39,7 +39,7 @@ constexpr uint8_t minorRevision = 0x0C;
  * match is found.
  */
 std::string findCperFilename(size_t);
-
+std::string findCperFilename(size_t number, const std::string& node);
 /** @brief Creates an index file and reads the error count from it.
  *
  *  @details Creates an index file in the specified RAS directory using the
@@ -281,6 +281,20 @@ void populateSignatureId(EFI_AMD_FATAL_ERROR_DATA& errorRecord,
 void populateFruStringPspSynd(EFI_ERROR_SECTION_DESCRIPTOR& sectionDesc,
                               uint32_t pspSynd1Lo, uint32_t pspSynd1Hi,
                               uint32_t pspSynd2Lo, uint32_t pspSynd2Hi);
+/**
+ * @brief Merges the contents of the source file into the destination file.
+ *
+ * This function reads the contents of the file specified by sourceFile
+ * and appends or merges it into the file specified by destFile.
+ * The exact merging behavior (e.g., append, overwrite, or custom logic)
+ * depends on the implementation.
+ *
+ * @param[in] sourceFile The path to the source file whose contents are to be merged.
+ * @param[inout] destFile The path to the destination file where the contents will be merged.
+ *
+ * @throws std::runtime_error if there is an error reading the source file or writing to the destination file.
+ */
+void mergeFile(const std::string& sourceFile, const std::string& destFile);
 
 } // namespace cper
 } // namespace util

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -684,6 +684,8 @@ void Manager::alertSrcHandler(struct apml_udev_monitor* udev_mon,
     ret = monitor_ras_alert(udev_mon->mon, block, &soc_num, &src);
     if (ret == OOB_SUCCESS)
     {
+        lg2::debug("APML alert received from socket {SOC} with source {SRC}", "SOC",
+                   soc_num, "SRC", src);
         if (rcd == nullptr)
         {
             rcd = std::make_shared<FatalCperRecord>();
@@ -2059,6 +2061,151 @@ bool Manager::checkIfCPUAlertsProcessed()
     return false;
 }
 
+void Manager::mergeAutonomousTraceData(const std::string& fullPath)
+{
+    std::string tracePropName = (node == secondNodeId)
+                                ? "AutonomousSecondNodeFilePath"
+                                : "AutonomousFilePath";
+    lg2::info("Current CPER file created: {FILE}", "FILE", fullPath);
+    lg2::info("Attempting to merge autonomous MP trace data from "
+              "amd-traces service using property: {PROP} for node {NODE}",
+              "PROP", tracePropName,
+              "NODE", node);
+    // Merge autonomous MP trace data from amd-traces service.
+    // amd-traces sets tracePropName property to "PENDING" at start,
+    // then to the file path on success or "" on error.
+    //
+    // Strategy:
+    //   1. Pre-check the property <E2><80><94> if amd-traces already finished
+    //      successfully, merge immediately without waiting.
+    //   2. If "PENDING" or "" (still working or not started yet),
+    //      fall through to signal-based wait.
+    //   3. Wait for signal-based wait to complete or timeout.
+    //   4. Merge the file if successful, log error if empty.
+    //   5. Log timeout if wait timed out.
+    sdbusplus::bus::bus traceBus = sdbusplus::bus::new_default();
+    std::string autonomousFile;
+    bool merged = false;
+
+    // --- Step 1: Pre-check property value ---
+    try
+    {
+        autonomousFile =
+            amd::ras::util::getProperty<std::string>(
+                traceBus, "com.amd.Traces",
+                "/com/amd/Traces",
+                "com.amd.Traces.Tbai",
+                tracePropName.c_str());
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed to read {PROP} "
+                   "property: {ERR}",
+                   "PROP", tracePropName,
+                   "ERR", e.what());
+    }
+
+    if (!autonomousFile.empty() && autonomousFile != "PENDING")
+    {
+        lg2::info("{PROP} already available: "
+                  "{FILE}, merging directly",
+                  "PROP", tracePropName,
+                  "FILE", autonomousFile);
+        amd::ras::util::cper::mergeFile(autonomousFile, fullPath);
+        merged = true;
+    }
+
+    // --- Step 2: Signal-based wait (if not already merged) ---
+    if (!merged)
+    {
+        lg2::info("{PROP} is '{VAL}', "
+                  "waiting for signal...",
+                  "PROP", tracePropName,
+                  "VAL", autonomousFile);
+
+        constexpr int maxTimeoutSec = 120;
+        constexpr int pollIntervalSec = 2;
+        bool signalReceived = false;
+        autonomousFile.clear();
+
+        auto propMatch = sdbusplus::bus::match::match(
+            traceBus,
+            "type='signal',member='PropertiesChanged',"
+            "interface='org.freedesktop.DBus.Properties',"
+            "path='/com/amd/Traces',"
+            "arg0='com.amd.Traces.Tbai'",
+            [&autonomousFile, &signalReceived, &tracePropName](
+                sdbusplus::message::message& msg) {
+                std::string intfName;
+                std::map<std::string,
+                         std::variant<std::string>> changedProps;
+                try
+                {
+                    msg.read(intfName, changedProps);
+                }
+                catch (const std::exception& e)
+                {
+                    lg2::error("Failed to read "
+                               "PropertiesChanged signal: "
+                               "{ERR}", "ERR", e.what());
+                    return;
+                }
+
+                auto it = changedProps.find(tracePropName);
+                if (it != changedProps.end())
+                {
+                    auto* val = std::get_if<std::string>(
+                        &(it->second));
+                    if (val && *val != "PENDING")
+                    {
+                        autonomousFile = *val;
+                        signalReceived = true;
+                    }
+                }
+            });
+
+        int elapsed = 0;
+        while (!signalReceived && elapsed < maxTimeoutSec)
+        {
+            traceBus.process_discard();
+            traceBus.wait(
+                static_cast<uint64_t>(pollIntervalSec) *
+                1000000ULL);
+            elapsed += pollIntervalSec;
+            if (!signalReceived)
+            {
+                lg2::debug("Waiting for {PROP} "
+                           "signal... ({SEC}s / {MAX}s)",
+                            "PROP", tracePropName,
+                           "SEC", elapsed, "MAX",
+                           maxTimeoutSec);
+            }
+        }
+
+        if (signalReceived && !autonomousFile.empty())
+        {
+            lg2::info("Merging autonomous trace file: "
+                      "{FILE}", "FILE", autonomousFile);
+            amd::ras::util::cper::mergeFile(
+                autonomousFile, fullPath);
+        }
+        else if (signalReceived && autonomousFile.empty())
+        {
+            lg2::warning("amd-traces reported error "
+                         "({PROP} is empty), "
+                         "skipping merge","PROP", tracePropName);
+        }
+        else
+        {
+            lg2::warning("Timed out waiting for "
+                         "{PROP} after {SEC}s, "
+                         "skipping merge",
+                         "PROP", tracePropName,
+                         "SEC", maxTimeoutSec);
+        }
+    }
+}
+
 bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
 {
     std::unique_lock lock(harvestMutex);
@@ -2248,7 +2395,12 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
     if (resetReady == true)
     {
         amd::ras::util::cper::createFile(rcd, fatalErr, 2, errCount, node);
-
+        if (src & fatalError)
+        {
+            std::string currentCperFile = amd::ras::util::cper::findCperFilename(errCount, node);
+            std::string fullPath = RAS_DIR + currentCperFile;
+            mergeAutonomousTraceData(fullPath);
+        }
         amd::ras::util::cper::exportToDBus(errCount, rcd->Header.TimeStamp,
                                            objectServer, systemBus, node);
         amd::ras::util::cper::updateIndexFile(errCount, node);

--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -790,6 +790,7 @@ void createFile(const std::shared_ptr<PtrType>& data,
     }
 
     std::string cperFilePath = RAS_DIR + cperFileName;
+    lg2::info("Creating CPER file: {CPERFILE}", "CPERFILE", cperFilePath.c_str());
 
     file = fopen(cperFilePath.c_str(), "w");
 
@@ -904,6 +905,170 @@ void createFile(const std::shared_ptr<PtrType>& data,
         }
     }
     fclose(file);
+}
+
+void mergeFile(const std::string& sourceFile, const std::string& destFile)
+{
+    constexpr size_t hdrSz = sizeof(EFI_COMMON_ERROR_RECORD_HEADER);
+    constexpr size_t descSz = sizeof(EFI_ERROR_SECTION_DESCRIPTOR);
+
+    // Helper: read entire file into byte vector.
+    auto readBinary = [](const std::string& path,
+                         std::vector<uint8_t>& buf) -> bool {
+        std::ifstream in(path, std::ios::binary);
+        if (!in.is_open())
+        {
+            return false;
+        }
+        in.seekg(0, std::ios::end);
+        buf.resize(static_cast<size_t>(in.tellg()));
+        in.seekg(0, std::ios::beg);
+        return !!in.read(reinterpret_cast<char*>(buf.data()),
+                         static_cast<std::streamsize>(buf.size()));
+    };
+
+    std::vector<uint8_t> destBuf, srcBuf;
+
+    if (!readBinary(destFile, destBuf) || !readBinary(sourceFile, srcBuf))
+    {
+        lg2::error("mergeFile: failed to read source or dest CPER file");
+        return;
+    }
+
+    if (destBuf.size() < hdrSz || srcBuf.size() < hdrSz)
+    {
+        lg2::error("mergeFile: file too small to contain a CPER header");
+        return;
+    }
+
+    auto* srcHdr =
+        reinterpret_cast<EFI_COMMON_ERROR_RECORD_HEADER*>(srcBuf.data());
+    uint16_t srcSecCount = srcHdr->SectionCount;
+    lg2::info("mergeFile: source CPER has {SRC_CNT} sections", "SRC_CNT",
+             srcSecCount);
+
+    if (srcSecCount == 0)
+    {
+        lg2::info("mergeFile: source CPER has 0 sections, nothing to merge");
+        return;
+    }
+
+    if (srcBuf.size() < hdrSz + descSz * srcSecCount)
+    {
+        lg2::error("mergeFile: source file too small for declared sections");
+        return;
+    }
+
+    auto* srcDescs = reinterpret_cast<EFI_ERROR_SECTION_DESCRIPTOR*>(
+        srcBuf.data() + hdrSz);
+
+    // Collect each source section payload using SectionOffset/SectionLength.
+    std::vector<std::vector<uint8_t>> srcPayloads(srcSecCount);
+    for (uint16_t s = 0; s < srcSecCount; ++s)
+    {
+        uint32_t off = srcDescs[s].SectionOffset;
+        uint32_t len = srcDescs[s].SectionLength;
+        lg2::info(
+            "mergeFile: source section {IDX} has offset {OFF} and length {LEN}",
+            "IDX", s, "OFF", off, "LEN", len);
+        if (off + len > srcBuf.size())
+        {
+            lg2::error(
+                "mergeFile: source section {IDX} extends past end of file",
+                "IDX", s);
+            return;
+        }
+        srcPayloads[s].assign(srcBuf.begin() + off,
+                              srcBuf.begin() + off + len);
+    }
+
+    auto* destHdr =
+        reinterpret_cast<EFI_COMMON_ERROR_RECORD_HEADER*>(destBuf.data());
+    uint16_t destSecCount = destHdr->SectionCount;
+    uint16_t newSecCount = destSecCount + srcSecCount;
+
+    lg2::info(
+        "mergeFile: dest has {DST_CNT} sections, source has {SRC_CNT} sections, "
+        "merging into a total of {NEW_CNT} sections",
+        "DST_CNT", destSecCount, "SRC_CNT", srcSecCount, "NEW_CNT", newSecCount);
+    size_t extraDescBytes = static_cast<size_t>(srcSecCount) * descSz;
+    size_t extraPayloadBytes = 0;
+    for (auto& p : srcPayloads)
+    {
+        extraPayloadBytes += p.size();
+    }
+
+    // Build merged file buffer.
+    std::vector<uint8_t> merged;
+    merged.resize(destBuf.size() + extraDescBytes + extraPayloadBytes);
+    size_t pos = 0;
+
+    // 1) Copy header.
+    std::memcpy(merged.data(), destBuf.data(), hdrSz);
+    pos = hdrSz;
+
+    // 2) Copy original descriptors, shifting SectionOffset by extraDescBytes.
+    size_t destDescStart = hdrSz;
+    for (uint16_t d = 0; d < destSecCount; ++d)
+    {
+        EFI_ERROR_SECTION_DESCRIPTOR desc;
+        std::memcpy(&desc, destBuf.data() + destDescStart + d * descSz,
+                     descSz);
+        desc.SectionOffset += static_cast<uint32_t>(extraDescBytes);
+        std::memcpy(merged.data() + pos, &desc, descSz);
+        pos += descSz;
+    }
+
+    // 3) Append source descriptors with offsets pointing past original data.
+    size_t appendBase = destBuf.size() + extraDescBytes;
+    size_t payloadCursor = 0;
+    for (uint16_t s = 0; s < srcSecCount; ++s)
+    {
+        EFI_ERROR_SECTION_DESCRIPTOR desc = srcDescs[s];
+        desc.SectionOffset =
+            static_cast<uint32_t>(appendBase + payloadCursor);
+        std::memcpy(merged.data() + pos, &desc, descSz);
+        pos += descSz;
+        payloadCursor += srcPayloads[s].size();
+    }
+
+    // 4) Copy original section data.
+    size_t destDataStart = hdrSz + destSecCount * descSz;
+    size_t destDataLen = destBuf.size() - destDataStart;
+    std::memcpy(merged.data() + pos, destBuf.data() + destDataStart,
+                destDataLen);
+    pos += destDataLen;
+
+    // 5) Append source payloads.
+    for (uint16_t s = 0; s < srcSecCount; ++s)
+    {
+        std::memcpy(merged.data() + pos, srcPayloads[s].data(),
+                    srcPayloads[s].size());
+        pos += srcPayloads[s].size();
+    }
+
+    // 6) Update header fields.
+    auto* mergedHdr =
+        reinterpret_cast<EFI_COMMON_ERROR_RECORD_HEADER*>(merged.data());
+    mergedHdr->SectionCount = newSecCount;
+    mergedHdr->RecordLength = static_cast<uint32_t>(pos);
+
+    // 7) Rewrite the destination file.
+    std::ofstream out(destFile, std::ios::binary | std::ios::trunc);
+    if (out.is_open())
+    {
+        out.write(reinterpret_cast<const char*>(merged.data()),
+                  static_cast<std::streamsize>(pos));
+        out.close();
+        lg2::info(
+            "mergeFile: merged {SRC_CNT} sections from {SRC} into {DST}",
+            "SRC_CNT", srcSecCount, "SRC", sourceFile, "DST", destFile);
+    }
+    else
+    {
+        lg2::error("mergeFile: failed to write merged CPER to {DST}", "DST",
+                   destFile);
+    }
 }
 
 } // namespace cper


### PR DESCRIPTION
Add support for MPX TraceLogs with TBAI service Interrupt flow
Update the apml_manager.cpp to check the TBAI service property "AutonomousFilePath" to fetch the CPER file from TBAI service and merge the CPER file from TBAI service into the CPER file generated for fatal errors
