### PR TITLE
Publish redfish phosphor-logging events when CPU errors encountered and CPERs generated

### DIFF
--- a/config/ras_config.json
+++ b/config/ras_config.json
@@ -77,21 +77,21 @@
         {
             "DramCeccOobEcMode": {
                 "Description": "DRAM CECC OOB error counter mode: 0=disabled, 1=no-leak mode, 2=leaky bucket mode",
-                "Value": 1,
+                "Value": 2,
                 "MaxBoundLimit": 2
             }
         },
         {
             "DramCeccLeakRate": {
                 "Description": "DRAM CECC leaky bucket leak rate (0x00-0x1F). Only used when DramCeccOobEcMode=2",
-                "Value": 0,
+                "Value": 20,
                 "MaxBoundLimit": 31
             }
         },
         {
             "DramCeccThresholdEn": {
                 "Description": "If this field is true, error thresholding for DRAM ECC correctable errors will be enabled",
-                "Value": false
+                "Value": true
             }
         },
         {
@@ -103,7 +103,7 @@
         {
             "DramCeccErrThresholdCnt": {
                 "Description": "Error threshold count for DRAM ECC correctable errors",
-                "Value": 1
+                "Value": 2
             }
         },
         {

--- a/config/ras_config.json
+++ b/config/ras_config.json
@@ -75,6 +75,20 @@
             }
         },
         {
+            "DramCeccOobEcMode": {
+                "Description": "DRAM CECC OOB error counter mode: 0=disabled, 1=no-leak mode, 2=leaky bucket mode",
+                "Value": 1,
+                "MaxBoundLimit": 2
+            }
+        },
+        {
+            "DramCeccLeakRate": {
+                "Description": "DRAM CECC leaky bucket leak rate (0x00-0x1F). Only used when DramCeccOobEcMode=2",
+                "Value": 0,
+                "MaxBoundLimit": 31
+            }
+        },
+        {
             "DramCeccThresholdEn": {
                 "Description": "If this field is true, error thresholding for DRAM ECC correctable errors will be enabled",
                 "Value": false

--- a/include/utils/util.hpp
+++ b/include/utils/util.hpp
@@ -123,6 +123,18 @@ template <typename ReturnType>
 ReturnType getProperty(sdbusplus::bus::bus&, const char*, const char*,
                        const char*, const char*);
 
+/** @brief Posts a Redfish event to the BMC logging service.
+ *
+ *  @param[in] messageId   - Redfish message registry ID.
+ *  @param[in] messageArgs - message arguments.
+ *  @param[in] severity    - phosphor-logging severity.
+ */
+void postRedfishEvent(
+    const std::string& messageId,
+    const std::string& messageArgs,
+    const std::string& severity =
+        "xyz.openbmc_project.Logging.Entry.Level.Error");
+
 } // namespace util
 } // namespace ras
 } // namespace amd

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -2029,7 +2029,20 @@ oob_status_t Manager::setMcaErrThreshold()
 
         getOobRegisters(&oob_config);
 
-        oob_config.dram_cecc_oob_ec_mode = 1;
+        amd::ras::config::Manager::AttributeValue dramCeccOobEcModeVal =
+            configMgr.getAttribute("DramCeccOobEcMode");
+        int64_t* dramCeccOobEcMode =
+            std::get_if<int64_t>(&dramCeccOobEcModeVal);
+
+        amd::ras::config::Manager::AttributeValue dramCeccLeakRateVal =
+            configMgr.getAttribute("DramCeccLeakRate");
+        int64_t* dramCeccLeakRate =
+            std::get_if<int64_t>(&dramCeccLeakRateVal);
+
+        oob_config.dram_cecc_oob_ec_mode =
+            static_cast<uint8_t>(*dramCeccOobEcMode);
+        oob_config.dram_cecc_leak_rate =
+            static_cast<uint8_t>(*dramCeccLeakRate);
         oob_config.mca_oob_misc0_ec_enable = 1;
 
         ret = setRasOobConfig(oob_config);
