### PR TITLE
Add PLDM RAS event handling and fatal error harvesting

### DIFF
--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -96,9 +96,7 @@ class Manager : public amd::ras::Manager
     sdbusplus::asio::object_server& objectServer;
     std::shared_ptr<sdbusplus::asio::connection>& systemBus;
 
-    uint8_t progId;
     size_t contextType;
-    uint64_t recordId;
     size_t watchdogTimerCounter;
     boost::asio::io_context& io;
     bool apmlInitialized;
@@ -109,7 +107,6 @@ class Manager : public amd::ras::Manager
     boost::asio::deadline_timer* DramCeccErrorPollingEvent;
     boost::asio::deadline_timer* PcieAerErrorPollingEvent;
     boost::asio::deadline_timer* ApmlAlertEvent;
-    std::mutex harvestMutex;
     std::mutex mcaErrorHarvestMtx;
     std::mutex dramErrorHarvestMtx;
     std::mutex pcieErrorHarvestMtx;

--- a/include/base_manager.hpp
+++ b/include/base_manager.hpp
@@ -3,6 +3,8 @@
 #include "config_manager.hpp"
 #include "oem_cper.hpp"
 
+#include <mutex>
+
 constexpr size_t socket1 = 1;
 constexpr size_t socket2 = 2;
 
@@ -71,6 +73,8 @@ class Manager
     size_t cpuCount;
     uint32_t boardId;
     uint32_t familyId;
+    uint8_t progId;
+    uint64_t recordId;
     std::unique_ptr<CpuId[]> cpuId;
     std::unique_ptr<uint32_t[]> uCode;
     std::unique_ptr<uint64_t[]> ppin;
@@ -86,6 +90,7 @@ class Manager
     size_t whFamilyId;
     size_t whModel;
     std::vector<uint8_t> blockId;
+    std::mutex harvestMutex;
 
     /** @brief Get the CPU socket information.
      *
@@ -119,6 +124,44 @@ class Manager
      *  @param[in] hostOff - true if the host transitioned to Off state.
      */
     virtual void onHostStateChanged(bool hostOff) = 0;
+
+    /** @brief Handle FCH error.
+     *
+     *  @details Logs the FCH error to the journal and Redfish,
+     *  increments the noncorrectable other error count, and saves.
+     *
+     *  @param[in] socNum - Socket number where the error occurred.
+     */
+    void handleFchError(uint8_t socNum);
+
+    /** @brief Initialize the fatal CPER record structures.
+     *
+     *  @details Allocates section descriptors and error records if not
+     *  already allocated, and populates the CPER header and error
+     *  descriptor with fatal error information.
+     *
+     *  @param[in] sectionCount - Number of CPER sections.
+     */
+    void initFatalCperRecord(uint16_t sectionCount);
+
+    /** @brief Process MCA bank signature IDs and PSP syndromes.
+     *
+     *  @details For each MCA bank, extracts signature ID fields
+     *  (MCA_STATUS, MCA_IPID, MCA_SYND) and PSP syndrome values
+     *  from the CrashDumpData, then populates the CPER record
+     *  with signature ID and FRU string information.
+     *
+     *  @param[in] socNum - Socket number.
+     *  @param[in] numBanks - Number of MCA banks to process.
+     */
+    void processMcaBankSignatures(uint8_t socNum, uint16_t numBanks);
+
+    /** @brief Clean up the fatal CPER record.
+     *
+     *  @details Frees the SectionDescriptor and ErrorRecord arrays
+     *  and resets the shared pointer to nullptr.
+     */
+    void cleanupFatalCperRecord();
 };
 
 } // namespace ras

--- a/include/oem_cper.hpp
+++ b/include/oem_cper.hpp
@@ -7,6 +7,10 @@ extern "C"
 
 constexpr uint8_t mcaDataBankLen = 128;
 constexpr uint16_t debugDumpDataLen = 12124;
+constexpr size_t mcaPspSynd1LoCode = 80;
+constexpr size_t mcaPspSynd1HiCode = 84;
+constexpr size_t mcaPspSynd2LoCode = 88;
+constexpr size_t mcaPspSynd2HiCode = 92;
 constexpr size_t length4 = 4;
 constexpr size_t length8 = 8;
 constexpr size_t length32 = 32;

