### PR TITLE
Update PCIe error severity from Root Error Status

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -69,6 +69,10 @@ constexpr size_t breakEvent = 3;
 constexpr uint16_t breakEventBanks = 1;
 constexpr size_t index28 = 28;
 constexpr size_t blockId25 = 25;
+constexpr uint32_t rootErrStatusOffset = 52;
+constexpr uint32_t fatalErrMsgRcvd = (1 << 6);
+constexpr uint32_t nonfatalErrMsgRcvd = (1 << 5);
+constexpr uint32_t errCorrRcvd = (1 << 0);
 
 void writeOobRegister(uint8_t info, uint32_t reg, uint32_t value)
 {
@@ -3317,7 +3321,7 @@ void Manager::dumpProcErrorSection(
                     dumpIndex++;
                 }
 
-                if (dataIn.offset == 0)
+                if (dataIn.offset == rootErrStatusOffset)
                 {
                     rootErrStatus = dataOut;
                     continue;
@@ -3373,7 +3377,18 @@ void Manager::dumpProcErrorSection(
         }
         else if (category == 2) // PCIE error
         {
-            Severity[section] = rootErrStatus & 0xFF;
+            if (rootErrStatus & fatalErrMsgRcvd)
+            {
+                Severity[section] = 1; // Fatal
+            }
+            else if (rootErrStatus & nonfatalErrMsgRcvd)
+            {
+                Severity[section] = 0; // Non-fatal uncorrected
+            }
+            else if (rootErrStatus & errCorrRcvd)
+            {
+                Severity[section] = 2; // Corrected
+            }
         }
         n++;
         section++;


### PR DESCRIPTION
Update PCIe error severity handling to decode severity based on Root Error Status register bits instead of using the raw register value directly.

Changes include:

- Add Root Error Status register offset definition
- Define Fatal, Non-Fatal, and Corrected error bit masks
- Capture Root Error Status from offset 52(0x34)
- Map PCIe severity values based on received error message type:
	Fatal -> 1
	Non-fatal uncorrected -> 0
	Corrected -> 2