### PR TITLE
Replace dealine timer with steady timer to fix the compilation issue

### DIFF
--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -7,7 +7,7 @@ extern "C"
 #include "esmi_mailbox.h"
 }
 
-#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <gpiod.hpp>
 
@@ -76,9 +76,9 @@ class Manager : public amd::ras::Manager
     bool platformInitialized;
     bool runtimeErrPollingSupported;
     std::vector<bool> cpuAlertProcessed;
-    boost::asio::deadline_timer* McaErrorPollingEvent;
-    boost::asio::deadline_timer* DramCeccErrorPollingEvent;
-    boost::asio::deadline_timer* PcieAerErrorPollingEvent;
+    boost::asio::steady_timer* McaErrorPollingEvent;
+    boost::asio::steady_timer* DramCeccErrorPollingEvent;
+    boost::asio::steady_timer* PcieAerErrorPollingEvent;
     std::mutex harvestMutex;
     std::mutex mcaErrorHarvestMtx;
     std::mutex dramErrorHarvestMtx;

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -267,8 +267,8 @@ void Manager::mcaErrorPollingHandler(int64_t* pollingPeriod)
     {
         delete McaErrorPollingEvent;
     }
-    McaErrorPollingEvent = new boost::asio::deadline_timer(
-        io, boost::posix_time::seconds(*pollingPeriod));
+    McaErrorPollingEvent = new boost::asio::steady_timer(
+        io, std::chrono::seconds(*pollingPeriod));
 
     McaErrorPollingEvent->async_wait(
         [this](const boost::system::error_code ec) {
@@ -299,8 +299,8 @@ void Manager::dramCeccErrorPollingHandler(int64_t* pollingPeriod)
     if (DramCeccErrorPollingEvent != nullptr)
         delete DramCeccErrorPollingEvent;
 
-    DramCeccErrorPollingEvent = new boost::asio::deadline_timer(
-        io, boost::posix_time::seconds(*pollingPeriod));
+    DramCeccErrorPollingEvent = new boost::asio::steady_timer(
+        io, std::chrono::seconds(*pollingPeriod));
 
     DramCeccErrorPollingEvent->async_wait(
         [this](const boost::system::error_code ec) {
@@ -334,8 +334,8 @@ void Manager::pcieAerErrorPollingHandler(int64_t* pollingPeriod)
     if (PcieAerErrorPollingEvent != nullptr)
         delete PcieAerErrorPollingEvent;
 
-    PcieAerErrorPollingEvent = new boost::asio::deadline_timer(
-        io, boost::posix_time::seconds(*pollingPeriod));
+    PcieAerErrorPollingEvent = new boost::asio::steady_timer(
+        io, std::chrono::seconds(*pollingPeriod));
 
     PcieAerErrorPollingEvent->async_wait(
         [this](const boost::system::error_code ec) {


### PR DESCRIPTION
***Description***
The latest openbmc CLI has to use the steady timer so have to make this change to get it compiled on the openbmc repo.

***Changes***
Replace the deadline timer with steady timer for the polling handlers

***Testing***
Checked for the successful compilation
<img width="338" height="236" alt="image" src="https://github.com/user-attachments/assets/2dd66409-f02b-49e2-a3c2-338bc4fafe92" />
