### PR TITLE
sdbusplus: use non-deprecated type aliases

### DIFF
--- a/include/utils/util.hpp
+++ b/include/utils/util.hpp
@@ -120,8 +120,8 @@ void rasRecoveryAction(std::string&, uint8_t, const std::string*,
  */
 
 template <typename ReturnType>
-ReturnType getProperty(sdbusplus::bus::bus&, const char*, const char*,
-                       const char*, const char*);
+ReturnType getProperty(sdbusplus::bus_t&, const char*, const char*, const char*,
+                       const char*);
 
 } // namespace util
 } // namespace ras

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -107,24 +107,25 @@ oob_status_t readOobRegister(uint8_t info, uint32_t reg, uint8_t* value)
 
 Manager::Manager(amd::ras::config::Manager& manager,
                  boost::asio::io_context& io, std::string& node) :
-    amd::ras::Manager(manager, node), progId(1), recordId(1), watchdogTimerCounter(0),
-    io(io), apmlInitialized(false), platformInitialized(false),
-    runtimeErrPollingSupported(false), McaErrorPollingEvent(nullptr),
-    DramCeccErrorPollingEvent(nullptr), PcieAerErrorPollingEvent(nullptr),
-    mcaErrorHarvestMtx(), dramErrorHarvestMtx(), pcieErrorHarvestMtx()
+    amd::ras::Manager(manager, node), progId(1), recordId(1),
+    watchdogTimerCounter(0), io(io), apmlInitialized(false),
+    platformInitialized(false), runtimeErrPollingSupported(false),
+    McaErrorPollingEvent(nullptr), DramCeccErrorPollingEvent(nullptr),
+    PcieAerErrorPollingEvent(nullptr), mcaErrorHarvestMtx(),
+    dramErrorHarvestMtx(), pcieErrorHarvestMtx()
 {}
 
 void Manager::currentHostStateMonitor()
 {
-    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+    sdbusplus::bus_t bus = sdbusplus::bus::new_default();
     boost::system::error_code ec;
 
-    static auto match = sdbusplus::bus::match::match(
+    static auto match = sdbusplus::bus::match_t(
         bus,
         "type='signal',member='PropertiesChanged', "
         "interface='org.freedesktop.DBus.Properties', "
         "arg0='xyz.openbmc_project.State.Host'",
-        [this](sdbusplus::message::message& message) {
+        [this](sdbusplus::message_t& message) {
             oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
             std::string intfName;
             std::map<std::string, std::variant<std::string>> properties;
@@ -427,15 +428,15 @@ void Manager::init()
 
     platformInitialize();
 
-    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+    sdbusplus::bus_t bus = sdbusplus::bus::new_default();
     boost::system::error_code ec;
 
-    static auto match = sdbusplus::bus::match::match(
+    static auto match = sdbusplus::bus::match_t(
         bus,
         "type='signal',member='PropertiesChanged', "
         "interface='org.freedesktop.DBus.Properties', "
         "arg0='xyz.openbmc_project.State.Watchdog'",
-        [this](sdbusplus::message::message& message) {
+        [this](sdbusplus::message_t& message) {
             std::string intfName;
             std::map<std::string, std::variant<bool>> properties;
 
@@ -465,7 +466,7 @@ void Manager::init()
 
             if (*currentTimerEnable == false)
             {
-                sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+                sdbusplus::bus_t bus = sdbusplus::bus::new_default();
                 std::string currentTimerUse =
                     amd::ras::util::getProperty<std::string>(
                         bus, "xyz.openbmc_project.Watchdog",
@@ -522,7 +523,8 @@ void Manager::configure()
     std::ifstream jsonFile(gpioConfigFile);
     if (!jsonFile.is_open())
     {
-        throw std::runtime_error("Failed to open GPIO config file: " + gpioConfigFile);
+        throw std::runtime_error(
+            "Failed to open GPIO config file: " + gpioConfigFile);
     }
 
     nlohmann::json config;
@@ -2545,7 +2547,7 @@ void Manager::harvestDramCeccErrorCounters(struct ras_rt_valid_err_inst inst,
             std::string objectPath =
                 "/xyz/openbmc_project/inventory/Memory/" + rootErrStatus;
 
-            sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+            sdbusplus::bus_t bus = sdbusplus::bus::new_default();
             uint16_t correctableErrorCount =
                 amd::ras::util::getProperty<uint16_t>(
                     bus, "xyz.openbmc_project.PCIe", objectPath.c_str(),

--- a/src/base_manager.cpp
+++ b/src/base_manager.cpp
@@ -94,7 +94,7 @@ void Manager::getCpuSocketInfo()
 
     if (*uCodeVersionFlag == true)
     {
-        sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+        sdbusplus::bus_t bus = sdbusplus::bus::new_default();
 
         for (size_t i = 0; i < cpuCount; i++)
         {
@@ -117,7 +117,7 @@ void Manager::getCpuSocketInfo()
         configMgr.getAttribute("HarvestPPIN");
     bool* harvestPpinFlag = std::get_if<bool>(&harvestPpin);
 
-    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+    sdbusplus::bus_t bus = sdbusplus::bus::new_default();
 
     if (*harvestPpinFlag == true)
     {

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -164,7 +164,7 @@ void triggerRsmrstReset()
         "xyz.openbmc_project.Control.Host.SOCReset", "SOCReset");
 
     sleep(1);
-    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+    sdbusplus::bus_t bus = sdbusplus::bus::new_default();
     std::string currentHostState = amd::ras::util::getProperty<std::string>(
         bus, "xyz.openbmc_project.State.Host",
         "/xyz/openbmc_project/state/host0", "xyz.openbmc_project.State.Host",
@@ -257,16 +257,16 @@ void rasRecoveryAction(std::string& node, uint8_t buf,
     }
 }
 
-template std::string getProperty(sdbusplus::bus::bus& bus, const char* service,
+template std::string getProperty(sdbusplus::bus_t& bus, const char* service,
                                  const char* path, const char* interface,
                                  const char* propertyName);
 
-template uint16_t getProperty(sdbusplus::bus::bus& bus, const char* service,
+template uint16_t getProperty(sdbusplus::bus_t& bus, const char* service,
                               const char* path, const char* interface,
                               const char* propertyName);
 
 template <typename ReturnType>
-ReturnType getProperty(sdbusplus::bus::bus& bus, const char* service,
+ReturnType getProperty(sdbusplus::bus_t& bus, const char* service,
                        const char* path, const char* interface,
                        const char* propertyName)
 {


### PR DESCRIPTION
A number of type aliases here are deprecated in sdbusplus and will
be removed in the future.  Switch to the non-deprecated (and shorter)
types.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