--- a/include/pldm_manager.hpp
+++ b/include/pldm_manager.hpp
@@ -5,6 +5,7 @@
 #include <boost/asio/deadline_timer.hpp>
 #include <sdbusplus/asio/connection.hpp>
 #include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/bus/match.hpp>
 
 namespace amd
 {
@@ -12,6 +13,25 @@ namespace ras
 {
 namespace pldm
 {
+
+/** @brief PLDM RAS Event IDs from the RasStatus Sensor (0x4C) */
+constexpr uint16_t eventIdFatalError = 0x4C01;
+constexpr uint16_t eventIdFchError = 0x4C02;
+constexpr uint16_t eventIdMcaOverflow = 0x4C08;
+constexpr uint16_t eventIdDramCeccOverflow = 0x4C10;
+constexpr uint16_t eventIdNonMcaCoreShutdown = 0x4C40;
+constexpr uint16_t eventIdMcaCoreShutdown = 0x4C41;
+
+/** @brief DataTransferHandle opcode in upper byte */
+constexpr uint8_t opcodeDbgLogDump = 0x5C;
+constexpr uint8_t opcodeDbgLogValidityCheck = 0x5B;
+constexpr uint8_t opcodeDbgLogDumpAlt = 0x62;
+constexpr uint8_t opcodeDbgLogValidityCheckAlt = 0x61;
+
+/** @brief Error context types matching APML definitions */
+constexpr size_t crashdump = 1;
+constexpr size_t shutdown = 2;
+
 /** @brief Manages RAS (Reliability, Availability, and Serviceability)
  * operations for PLDM.
  *
@@ -74,6 +94,9 @@ class Manager : public amd::ras::Manager
     // Indicates whether runtime error polling is supported for PLDM
     bool runtimeErrPollingSupported;
 
+    // D-Bus match rule for PLDM message poll events
+    std::unique_ptr<sdbusplus::bus::match_t> pldmEventMatch;
+
     /** @brief Called when the host power state changes.
      *
      *  @details Performs PLDM-specific actions on host state transitions,
@@ -90,6 +113,65 @@ class Manager : public amd::ras::Manager
      *  error reporting.
      */
     void platformInitialize();
+
+    /** @brief Handles incoming PLDM RAS event signals.
+     *
+     *  @details Processes the PldmMessagePollEvent signal, extracts
+     *  the event ID and data transfer handle, reads error data from
+     *  the file descriptor, and dispatches appropriate error handling
+     *  based on the RAS event type.
+     *
+     *  @param[in] msg - The D-Bus message containing the PLDM event.
+     */
+    void handlePldmRasEvent(sdbusplus::message_t& msg);
+
+    /** @brief Reads event data from a file descriptor.
+     *
+     *  @details Performs a complete read of eventDataSize bytes from
+     *  the given file descriptor, handling partial reads and EINTR.
+     *
+     *  @param[in] fd - File descriptor to read from.
+     *  @param[in] eventDataSize - Number of bytes to read.
+     *  @param[out] eventData - Buffer populated with the read data.
+     *  @return true on success, false on read failure.
+     */
+    bool readEventDataFromFd(int fd, uint16_t eventDataSize,
+                             std::vector<uint8_t>& eventData);
+
+    /** @brief Handles fatal error or MCA core shutdown events via PLDM.
+     *
+     *  @details Processes the error event data from PMFW,
+     *  populates the CPER record with MCA bank data and debug log
+     *  dumps, generates the CPER file, exports to D-Bus, and
+     *  triggers the configured recovery action.
+     *
+     *  @param[in] eventData - Raw event data from PMFW containing
+     *                         MCA banks and debug log dump data.
+     *  @param[in] socNum - Socket number derived from terminus info.
+     *  @param[in] contextType - Error context (crashdump or shutdown).
+     */
+    void handleFatalOrShutdownError(const std::vector<uint8_t>& eventData,
+                                    uint8_t socNum, size_t contextType);
+
+    /** @brief Extracts socket number from PLDM terminus name.
+     *
+     *  @param[in] terminusName - The terminus name string.
+     *  @return Socket number (0-based).
+     */
+    uint8_t getSocketFromTerminus(const std::string& terminusName);
+
+    /** @brief Harvests the CPER fatal error record from PLDM event data.
+     *
+     *  @details Parses the event data payload from PMFW and fills in
+     *  the FatalCperRecord structures including MCA bank data and
+     *  debug log ID data.
+     *
+     *  @param[in] eventData - Raw event data payload.
+     *  @param[in] socNum - Socket number.
+     *  @param[in] contextType - Context type (crashdump or shutdown).
+     */
+    void harvestMcaDataBanksOverPldm(const std::vector<uint8_t>& eventData,
+                                     uint8_t socNum, size_t contextType);
 };
 
 } // namespace pldm

--- a/include/utils/cper.hpp
+++ b/include/utils/cper.hpp
@@ -253,6 +253,35 @@ void dumpCoreDebugDumpHeader(
     const std::shared_ptr<CoreDebugDumpCperRecord>& coreDebugPtr,
     uint16_t sectionIdx, const std::unique_ptr<CpuId[]>& cpuId);
 
+/** @brief Populates the SignatureID and sets the ValidFields bit in a fatal
+ *         error record when a valid signature is found.
+ *
+ *  @param[in,out] errorRecord - Fatal error data record to update.
+ *  @param[in] mcaSyndLo - MCA Syndrome register low 32 bits.
+ *  @param[in] mcaSyndHi - MCA Syndrome register high 32 bits.
+ *  @param[in] mcaIpidLo - MCA IPID register low 32 bits.
+ *  @param[in] mcaIpidHi - MCA IPID register high 32 bits.
+ *  @param[in] mcaStatusLo - MCA Status register low 32 bits.
+ *  @param[in] mcaStatusHi - MCA Status register high 32 bits.
+ */
+void populateSignatureId(EFI_AMD_FATAL_ERROR_DATA& errorRecord,
+                         uint32_t mcaSyndLo, uint32_t mcaSyndHi,
+                         uint32_t mcaIpidLo, uint32_t mcaIpidHi,
+                         uint32_t mcaStatusLo, uint32_t mcaStatusHi);
+
+/** @brief Copies PSP syndrome data into the FruString field of a section
+ *         descriptor.
+ *
+ *  @param[in,out] sectionDesc - Section descriptor whose FruString is updated.
+ *  @param[in] pspSynd1Lo - PSP Syndrome 1 low 32 bits.
+ *  @param[in] pspSynd1Hi - PSP Syndrome 1 high 32 bits.
+ *  @param[in] pspSynd2Lo - PSP Syndrome 2 low 32 bits.
+ *  @param[in] pspSynd2Hi - PSP Syndrome 2 high 32 bits.
+ */
+void populateFruStringPspSynd(EFI_ERROR_SECTION_DESCRIPTOR& sectionDesc,
+                              uint32_t pspSynd1Lo, uint32_t pspSynd1Hi,
+                              uint32_t pspSynd2Lo, uint32_t pspSynd2Hi);
+
 } // namespace cper
 } // namespace util
 } // namespace ras

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -34,7 +34,6 @@ constexpr size_t socket0 = 0;
 constexpr size_t socket1 = 1;
 
 constexpr uint32_t badData = 0xBAADDA7A;
-constexpr size_t epycProgSegId = 0x1;
 constexpr size_t fatalError = 1;
 constexpr size_t resetHangErr = 0x2;
 
