### PR TITLE
bump CPER minor revision for x86 exception support

### DIFF
--- a/include/utils/cper.hpp
+++ b/include/utils/cper.hpp
@@ -25,7 +25,7 @@ constexpr uint8_t cperValidTimestamp = 0x2;
 constexpr uint8_t addcGenNumber3 = 0x03;
 constexpr uint8_t familyId1ah = 0x1A;
 constexpr uint16_t pcieVendorId = 0x1022;
-constexpr uint8_t minorRevision = 0xB;
+constexpr uint8_t minorRevision = 0x0C;
 
 /** @brief Finds a filename in the RAS directory that matches a given pattern.
  *


### PR DESCRIPTION
Update the CPER minor revision from 0x0B to 0x0C to reflect the addition of x86 exception core debug dump harvesting support.

This revision update aligns the CPER versioning with the latest CPER format and feature enhancements.