@@ -2148,8 +2161,21 @@ oob_status_t Manager::setMcaOobConfig()
     if (*dramCeccPollingEn == true)
     {
         /* DRAM CECC OOB Error Counter Mode */
+        amd::ras::config::Manager::AttributeValue dramCeccOobEcModeVal =
+            configMgr.getAttribute("DramCeccOobEcMode");
+        int64_t* dramCeccOobEcMode =
+            std::get_if<int64_t>(&dramCeccOobEcModeVal);
+
+        amd::ras::config::Manager::AttributeValue dramCeccLeakRateVal =
+            configMgr.getAttribute("DramCeccLeakRate");
+        int64_t* dramCeccLeakRate =
+            std::get_if<int64_t>(&dramCeccLeakRateVal);
+
         oob_config.core_mca_err_reporting_en = 1;
-        oob_config.dram_cecc_oob_ec_mode = 1; /*Enabled in No leak mode*/
+        oob_config.dram_cecc_oob_ec_mode =
+            static_cast<uint8_t>(*dramCeccOobEcMode);
+        oob_config.dram_cecc_leak_rate =
+            static_cast<uint8_t>(*dramCeccLeakRate);
     }
 
     ret = setRasOobConfig(oob_config);

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -1543,10 +1543,8 @@ bool Manager::decodeInterrupt(uint8_t socNum)
         {
             std::string err_msg =
                 "The APML_ALERT_L is asserted due to MCE error";
-            sd_journal_send("MESSAGE=%s", err_msg.c_str(), "PRIORITY=%i",
-                            LOG_ERR, "REDFISH_MESSAGE_ID=%s",
-                            "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
-                            err_msg.c_str(), NULL);
+
+            amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", err_msg);
 
             uint8_t buffer;
             oob_status_t ret;
@@ -1610,10 +1608,7 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                         "Fatal error detected in the control fabric. "
                         "BMC may trigger a reset based on policy set. ";
 
-                    sd_journal_send(
-                        "MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
-                        "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
-                        "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+                    amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", rasErrMsg);
 
                     harvestBreakEvent(socNum);
                     cpuAlertProcessed.assign(cpuCount, true);
@@ -1624,10 +1619,8 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                         "System hang while resetting in syncflood."
                         "Suggested next step is to do an additional manual "
                         "immediate reset";
-                    sd_journal_send(
-                        "MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
-                        "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
-                        "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+
+                    amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", rasErrMsg);
 
                     fchHangError = true;
                 }
@@ -1655,10 +1648,7 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                         contextType = crashdump;
                     }
 
-                    sd_journal_send(
-                        "MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
-                        "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
-                        "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+                    amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", rasErrMsg);
 
                     if (false == harvestMcaValidityCheck(socNum, &errorCheck))
                     {
@@ -1672,10 +1662,7 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                     std::string rasErrMsg =
                         "Non MCA Shutdown error detected in the system";
 
-                    sd_journal_send(
-                        "MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
-                        "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
-                        "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+                    amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", rasErrMsg);
 
                     nonMcaShutdownError = true;
                 }
@@ -1688,11 +1675,7 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                         std::string mcaErrOverflowMsg =
                             "MCA runtime error counter overflow occured";
 
-                        sd_journal_send(
-                            "MESSAGE=%s", mcaErrOverflowMsg.c_str(),
-                            "PRIORITY=%i", LOG_ERR, "REDFISH_MESSAGE_ID=%s",
-                            "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
-                            mcaErrOverflowMsg.c_str(), NULL);
+                        amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", mcaErrOverflowMsg);
 
                         runtimeError = true;
                     }
@@ -1703,11 +1686,7 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                         std::string dramErrOverlowMsg =
                             "DRAM CECC runtime error counter overflow occured";
 
-                        sd_journal_send(
-                            "MESSAGE=%s", dramErrOverlowMsg.c_str(),
-                            "PRIORITY=%i", LOG_ERR, "REDFISH_MESSAGE_ID=%s",
-                            "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
-                            dramErrOverlowMsg.c_str(), NULL);
+                        amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", dramErrOverlowMsg);
 
                         runtimeError = true;
                     }
@@ -1718,11 +1697,7 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                         std::string pcieErrOverlowMsg =
                             "PCIE runtime error counter overflow occured";
 
