### PR TITLE
Update source for FruText Data

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -1774,9 +1774,7 @@ void Manager::harvestMcaDataBanks(uint8_t socNum,
             } // if (ret != OOB_SUCCESS)
 
             rcd->ErrorRecord[socNum].CrashDumpData[n].McaData[offset] = buffer;
-
         } // for loop
-
 
         n++;
     }

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -1651,6 +1651,8 @@ void Manager::harvestX86ExceptionData(uint8_t socNum)
 void Manager::harvestMcaDataBanks(uint8_t socNum,
                                   struct ras_df_err_chk errorCheck)
 {
+    constexpr size_t mcaConfigLoOffset = 0x20;
+    constexpr uint32_t mcaFruTextInMcaBit = 9;
     uint16_t n = 0;
     uint16_t maxOffset32;
     uint32_t buffer;
@@ -1674,6 +1676,7 @@ void Manager::harvestMcaDataBanks(uint8_t socNum,
     uint32_t mcaPspSynd1Hi = 0;
     uint32_t mcaPspSynd2Lo = 0;
     uint32_t mcaPspSynd2Hi = 0;
+    uint32_t mcaConfigLo = 0;
 
     amd::ras::config::Manager::AttributeValue sigIdOffsetVal =
         configMgr.getAttribute("SigIdOffset");
@@ -1748,6 +1751,7 @@ void Manager::harvestMcaDataBanks(uint8_t socNum,
 
     while (n < errorCheck.df_block_instances)
     {
+        mcaConfigLo = 0;
         for (uint32_t offset = 0; offset < maxOffset32; offset++)
         {
             memset(&buffer, 0, sizeof(buffer));
@@ -1845,6 +1849,10 @@ void Manager::harvestMcaDataBanks(uint8_t socNum,
             {
                 mcaPspSynd2Hi = buffer;
             }
+            if (dfError.input[0] == mcaConfigLoOffset)
+            {
+                mcaConfigLo = buffer;
+            }
 
         } // for loop
 
@@ -1872,14 +1880,17 @@ void Manager::harvestMcaDataBanks(uint8_t socNum,
             mcaStatusHi = 0;
         }
 
-        memcpy(rcd->SectionDescriptor[socNum].FruString + offLo1,
-               &mcaPspSynd1Lo, copySize);
-        memcpy(rcd->SectionDescriptor[socNum].FruString + offHi1,
-               &mcaPspSynd1Hi, copySize);
-        memcpy(rcd->SectionDescriptor[socNum].FruString + offLo2,
-               &mcaPspSynd2Lo, copySize);
-        memcpy(rcd->SectionDescriptor[socNum].FruString + offHi2,
-               &mcaPspSynd2Hi, copySize);
+        if ((mcaConfigLo & (1U << mcaFruTextInMcaBit)) != 0)
+        {
+            memcpy(rcd->SectionDescriptor[socNum].FruString + offLo1,
+                   &mcaPspSynd1Lo, copySize);
+            memcpy(rcd->SectionDescriptor[socNum].FruString + offHi1,
+                   &mcaPspSynd1Hi, copySize);
+            memcpy(rcd->SectionDescriptor[socNum].FruString + offLo2,
+                   &mcaPspSynd2Lo, copySize);
+            memcpy(rcd->SectionDescriptor[socNum].FruString + offHi2,
+                   &mcaPspSynd2Hi, copySize);
+        }
 
         n++;
     }
@@ -3170,6 +3181,8 @@ void Manager::dumpProcErrorSection(
     struct ras_rt_valid_err_inst inst, uint8_t category, uint16_t section,
     uint32_t* Severity, uint64_t* CheckInfo)
 {
+    constexpr size_t mcaConfigLoOffset = 0x20;
+    constexpr uint32_t mcaFruTextInMcaBit = 9;
     uint16_t n = 0;
     struct run_time_err_d_in dataIn;
     uint32_t dataOut = 0;
@@ -3183,6 +3196,7 @@ void Manager::dumpProcErrorSection(
     uint32_t mcaPspSynd2Lo = 0;
     uint32_t mcaPspSynd2Hi = 0;
     uint32_t mcaIpidHi = 0;
+    uint32_t mcaConfigLo = 0;
 
     amd::ras::config::Manager::AttributeValue apmlRetry =
         configMgr.getAttribute("ApmlRetries");
@@ -3209,6 +3223,7 @@ void Manager::dumpProcErrorSection(
 
     while (n < inst.number_of_inst)
     {
+        mcaConfigLo = 0;
         if (category ==
             1) // For Dram Cecc error , the dump started from offset 4
         {
@@ -3290,6 +3305,10 @@ void Manager::dumpProcErrorSection(
                 {
                     mcaIpidHi = dataOut;
                 }
+                else if (dataIn.offset == mcaConfigLoOffset + baseOffset)
+                {
+                    mcaConfigLo = dataOut;
+                }
 
                 if (dataIn.offset == mcaPspSynd1LoCode + baseOffset)
                 {
@@ -3334,22 +3353,37 @@ void Manager::dumpProcErrorSection(
 
         if ((category == 0) || (category == 1))
         {
-            memcpy(ProcPtr->SectionDescriptor[section].FruString + offLo1,
-                   &mcaPspSynd1Lo, copySize);
-            memcpy(ProcPtr->SectionDescriptor[section].FruString + offHi1,
-                   &mcaPspSynd1Hi, copySize);
-            memcpy(ProcPtr->SectionDescriptor[section].FruString + offLo2,
-                   &mcaPspSynd2Lo, copySize);
-            memcpy(ProcPtr->SectionDescriptor[section].FruString + offHi2,
-                   &mcaPspSynd2Hi, copySize);
-
-            if (category == 0 && mcaPspSynd1Lo == 0 && mcaPspSynd1Hi == 0 &&
-                mcaPspSynd2Lo == 0 && mcaPspSynd2Hi == 0 &&
-                (mcaIpidHi & 0xFFF) == umcHardwareId)
+            if ((mcaConfigLo & (1U << mcaFruTextInMcaBit)) != 0)
             {
-                std::strncpy(ProcPtr->SectionDescriptor[section].FruString,
-                             "MemoryError", 19);
-                ProcPtr->SectionDescriptor[section].FruString[19] = '\0';
+                memcpy(ProcPtr->SectionDescriptor[section].FruString + offLo1,
+                       &mcaPspSynd1Lo, copySize);
+                memcpy(ProcPtr->SectionDescriptor[section].FruString + offHi1,
+                       &mcaPspSynd1Hi, copySize);
+                memcpy(ProcPtr->SectionDescriptor[section].FruString + offLo2,
+                       &mcaPspSynd2Lo, copySize);
+                memcpy(ProcPtr->SectionDescriptor[section].FruString + offHi2,
+                       &mcaPspSynd2Hi, copySize);
+
+                if (category == 0 && mcaPspSynd1Lo == 0 && mcaPspSynd1Hi == 0 &&
+                    mcaPspSynd2Lo == 0 && mcaPspSynd2Hi == 0 &&
+                    (mcaIpidHi & 0xFFF) == umcHardwareId)
+                {
+                    std::strncpy(ProcPtr->SectionDescriptor[section].FruString,
+                                 "MemoryError", 19);
+                    ProcPtr->SectionDescriptor[section].FruString[19] = '\0';
+                }
+            }
+            else
+            {
+                if (mcaPspSynd1Lo == 0 && mcaPspSynd1Hi == 0 &&
+                    mcaPspSynd2Lo == 0 && mcaPspSynd2Hi == 0)
+                {
+                    std::memset(ProcPtr->SectionDescriptor[section].FruString,
+                                0, 20);
+                }
+                ProcPtr->SectionDescriptor[section].FruString[0] = 'P';
+                ProcPtr->SectionDescriptor[section].FruString[1] = '0' + socNum;
+                ProcPtr->SectionDescriptor[section].FruString[2] = '\0';
             }
 
             CheckInfo[section] = 0;


### PR DESCRIPTION
Current BMC code have two source for Frutext. One is filled with P0/P1 by BMC which is the legacy design.Another is from the MCA ASPSYND1, ASPSYND2 which is newly introduced. This change updates to read the FruTextData based on the value in MCA_CONFIG[McaFruTextInMca] to determine the source. BMC is supposed to check MCA_CONFIG[McaFruTextInMca] to determine the source,

=1: use MCA_ASPSYND1/MCA_ASPSYND2,

=0: use legacy

Tested: Tested on kenya. frutext data is not empty.

'''

root@kenya-1637:/usr/bin# ./addc-tool cper --analyze /var/lib/amd-bmc-ras/ras-error0.cper {
  "tool_version": "3.2.0",
  "json_version": "3.0.0",
  "cper_timestamp": "2126-05-07T17:31:50+00:00",
  "cper_filename": "ras-error0.cper",
  "platform_id": {
    "value": "6f697461-0000-0000-0000-000000000000"
  },
  "events": [
    {
      "metadata": {
        "section_index": 0,
        "context_structure_index": 0,
        "context_type": "Unknown",
        "event_class": "dbglog_dump",
        "event_index": 0,
        "cper_timestamp": "2126/05/07 17:31:50",
        "addc_version": {
          "name": "AMD EPYC Venice",
          "value": "3.1.11"
        }
      },
      "platform": {
        "apic_id": "0x0000000000000000",
        "cpuid": {
          "eax": "0x00ff000b00000010",
          "ebx": "0x0000000000000000",
          "ecx": "0x0000000000000000",
          "edx": "0x0000000000000000"
        },
        "ucode": null,
        "ppin": null,
        **"fru": "P0",
        "fru_id": "00000000-0000-0000-0000-000000000000"**
      },

'''