@@ -48,21 +47,11 @@ constexpr size_t mcaErrOverflow = 8;
 constexpr size_t dramCeccErrOverflow = 16;
 constexpr size_t pcieErrOverflow = 32;
 constexpr size_t x86ExceptionBit = 0x80;
-constexpr size_t base16 = 16;
 constexpr size_t byteMask = 0xFF;
 constexpr size_t cfError = 0x6;
 
-constexpr size_t mcaPspSynd1LoCode = 80;
-constexpr size_t mcaPspSynd1HiCode = 84;
-constexpr size_t mcaPspSynd2LoCode = 88;
-constexpr size_t mcaPspSynd2HiCode = 92;
 constexpr size_t mcaIpidHiOffset = 0x2C;
 constexpr uint32_t umcHardwareId = 0x96;
-constexpr size_t offLo1 = 0;
-constexpr size_t offHi1 = 4;
-constexpr size_t offLo2 = 8;
-constexpr size_t offHi2 = 12;
-constexpr size_t copySize = 4;
 constexpr size_t crashdump = 1;
 constexpr size_t shutdown = 2;
 constexpr size_t breakEvent = 3;
@@ -116,8 +105,8 @@ Manager::Manager(amd::ras::config::Manager& manager,
                  std::shared_ptr<sdbusplus::asio::connection>& systemBus,
                  boost::asio::io_context& io, std::string& node) :
     amd::ras::Manager(manager, node), objectServer(objectServer),
-    systemBus(systemBus), progId(1), recordId(1), watchdogTimerCounter(0),
-    io(io), apmlInitialized(false), platformInitialized(false),
+    systemBus(systemBus), watchdogTimerCounter(0), io(io),
+    apmlInitialized(false), platformInitialized(false),
     runtimeErrPollingSupported(false), McaErrorPollingEvent(nullptr),
     DramCeccErrorPollingEvent(nullptr), PcieAerErrorPollingEvent(nullptr),
     ApmlAlertEvent(nullptr), mcaErrorHarvestMtx(), dramErrorHarvestMtx(),
@@ -1655,55 +1644,15 @@ void Manager::harvestMcaDataBanks(uint8_t socNum,
     uint16_t maxOffset32;
     uint32_t buffer;
     oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
-    bool validSignatureId = false;
-
-    uint32_t syndOffsetLo = 0;
-    uint32_t syndOffsetHi = 0;
-    uint32_t ipidOffsetLo = 0;
-    uint32_t ipidOffsetHi = 0;
-    uint32_t statusOffsetLo = 0;
-    uint32_t statusOffsetHi = 0;
-
-    uint32_t mcaStatusLo = 0;
-    uint32_t mcaStatusHi = 0;
-    uint32_t mcaIpidLo = 0;
-    uint32_t mcaIpidHi = 0;
-    uint32_t mcaSyndLo = 0;
-    uint32_t mcaSyndHi = 0;
-    uint32_t mcaPspSynd1Lo = 0;
-    uint32_t mcaPspSynd1Hi = 0;
-    uint32_t mcaPspSynd2Lo = 0;
-    uint32_t mcaPspSynd2Hi = 0;
-
-    amd::ras::config::Manager::AttributeValue sigIdOffsetVal =
-        configMgr.getAttribute("SigIdOffset");
-    std::vector<std::string>* sigIDOffset =
-        std::get_if<std::vector<std::string>>(&sigIdOffsetVal);
 
     amd::ras::config::Manager::AttributeValue apmlRetry =
         configMgr.getAttribute("ApmlRetries");
     int64_t* apmlRetryCount = std::get_if<int64_t>(&apmlRetry);
 
-    uint16_t sectionCount = 2;  // Standard section count is 2
-    uint32_t errorSeverity = 1; // Error severity for fatal error is 1
+    constexpr uint16_t sectionCount = 2;
 
-    if (rcd->SectionDescriptor == nullptr)
-    {
-        rcd->SectionDescriptor = new EFI_ERROR_SECTION_DESCRIPTOR[sectionCount];
-        std::memset(rcd->SectionDescriptor, 0,
-                    2 * sizeof(EFI_ERROR_SECTION_DESCRIPTOR));
-    }
+    initFatalCperRecord(sectionCount);
 
-    if (rcd->ErrorRecord == nullptr)
-    {
-        rcd->ErrorRecord = new EFI_AMD_FATAL_ERROR_DATA[sectionCount];
-        std::memset(rcd->ErrorRecord, 0, 2 * sizeof(EFI_AMD_FATAL_ERROR_DATA));
-    }
-
-    amd::ras::util::cper::dumpHeader(rcd, sectionCount, errorSeverity, fatalErr,
-                                     boardId, recordId);
-    amd::ras::util::cper::dumpErrorDescriptor(rcd, sectionCount, fatalErr,
-                                              &errorSeverity, progId);
     amd::ras::util::cper::dumpProcessorError(rcd, socNum, cpuId, socIndex,
                                              errorCheck.df_block_instances);
     amd::ras::util::cper::dumpContext(rcd, errorCheck.df_block_instances,
@@ -1729,13 +1678,6 @@ void Manager::harvestMcaDataBanks(uint8_t socNum,
                                 debugLogIdOffset);
         }
     }
-
-    syndOffsetLo = std::stoul((*sigIDOffset)[0], nullptr, base16);
-    syndOffsetHi = std::stoul((*sigIDOffset)[1], nullptr, base16);
-    ipidOffsetLo = std::stoul((*sigIDOffset)[2], nullptr, base16);
-    ipidOffsetHi = std::stoul((*sigIDOffset)[3], nullptr, base16);
-    statusOffsetLo = std::stoul((*sigIDOffset)[4], nullptr, base16);
-    statusOffsetHi = std::stoul((*sigIDOffset)[5], nullptr, base16);
 
     maxOffset32 = ((errorCheck.err_log_len % 4) ? 1 : 0) +
                   (errorCheck.err_log_len >> 2);