-                        sd_journal_send(
-                            "MESSAGE=%s", pcieErrOverlowMsg.c_str(),
-                            "PRIORITY=%i", LOG_ERR, "REDFISH_MESSAGE_ID=%s",
-                            "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
-                            pcieErrOverlowMsg.c_str(), NULL);
+                        amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", pcieErrOverlowMsg);
 
                         runtimeError = true;
                     }
@@ -1842,11 +1817,9 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                                                 }
                                             }
 
-                                            sd_journal_send(
-                                                "PRIORITY=%i", LOG_INFO,
-                                                "REDFISH_MESSAGE_ID=%s",
-                                                "OpenBMC.0.1.AmdAifsFailureMatch",
-                                                NULL);
+                                            amd::ras::util::postRedfishEvent(
+                                                "OpenBMC.0.1.AmdAifsFailureMatch", "",
+                                                "xyz.openbmc_project.Logging.Entry.Level.Informational");
 
                                             break;
                                         }

--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -611,10 +611,7 @@ void createFile(const std::shared_ptr<PtrType>& data,
             std::string rasErrMsg = "Generated runtime CPER file : ";
             rasErrMsg.append(cperFilePath);
 
-            sd_journal_send("MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i",
-                            LOG_ERR, "REDFISH_MESSAGE_ID=%s",
-                            "OpenBMC.0.1.AtScaleDebugConnected",
-                            "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+            amd::ras::util::postRedfishEvent("OpenBMC.0.1.AtScaleDebugConnected", rasErrMsg);
         }
     }
     else if (errorType == fatalErr)
@@ -635,10 +632,7 @@ void createFile(const std::shared_ptr<PtrType>& data,
             std::string rasErrMsg = "Generated Fatal CPER file : ";
             rasErrMsg.append(cperFilePath);
 
-            sd_journal_send("MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i",
-                            LOG_ERR, "REDFISH_MESSAGE_ID=%s",
-                            "OpenBMC.0.1.AtScaleDebugConnected",
-                            "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+            amd::ras::util::postRedfishEvent("OpenBMC.0.1.AtScaleDebugConnected", rasErrMsg);
         }
     }
     else if (errorType == runtimePcieErr)
@@ -657,10 +651,7 @@ void createFile(const std::shared_ptr<PtrType>& data,
             std::string rasErrMsg = "Generated runtime CPER file : ";
             rasErrMsg.append(cperFilePath);
 
-            sd_journal_send(
-                "MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
-                "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.AtScaleDebugConnected",
-                "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+            amd::ras::util::postRedfishEvent("OpenBMC.0.1.AtScaleDebugConnected", rasErrMsg);
         }
     }
     fclose(file);

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -287,6 +287,32 @@ ReturnType getProperty(sdbusplus::bus::bus& bus, const char* service,
     return std::get<ReturnType>(value);
 }
 
+void postRedfishEvent(const std::string& messageId,
+                      const std::string& messageArgs,
+                      const std::string& severity)
+{
+    std::map<std::string, std::string> addData{
+        {"REDFISH_MESSAGE_ID",   messageId},
+        {"REDFISH_MESSAGE_ARGS", messageArgs},
+    };
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+        auto method = bus.new_method_call(
+            "xyz.openbmc_project.Logging",
+            "/xyz/openbmc_project/logging",
+            "xyz.openbmc_project.Logging.Create",
+            "Create");
+        method.append(messageId, severity, addData);
+        bus.call_noreply(method);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed to post Redfish EventLog entry {ID}: {ERR}",
+                   "ID", messageId, "ERR", e.what());
+    }
+}
+
 } // namespace util
 } // namespace ras
 } // namespace amd


### PR DESCRIPTION
***Description***
Modify the redfish event logging to make use of phosphor-logging and publish the redfish event when the CPU errors are encountered and the CPER's are generated for the error with the BMC disk path for the CPER.

***Changes***
Make use of phosphor-logging `Create` method to add the `redfishMsgArgs, Description, MessageID and severity`.
Using `mfg-tool log-display` will display the events.

***Testing***
<img width="881" height="377" alt="image" src="https://github.com/user-attachments/assets/ddc0563a-2aa0-4210-87b3-4826be9eb0b9" />

