### PR TITLE
fix DRAM and PCIe runtime error handling typos

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -859,10 +859,10 @@ void Manager::harvestRuntimeErrors(uint8_t errorPollingType,
         {
             sectionStart = sectionCount - p1Inst.number_of_inst;
 
-            dumpProcErrorSection(mcaPtr, 1, p1Inst, dramCeccErr, sectionStart,
+            dumpProcErrorSection(dramPtr, 1, p1Inst, dramCeccErr, sectionStart,
                                  severity, checkInfo);
             amd::ras::util::cper::dumpProcErrorInfoSection(
-                mcaPtr, p1Inst.number_of_inst, checkInfo, sectionStart,
+                dramPtr, p1Inst.number_of_inst, checkInfo, sectionStart,
                 cpuCount, cpuId);
         }
 
@@ -923,7 +923,7 @@ void Manager::harvestRuntimeErrors(uint8_t errorPollingType,
         }
 
         amd::ras::util::cper::calculateSeverity(
-            severity, sectionCount, &highestSeverity, runtimeDramErr);
+            severity, sectionCount, &highestSeverity, runtimePcieErr);
 
         amd::ras::util::cper::dumpHeader(pciePtr, sectionCount, highestSeverity,
                                          runtimePcieErr, boardId, recordId);


### PR DESCRIPTION
Correct runtime error processing for DRAM and PCIe error paths in harvestRuntimeErrors().

Changes include:

Use dramPtr instead of mcaPtr when dumping DRAM CECC processor error sections and error info sections
Use runtimePcieErr instead of runtimeDramErr when
calculating PCIe error severity