@@ -1798,91 +1740,12 @@ void Manager::harvestMcaDataBanks(uint8_t socNum,
 
             rcd->ErrorRecord[socNum].CrashDumpData[n].McaData[offset] = buffer;
 
-            if (dfError.input[0] == statusOffsetLo)
-            {
-                mcaStatusLo = buffer;
-            }
-            if (dfError.input[0] == statusOffsetHi)
-            {
-                mcaStatusHi = buffer;
-
-                /*Bit 23 and bit 25 of MCA_STATUS_HI
-                  should be set for a valid signature ID*/
-                if ((mcaStatusHi & (1 << 25)) && (mcaStatusHi & (1 << 23)))
-                {
-                    validSignatureId = true;
-                }
-            }
-            if (dfError.input[0] == ipidOffsetLo)
-            {
-                mcaIpidLo = buffer;
-            }
-            if (dfError.input[0] == ipidOffsetHi)
-            {
-                mcaIpidHi = buffer;
-            }
-            if (dfError.input[0] == syndOffsetLo)
-            {
-                mcaSyndLo = buffer;
-            }
-            if (dfError.input[0] == syndOffsetHi)
-            {
-                mcaSyndHi = buffer;
-            }
-            if (dfError.input[0] == mcaPspSynd1LoCode)
-            {
-                mcaPspSynd1Lo = buffer;
-            }
-            if (dfError.input[0] == mcaPspSynd1HiCode)
-            {
-                mcaPspSynd1Hi = buffer;
-            }
-            if (dfError.input[0] == mcaPspSynd2LoCode)
-            {
-                mcaPspSynd2Lo = buffer;
-            }
-            if (dfError.input[0] == mcaPspSynd2HiCode)
-            {
-                mcaPspSynd2Hi = buffer;
-            }
-
         } // for loop
-
-        if (validSignatureId == true)
-        {
-            rcd->ErrorRecord[socNum].SignatureID[0] = mcaSyndLo;
-            rcd->ErrorRecord[socNum].SignatureID[1] = mcaSyndHi;
-            rcd->ErrorRecord[socNum].SignatureID[2] = mcaIpidLo;
-            rcd->ErrorRecord[socNum].SignatureID[3] = mcaIpidHi;
-            rcd->ErrorRecord[socNum].SignatureID[4] = mcaStatusLo;
-            rcd->ErrorRecord[socNum].SignatureID[5] = mcaStatusHi;
-
-            rcd->ErrorRecord[socNum].ProcError.ValidFields =
-                rcd->ErrorRecord[socNum].ProcError.ValidFields | 0x4;
-
-            validSignatureId = false;
-        }
-        else
-        {
-            mcaSyndLo = 0;
-            mcaSyndHi = 0;
-            mcaIpidLo = 0;
-            mcaIpidHi = 0;
-            mcaStatusLo = 0;
-            mcaStatusHi = 0;
-        }
-
-        memcpy(rcd->SectionDescriptor[socNum].FruString + offLo1,
-               &mcaPspSynd1Lo, copySize);
-        memcpy(rcd->SectionDescriptor[socNum].FruString + offHi1,
-               &mcaPspSynd1Hi, copySize);
-        memcpy(rcd->SectionDescriptor[socNum].FruString + offLo2,
-               &mcaPspSynd2Lo, copySize);
-        memcpy(rcd->SectionDescriptor[socNum].FruString + offHi2,
-               &mcaPspSynd2Hi, copySize);
 
         n++;
     }
+
+    processMcaBankSignatures(socNum, errorCheck.df_block_instances);
 }
 
 bool Manager::harvestMcaValidityCheck(uint8_t info,
@@ -1998,19 +1861,8 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
         }
         else if (src & resetHangErr)
         {
-            std::string rasErrMsg =
-                "System hang while resetting in syncflood."
-                "Suggested next step is to do an additional manual "
-                "immediate reset";
-            sd_journal_send("MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i",
-                            LOG_ERR, "REDFISH_MESSAGE_ID=%s",
-                            "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
-                            rasErrMsg.c_str(), NULL);
-
+            handleFchError(socNum);
             fchHangError = true;
-            configMgr.incrementNoncorrectableOtherError(socNum);
-            configMgr.updateErrorCountDbus();
-            configMgr.saveErrorCounts();
         }
     }
     else
@@ -2277,18 +2129,7 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
                                               systemRecovery, resetSignal);
         }
 
-        if (rcd->SectionDescriptor != nullptr)
-        {
-            delete[] rcd->SectionDescriptor;
-            rcd->SectionDescriptor = nullptr;
-        }
-        if (rcd->ErrorRecord != nullptr)
-        {
-            delete[] rcd->ErrorRecord;
-            rcd->ErrorRecord = nullptr;
-        }
-
-        rcd = nullptr;
+        cleanupFatalCperRecord();
 
         cpuAlertProcessed.assign(cpuCount, false);
     }
@@ -2399,19 +2240,8 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                 }
                 else if (buf & resetHangErr)
                 {
-                    std::string rasErrMsg =
-                        "System hang while resetting in syncflood."
-                        "Suggested next step is to do an additional manual "
-                        "immediate reset";
-                    sd_journal_send(
-                        "MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
-                        "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
-                        "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
-
+                    handleFchError(socNum);
                     fchHangError = true;
-                    configMgr.incrementNoncorrectableOtherError(socNum);
-                    configMgr.updateErrorCountDbus();
-                    configMgr.saveErrorCounts();
                 }
             }
             else
@@ -2700,18 +2530,7 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                                                       resetSignal);
                 }
 
-                if (rcd->SectionDescriptor != nullptr)
-                {
-                    delete[] rcd->SectionDescriptor;
-                    rcd->SectionDescriptor = nullptr;
-                }
-                if (rcd->ErrorRecord != nullptr)
-                {
-                    delete[] rcd->ErrorRecord;
-                    rcd->ErrorRecord = nullptr;
-                }
-
-                rcd = nullptr;
+                cleanupFatalCperRecord();
 
                 cpuAlertProcessed.assign(cpuCount, false);
             }
@@ -3331,14 +3150,9 @@ void Manager::dumpProcErrorSection(
 
         if ((category == 0) || (category == 1))
         {
-            memcpy(ProcPtr->SectionDescriptor[section].FruString + offLo1,
-                   &mcaPspSynd1Lo, copySize);
-            memcpy(ProcPtr->SectionDescriptor[section].FruString + offHi1,
-                   &mcaPspSynd1Hi, copySize);
-            memcpy(ProcPtr->SectionDescriptor[section].FruString + offLo2,
-                   &mcaPspSynd2Lo, copySize);
-            memcpy(ProcPtr->SectionDescriptor[section].FruString + offHi2,
-                   &mcaPspSynd2Hi, copySize);
+            amd::ras::util::cper::populateFruStringPspSynd(
+                ProcPtr->SectionDescriptor[section], mcaPspSynd1Lo,
+                mcaPspSynd1Hi, mcaPspSynd2Lo, mcaPspSynd2Hi);
 
             if (category == 0 && mcaPspSynd1Lo == 0 && mcaPspSynd1Hi == 0 &&
                 mcaPspSynd2Lo == 0 && mcaPspSynd2Hi == 0 &&

--- a/src/base_manager.cpp
+++ b/src/base_manager.cpp
@@ -3,6 +3,8 @@
 #include "utils/cper.hpp"
 #include "utils/util.hpp"
 
+#include <systemd/sd-journal.h>
+
 #include <boost/asio/io_context.hpp>
 #include <nlohmann/json.hpp>
 #include <phosphor-logging/lg2.hpp>
@@ -142,9 +144,9 @@ void Manager::getCpuSocketInfo()
 }
 
 Manager::Manager(amd::ras::config::Manager& manager, std::string& node) :
-    errCount(0), configMgr(manager), rcd(nullptr), mcaPtr(nullptr),
-    dramPtr(nullptr), pciePtr(nullptr), coreDebugDumpPtr(nullptr), node(node),
-    whFamilyId(0), whModel(0)
+    errCount(0), progId(1), recordId(1), configMgr(manager), rcd(nullptr),
+    mcaPtr(nullptr), dramPtr(nullptr), pciePtr(nullptr),
+    coreDebugDumpPtr(nullptr), node(node), whFamilyId(0), whModel(0)
 {}
 
 void Manager::loadPlatformConfig()
@@ -225,6 +227,119 @@ void Manager::currentHostStateMonitor()
                             "xyz.openbmc_project.State.Host.HostState.Off");
             onHostStateChanged(hostOff);
         });
+}
+
+void Manager::handleFchError(uint8_t socNum)
+{
+    std::string rasErrMsg = "System hang while resetting in syncflood."
+                            "Suggested next step is to do an additional manual "
+                            "immediate reset";
+    sd_journal_send("MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
+                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
+                    "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+
+    configMgr.incrementNoncorrectableOtherError(socNum);
+    configMgr.updateErrorCountDbus();
+    configMgr.saveErrorCounts();
+}
+
+void Manager::cleanupFatalCperRecord()
+{
+    if (rcd != nullptr)
+    {
+        if (rcd->SectionDescriptor != nullptr)
+        {
+            delete[] rcd->SectionDescriptor;
+            rcd->SectionDescriptor = nullptr;
+        }
+        if (rcd->ErrorRecord != nullptr)
+        {
+            delete[] rcd->ErrorRecord;
+            rcd->ErrorRecord = nullptr;
+        }
+        rcd = nullptr;
+    }
+}
+
+void Manager::initFatalCperRecord(uint16_t sectionCount)
+{
+    uint32_t errorSeverity = 1;
+
+    if (rcd->SectionDescriptor == nullptr)
+    {
+        rcd->SectionDescriptor = new EFI_ERROR_SECTION_DESCRIPTOR[sectionCount];
+        std::memset(rcd->SectionDescriptor, 0,
+                    sectionCount * sizeof(EFI_ERROR_SECTION_DESCRIPTOR));
+    }
+
+    if (rcd->ErrorRecord == nullptr)
+    {
+        rcd->ErrorRecord = new EFI_AMD_FATAL_ERROR_DATA[sectionCount];
+        std::memset(rcd->ErrorRecord, 0,
+                    sectionCount * sizeof(EFI_AMD_FATAL_ERROR_DATA));
+    }
+
+    amd::ras::util::cper::dumpHeader(rcd, sectionCount, errorSeverity, fatalErr,
+                                     boardId, recordId);
+    amd::ras::util::cper::dumpErrorDescriptor(rcd, sectionCount, fatalErr,
+                                              &errorSeverity, progId);
+}
+
+void Manager::processMcaBankSignatures(uint8_t socNum, uint16_t numBanks)
+{
+    amd::ras::config::Manager::AttributeValue sigIdOffsetVal =
+        configMgr.getAttribute("SigIdOffset");
+    std::vector<std::string>* sigIDOffset =
+        std::get_if<std::vector<std::string>>(&sigIdOffsetVal);
+
+    uint32_t syndOffsetLo = std::stoul((*sigIDOffset)[0], nullptr, base16);
+    uint32_t syndOffsetHi = std::stoul((*sigIDOffset)[1], nullptr, base16);
+    uint32_t ipidOffsetLo = std::stoul((*sigIDOffset)[2], nullptr, base16);
+    uint32_t ipidOffsetHi = std::stoul((*sigIDOffset)[3], nullptr, base16);
+    uint32_t statusOffsetLo = std::stoul((*sigIDOffset)[4], nullptr, base16);
+    uint32_t statusOffsetHi = std::stoul((*sigIDOffset)[5], nullptr, base16);
+
+    for (uint16_t n = 0; n < numBanks; n++)
+    {
+        uint32_t mcaStatusLo = rcd->ErrorRecord[socNum]
+                                   .CrashDumpData[n]
+                                   .McaData[statusOffsetLo / 4];
+        uint32_t mcaStatusHi = rcd->ErrorRecord[socNum]
+                                   .CrashDumpData[n]
+                                   .McaData[statusOffsetHi / 4];
+        uint32_t mcaIpidLo =
+            rcd->ErrorRecord[socNum].CrashDumpData[n].McaData[ipidOffsetLo / 4];
+        uint32_t mcaIpidHi =
+            rcd->ErrorRecord[socNum].CrashDumpData[n].McaData[ipidOffsetHi / 4];
+        uint32_t mcaSyndLo =
+            rcd->ErrorRecord[socNum].CrashDumpData[n].McaData[syndOffsetLo / 4];
+        uint32_t mcaSyndHi =
+            rcd->ErrorRecord[socNum].CrashDumpData[n].McaData[syndOffsetHi / 4];
+
+        uint32_t mcaPspSynd1Lo = rcd->ErrorRecord[socNum]
+                                     .CrashDumpData[n]
+                                     .McaData[mcaPspSynd1LoCode / 4];
+        uint32_t mcaPspSynd1Hi = rcd->ErrorRecord[socNum]
+                                     .CrashDumpData[n]
+                                     .McaData[mcaPspSynd1HiCode / 4];
+        uint32_t mcaPspSynd2Lo = rcd->ErrorRecord[socNum]
+                                     .CrashDumpData[n]
+                                     .McaData[mcaPspSynd2LoCode / 4];
+        uint32_t mcaPspSynd2Hi = rcd->ErrorRecord[socNum]
+                                     .CrashDumpData[n]
+                                     .McaData[mcaPspSynd2HiCode / 4];
+
+        if ((mcaStatusHi & (1 << 25)) && (mcaStatusHi & (1 << 23)))
+        {
+            amd::ras::util::cper::populateSignatureId(
+                rcd->ErrorRecord[socNum], mcaSyndLo, mcaSyndHi, mcaIpidLo,
+                mcaIpidHi, mcaStatusLo, mcaStatusHi);
+        }
+
+        amd::ras::util::cper::populateFruStringPspSynd(
+            rcd->SectionDescriptor[socNum], mcaPspSynd1Lo, mcaPspSynd1Hi,
+            mcaPspSynd2Lo, mcaPspSynd2Hi);
+    }
 }
 
 } // namespace ras

--- a/src/pldm_manager.cpp
+++ b/src/pldm_manager.cpp
@@ -1,6 +1,7 @@
 #include "pldm_manager.hpp"
 
 #include "config_manager.hpp"
+#include "oem_cper.hpp"
 #include "utils/cper.hpp"
 #include "utils/util.hpp"
 
@@ -10,9 +11,14 @@ extern "C"
 #include "esmi_mailbox.h"
 }
 
+#include <unistd.h>
+
 #include <nlohmann/json.hpp>
 #include <phosphor-logging/lg2.hpp>
 #include <phosphor-logging/log.hpp>
+
+#include <cerrno>
+#include <cstring>
 
 namespace amd
 {
@@ -20,6 +26,8 @@ namespace ras
 {
 namespace pldm
 {
+
+constexpr uint32_t badData = 0xBAADDA7A;
 
 Manager::Manager(amd::ras::config::Manager& manager,
                  sdbusplus::asio::object_server& objectServer,
@@ -118,6 +126,296 @@ void Manager::registerEventHandler()
     lg2::info("PLDM MANAGER REGISTER EVENT HANDLER");
 
     amd::ras::util::cper::createRecord(objectServer, systemBus, node);
+
+    const std::string matchRule =
+        "type='signal',"
+        "interface='xyz.openbmc_project.PLDM.Event',"
+        "member='PldmMessagePollEvent'";
+
+    pldmEventMatch = std::make_unique<sdbusplus::bus::match_t>(
+        static_cast<sdbusplus::bus_t&>(*systemBus), matchRule,
+        [this](sdbusplus::message_t& msg) { handlePldmRasEvent(msg); });
+
+    lg2::info("Registered PLDM RAS event signal monitor");
+}
+
+void Manager::handlePldmRasEvent(sdbusplus::message_t& msg)
+{
+    uint64_t epochTimestamp = 0;
+    uint8_t terminusId = 0;
+    std::string terminusName;
+    uint8_t formatVersion = 0;
+    uint8_t eventClass = 0;
+    uint16_t eventId = 0;
+    uint32_t dataTransferHandle = 0;
+    uint16_t eventDataSize = 0;
+    sdbusplus::message::unix_fd eventDataFd;
+
+    try
+    {
+        msg.read(epochTimestamp, terminusId, terminusName, formatVersion,
+                 eventClass, eventId, dataTransferHandle, eventDataSize,
+                 eventDataFd);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed to read PLDM event signal: {ERROR}", "ERROR",
+                   e.what());
+        return;
+    }
+
+    lg2::info(
+        "PLDM RAS event received: terminus={TERMINUS}, eventId=0x{EVENTID}, "
+        "dataTransferHandle=0x{HANDLE}, eventDataSize={SIZE}",
+        "TERMINUS", terminusName, "EVENTID", lg2::hex, eventId, "HANDLE",
+        lg2::hex, dataTransferHandle, "SIZE", eventDataSize);
+
+    // Read error data from the file descriptor
+    std::vector<uint8_t> eventData;
+    if (eventDataSize > 0)
+    {
+        if (!readEventDataFromFd(eventDataFd, eventDataSize, eventData))
+        {
+            return;
+        }
+    }
+
+    uint8_t socNum = getSocketFromTerminus(terminusName);
+
+    switch (eventId)
+    {
+        case pldm::eventIdFatalError:
+            lg2::error("PLDM RAS Event: Fatal error/SYNCFLOOD on {TERMINUS}",
+                       "TERMINUS", terminusName);
+            handleFatalOrShutdownError(eventData, socNum, crashdump);
+            break;
+
+        case pldm::eventIdFchError:
+            lg2::error("PLDM RAS Event: FCH Error on {TERMINUS}", "TERMINUS",
+                       terminusName);
+            handleFchError(socNum);
+            break;
+
+        case pldm::eventIdMcaOverflow:
+            lg2::error(
+                "PLDM RAS Event: MCA error counter overflow on {TERMINUS}",
+                "TERMINUS", terminusName);
+            break;
+
+        case pldm::eventIdDramCeccOverflow:
+            lg2::error(
+                "PLDM RAS Event: DRAM CECC error counter overflow on {TERMINUS}",
+                "TERMINUS", terminusName);
+            break;
+
+        case pldm::eventIdNonMcaCoreShutdown:
+            lg2::error(
+                "PLDM RAS Event: Non-MCA initiated core shutdown on {TERMINUS}",
+                "TERMINUS", terminusName);
+            {
+                std::string rasErrMsg =
+                    "Non MCA Shutdown error detected in the system";
+                sd_journal_send(
+                    "MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
+                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
+                    "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+                configMgr.incrementNoncorrectableOtherError(socNum);
+                configMgr.updateErrorCountDbus();
+                configMgr.saveErrorCounts();
+            }
+            break;
+
+        case pldm::eventIdMcaCoreShutdown:
+            lg2::error(
+                "PLDM RAS Event: MCA initiated core shutdown on {TERMINUS}",
+                "TERMINUS", terminusName);
+            handleFatalOrShutdownError(eventData, socNum, shutdown);
+            break;
+
+        default:
+            lg2::warning(
+                "PLDM RAS Event: Unknown eventId 0x{EVENTID} on {TERMINUS}",
+                "EVENTID", eventId, "TERMINUS", terminusName);
+            break;
+    }
+}
+
+uint8_t Manager::getSocketFromTerminus(const std::string& terminusName)
+{
+    // Extract socket number from the trailing digit in terminus name
+    // Common patterns: "P0", "P1", "socket0", "socket1", "Processor0", etc.
+    for (auto it = terminusName.rbegin(); it != terminusName.rend(); ++it)
+    {
+        if (std::isdigit(*it))
+        {
+            return static_cast<uint8_t>(*it - '0');
+        }
+    }
+    // Default to socket 0
+    return 0;
+}
+
+void Manager::handleFatalOrShutdownError(const std::vector<uint8_t>& eventData,
+                                         uint8_t socNum, size_t contextType)
+{
+    std::unique_lock lock(harvestMutex);
+
+    std::string rasErrMsg;
+    uint8_t rasStatusByte;
+
+    if (contextType == crashdump)
+    {
+        rasErrMsg = "RAS FATAL Error detected. "
+                    "System may reset after harvesting "
+                    "MCA data based on policy set.";
+        rasStatusByte = 0x01; // fatal_err bit
+    }
+    else
+    {
+        rasErrMsg =
+            "MCA CPU shutdown error detected."
+            "System may reset after harvesting MCA data based on policy set.";
+        rasStatusByte = 0x41; // fatal_err + shutdown bits
+    }
+
+    sd_journal_send("MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
+                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
+                    "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+
+    configMgr.incrementNoncorrectableCPUError(socNum, 0);
+    configMgr.updateErrorCountDbus();
+    configMgr.saveErrorCounts();
+
+    harvestMcaDataBanksOverPldm(eventData, socNum, contextType);
+
+    amd::ras::util::cper::createFile(rcd, fatalErr, 2, errCount, node);
+
+    amd::ras::util::cper::exportToDBus(errCount, rcd->Header.TimeStamp,
+                                       objectServer, systemBus, node);
+    amd::ras::util::cper::updateIndexFile(errCount, node);
+
+    // Trigger recovery action based on configured policy
+    amd::ras::config::Manager::AttributeValue ResetSignalVal =
+        configMgr.getAttribute("ResetSignalType");
+    std::string* resetSignal = std::get_if<std::string>(&ResetSignalVal);
+
+    amd::ras::config::Manager::AttributeValue SystemRecoveryVal =
+        configMgr.getAttribute("SystemRecoveryMode");
+    std::string* systemRecovery = std::get_if<std::string>(&SystemRecoveryVal);
+
+    amd::ras::util::rasRecoveryAction(node, rasStatusByte, systemRecovery,
+                                      resetSignal);
+
+    cleanupFatalCperRecord();
+}
+
+void Manager::harvestMcaDataBanksOverPldm(const std::vector<uint8_t>& eventData,
+                                          uint8_t socNum, size_t contextType)
+{
+    constexpr uint16_t sectionCount = 2;
+
+    if (rcd == nullptr)
+    {
+        rcd = std::make_shared<FatalCperRecord>();
+    }
+
+    initFatalCperRecord(sectionCount);
+
+    uint16_t numMcaBanks = eventData.size() / mcaDataBankLen;
+    uint16_t wordsPerMcaBank =
+        ((eventData.size() % 4) ? 1 : 0) + (eventData.size() >> 2);
+    if (numMcaBanks == 0)
+    {
+        lg2::info(
+            "No valid mca banks found. Harvesting additional debug log ID dumps");
+    }
+
+    // Clamp to valid range
+    if (numMcaBanks > 32)
+    {
+        lg2::warning(
+            "Invalid MCA bank count {COUNT} from PLDM data, clamping to 32",
+            "COUNT", numMcaBanks);
+        numMcaBanks = 32;
+    }
+
+    lg2::info("Number of Valid MCA bank: {NUMBANKS}", "NUMBANKS", numMcaBanks);
+    lg2::info("Number of 32 Bit Words per MCA bank: {WORDS_PER_BANK}",
+              "WORDS_PER_BANK", wordsPerMcaBank);
+
+    // Populate processor error info
+    amd::ras::util::cper::dumpProcessorError(rcd, socNum, cpuId, socIndex,
+                                             numMcaBanks);
+    amd::ras::util::cper::dumpContext(rcd, numMcaBanks, wordsPerMcaBank, socNum,
+                                      ppin, uCode, contextType);
+
+    uint16_t maxOffset32 = mcaDataBankLen / 4;
+
+    for (uint16_t n = 0; n < numMcaBanks; n++)
+    {
+        // In PLDM mode, all MCA data is available in eventData.
+        // Copy the entire bank at once instead of reading 4 bytes
+        // per transaction as done in APML mode via read_ras_df_err_dump().
+        size_t bankStart = static_cast<size_t>(n) * mcaDataBankLen;
+
+        if (bankStart + mcaDataBankLen <= eventData.size())
+        {
+            std::memcpy(rcd->ErrorRecord[socNum].CrashDumpData[n].McaData,
+                        &eventData[bankStart], mcaDataBankLen);
+        }
+        else
+        {
+            // Partial or missing bank data - fill with bad data pattern
+            size_t available = (bankStart < eventData.size())
+                                   ? (eventData.size() - bankStart)
+                                   : 0;
+            if (available > 0)
+            {
+                std::memcpy(rcd->ErrorRecord[socNum].CrashDumpData[n].McaData,
+                            &eventData[bankStart], available);
+            }
+            // Fill remaining words with bad data
+            for (uint32_t w = available / 4; w < maxOffset32; w++)
+            {
+                rcd->ErrorRecord[socNum].CrashDumpData[n].McaData[w] = badData;
+            }
+        }
+    }
+
+    processMcaBankSignatures(socNum, numMcaBanks);
+}
+
+bool Manager::readEventDataFromFd(int fd, uint16_t eventDataSize,
+                                  std::vector<uint8_t>& eventData)
+{
+    eventData.resize(eventDataSize);
+    ssize_t totalBytesRead = 0;
+
+    while (totalBytesRead < eventDataSize)
+    {
+        ssize_t bytesRead = read(fd, eventData.data() + totalBytesRead,
+                                 eventDataSize - totalBytesRead);
+        if (bytesRead < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            lg2::error("Failed to read event data from fd {FD}: {ERROR}", "FD",
+                       fd, "ERROR", strerror(errno));
+            return false;
+        }
+        if (bytesRead == 0)
+        {
+            break;
+        }
+        totalBytesRead += bytesRead;
+    }
+
+    eventData.resize(totalBytesRead);
+    lg2::info("Read {BYTES} bytes of event data from fd", "BYTES",
+              totalBytesRead);
+    return true;
 }
 
 } // namespace pldm

--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -915,6 +915,37 @@ void cper::dumpCoreDebugDumpHeader(
     hdr.cpuidInfo.edx = cpuId[0].edx;
 }
 
+void cper::populateSignatureId(EFI_AMD_FATAL_ERROR_DATA& errorRecord,
+                               uint32_t mcaSyndLo, uint32_t mcaSyndHi,
+                               uint32_t mcaIpidLo, uint32_t mcaIpidHi,
+                               uint32_t mcaStatusLo, uint32_t mcaStatusHi)
+{
+    errorRecord.SignatureID[0] = mcaSyndLo;
+    errorRecord.SignatureID[1] = mcaSyndHi;
+    errorRecord.SignatureID[2] = mcaIpidLo;
+    errorRecord.SignatureID[3] = mcaIpidHi;
+    errorRecord.SignatureID[4] = mcaStatusLo;
+    errorRecord.SignatureID[5] = mcaStatusHi;
+
+    errorRecord.ProcError.ValidFields = errorRecord.ProcError.ValidFields | 0x4;
+}
+
+void cper::populateFruStringPspSynd(EFI_ERROR_SECTION_DESCRIPTOR& sectionDesc,
+                                    uint32_t pspSynd1Lo, uint32_t pspSynd1Hi,
+                                    uint32_t pspSynd2Lo, uint32_t pspSynd2Hi)
+{
+    constexpr size_t off1Lo = 0;
+    constexpr size_t off1Hi = 4;
+    constexpr size_t off2Lo = 8;
+    constexpr size_t off2Hi = 12;
+    constexpr size_t cpSize = 4;
+
+    memcpy(sectionDesc.FruString + off1Lo, &pspSynd1Lo, cpSize);
+    memcpy(sectionDesc.FruString + off1Hi, &pspSynd1Hi, cpSize);
+    memcpy(sectionDesc.FruString + off2Lo, &pspSynd2Lo, cpSize);
+    memcpy(sectionDesc.FruString + off2Hi, &pspSynd2Hi, cpSize);
+}
+
 } // namespace util
 } // namespace ras
 } // namespace amd


### PR DESCRIPTION
Register a D-Bus match for PldmMessagePollEvent signals to receive RAS events from PMFW via PLDM. Event data is read from the passed file descriptor, and dispatched based on event ID:

  - Fatal error (0x4C01): harvest MCA bank data from the event payload, populate a CPER record with crash dump context, export to D-Bus, and trigger the configured system recovery action.
  - FCH error (0x4C02): log the error and increment non-correctable error counters.
  - MCA overflow (0x4C08) / DRAM CECC overflow (0x4C10): log the event.
  - Non-MCA core shutdown (0x4C40): log error, increment counters.
  - MCA core shutdown (0x4C41): harvest MCA data with shutdown context, generate CPER record, and trigger recovery.