### PR TITLE
Generalize RAS handling for 4-socket platforms

### DIFF
--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -315,14 +315,12 @@ class Manager : public amd::ras::Manager
      * error polling type
      *
      * @param[in] errorPollingType - The type of error polling.
-     * @param[in] p0Inst - Structure representing a valid RAS error instance for
-     * processor 0.
-     * @param[in] p1Inst - Structure representing a valid RAS error instance for
-     * processor 1.
+     * @param[in] instVec - Vector of valid RAS error instances, one per
+     *            socket in socIndex order.
      *
      */
-    void harvestRuntimeErrors(uint8_t, struct ras_rt_valid_err_inst,
-                              struct ras_rt_valid_err_inst);
+    void harvestRuntimeErrors(uint8_t,
+                              std::vector<struct ras_rt_valid_err_inst>&);
 
     /** @brief Check runtime error information.
      *

--- a/include/base_manager.hpp
+++ b/include/base_manager.hpp
@@ -8,6 +8,8 @@
 
 constexpr size_t socket1 = 1;
 constexpr size_t socket2 = 2;
+constexpr size_t socket3 = 3;
+constexpr size_t socket4 = 4;
 
 namespace amd
 {

--- a/include/config_manager.hpp
+++ b/include/config_manager.hpp
@@ -124,35 +124,21 @@ class Manager : public amd::ras::config::ConfigIface
     void updateErrorCountDbus();
 
     /** @brief Increment the correctable CPU error count for a given index.
-     *  @param[in] socNum - socket number (0 or 1).
+     *  @param[in] socNum - socket number (0-3).
      *  @param[in] index - CPU error index to increment.
      */
     void incrementCorrectableCPUError(size_t socNum, size_t index)
     {
-        if (socNum == 0)
-        {
-            p0CorrectableCPUErrors.at(index)++;
-        }
-        else
-        {
-            p1CorrectableCPUErrors.at(index)++;
-        }
+        correctableCPUErrors.at(socNum).at(index)++;
     }
 
     /** @brief Increment the noncorrectable CPU error count for a given index.
-     *  @param[in] socNum - socket number (0 or 1).
+     *  @param[in] socNum - socket number (0-3).
      *  @param[in] index - CPU error index to increment.
      */
     void incrementNoncorrectableCPUError(size_t socNum, size_t index)
     {
-        if (socNum == 0)
-        {
-            p0NoncorrectableCPUErrors.at(index)++;
-        }
-        else
-        {
-            p1NoncorrectableCPUErrors.at(index)++;
-        }
+        noncorrectableCPUErrors.at(socNum).at(index)++;
     }
 
     /** @brief Get the threshold count for a given error category.
@@ -171,48 +157,31 @@ class Manager : public amd::ras::config::ConfigIface
                                const std::string& thresholdCntKey);
 
     /** @brief Increment the correctable other error count.
-     *  @param[in] socNum - socket number (0 or 1).
+     *  @param[in] socNum - socket number (0-3).
      *  @param[in] thresholdCount - threshold count to increment by.
      */
     void incrementCorrectableOtherError(size_t socNum, uint64_t thresholdCount)
     {
-        if (socNum == 0)
-        {
-            p0CorrectableOtherErrors += thresholdCount;
-        }
-        else
-        {
-            p1CorrectableOtherErrors += thresholdCount;
-        }
+        correctableOtherErrors.at(socNum) += thresholdCount;
     }
 
     /** @brief Increment the noncorrectable other error count.
-     *  @param[in] socNum - socket number (0 or 1).
+     *  @param[in] socNum - socket number (0-3).
      */
     void incrementNoncorrectableOtherError(size_t socNum)
     {
-        if (socNum == 0)
-        {
-            p0NoncorrectableOtherErrors++;
-        }
-        else
-        {
-            p1NoncorrectableOtherErrors++;
-        }
+        noncorrectableOtherErrors.at(socNum)++;
     }
 
   private:
     static constexpr size_t maxErrorIndex = 256;
-    inline static std::array<uint64_t, maxErrorIndex> p0CorrectableCPUErrors{};
-    inline static std::array<uint64_t, maxErrorIndex>
-        p0NoncorrectableCPUErrors{};
-    inline static uint64_t p0CorrectableOtherErrors{};
-    inline static uint64_t p0NoncorrectableOtherErrors{};
-    inline static std::array<uint64_t, maxErrorIndex> p1CorrectableCPUErrors{};
-    inline static std::array<uint64_t, maxErrorIndex>
-        p1NoncorrectableCPUErrors{};
-    inline static uint64_t p1CorrectableOtherErrors{};
-    inline static uint64_t p1NoncorrectableOtherErrors{};
+    static constexpr size_t maxSockets = 4;
+    inline static std::array<std::array<uint64_t, maxErrorIndex>, maxSockets>
+        correctableCPUErrors{};
+    inline static std::array<std::array<uint64_t, maxErrorIndex>, maxSockets>
+        noncorrectableCPUErrors{};
+    inline static std::array<uint64_t, maxSockets> correctableOtherErrors{};
+    inline static std::array<uint64_t, maxSockets> noncorrectableOtherErrors{};
     sdbusplus::asio::object_server& objServer;
     std::shared_ptr<sdbusplus::asio::connection>& systemBus;
     std::string node;

--- a/include/utils/cper.hpp
+++ b/include/utils/cper.hpp
@@ -221,7 +221,8 @@ void createFile(const std::shared_ptr<T>&, const std::string_view&, uint16_t,
  *  @return Returns true if the signature ID matches, false otherwise.
  */
 bool checkSignatureIdMatch(std::map<std::string, std::string>*,
-                           const std::shared_ptr<FatalCperRecord>&);
+                           const std::shared_ptr<FatalCperRecord>&,
+                           size_t cpuCount);
 
 /** @brief Determines the highest severity level from section severities for
  * CPER.

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -794,9 +794,9 @@ void Manager::alertEventHandler(
         });
 }
 
-void Manager::harvestRuntimeErrors(uint8_t errorPollingType,
-                                   struct ras_rt_valid_err_inst p0Inst,
-                                   struct ras_rt_valid_err_inst p1Inst)
+void Manager::harvestRuntimeErrors(
+    uint8_t errorPollingType,
+    std::vector<struct ras_rt_valid_err_inst>& instVec)
 {
     uint32_t* severity = nullptr;
     uint64_t* checkInfo = nullptr;
@@ -805,7 +805,11 @@ void Manager::harvestRuntimeErrors(uint8_t errorPollingType,
     uint32_t sectionSize;
     uint64_t thresholdCount = 1;
 
-    uint16_t sectionCount = p0Inst.number_of_inst + p1Inst.number_of_inst;
+    uint16_t sectionCount = 0;
+    for (const auto& inst : instVec)
+    {
+        sectionCount += inst.number_of_inst;
+    }
 
     severity = new uint32_t[sectionCount];
     checkInfo = new uint64_t[sectionCount];
@@ -825,25 +829,19 @@ void Manager::harvestRuntimeErrors(uint8_t errorPollingType,
 
         uint16_t sectionStart = 0;
 
-        if (p0Inst.number_of_inst != 0)
+        for (size_t idx = 0; idx < instVec.size(); ++idx)
         {
-            dumpProcErrorSection(mcaPtr, socIndex[0], p0Inst, mcaErr,
-                                 sectionStart, severity, checkInfo);
+            if (instVec[idx].number_of_inst != 0)
+            {
+                dumpProcErrorSection(mcaPtr, socIndex[idx], instVec[idx],
+                                     mcaErr, sectionStart, severity, checkInfo);
 
-            amd::ras::util::cper::dumpProcErrorInfoSection(
-                mcaPtr, p0Inst.number_of_inst, checkInfo, sectionStart,
-                cpuCount, cpuId);
-        }
-        if (p1Inst.number_of_inst != 0)
-        {
-            sectionStart = sectionCount - p1Inst.number_of_inst;
+                amd::ras::util::cper::dumpProcErrorInfoSection(
+                    mcaPtr, instVec[idx].number_of_inst, checkInfo,
+                    sectionStart, cpuCount, cpuId);
 
-            dumpProcErrorSection(mcaPtr, socIndex[1], p1Inst, mcaErr,
-                                 sectionStart, severity, checkInfo);
-
-            amd::ras::util::cper::dumpProcErrorInfoSection(
-                mcaPtr, p1Inst.number_of_inst, checkInfo, sectionStart,
-                cpuCount, cpuId);
+                sectionStart += instVec[idx].number_of_inst;
+            }
         }
 
         amd::ras::util::cper::calculateSeverity(
@@ -902,23 +900,18 @@ void Manager::harvestRuntimeErrors(uint8_t errorPollingType,
 
         uint16_t sectionStart = 0;
 
-        if (p0Inst.number_of_inst != 0)
+        for (size_t idx = 0; idx < instVec.size(); ++idx)
         {
-            dumpProcErrorSection(dramPtr, 0, p0Inst, dramCeccErr, sectionStart,
-                                 severity, checkInfo);
-            amd::ras::util::cper::dumpProcErrorInfoSection(
-                dramPtr, p0Inst.number_of_inst, checkInfo, sectionStart,
-                cpuCount, cpuId);
-        }
-        if (p1Inst.number_of_inst != 0)
-        {
-            sectionStart = sectionCount - p1Inst.number_of_inst;
+            if (instVec[idx].number_of_inst != 0)
+            {
+                dumpProcErrorSection(dramPtr, idx, instVec[idx], dramCeccErr,
+                                     sectionStart, severity, checkInfo);
+                amd::ras::util::cper::dumpProcErrorInfoSection(
+                    dramPtr, instVec[idx].number_of_inst, checkInfo,
+                    sectionStart, cpuCount, cpuId);
 
-            dumpProcErrorSection(dramPtr, 1, p1Inst, dramCeccErr, sectionStart,
-                                 severity, checkInfo);
-            amd::ras::util::cper::dumpProcErrorInfoSection(
-                dramPtr, p1Inst.number_of_inst, checkInfo, sectionStart,
-                cpuCount, cpuId);
+                sectionStart += instVec[idx].number_of_inst;
+            }
         }
 
         amd::ras::util::cper::calculateSeverity(
@@ -966,17 +959,15 @@ void Manager::harvestRuntimeErrors(uint8_t errorPollingType,
 
         uint16_t sectionStart = 0;
 
-        if (p0Inst.number_of_inst != 0)
+        for (size_t idx = 0; idx < instVec.size(); ++idx)
         {
-            dumpProcErrorSection(pciePtr, 0, p0Inst, pcieErr, sectionStart,
-                                 severity, checkInfo);
-        }
-        if (p1Inst.number_of_inst != 0)
-        {
-            sectionStart = sectionCount - p1Inst.number_of_inst;
+            if (instVec[idx].number_of_inst != 0)
+            {
+                dumpProcErrorSection(pciePtr, idx, instVec[idx], pcieErr,
+                                     sectionStart, severity, checkInfo);
 
-            dumpProcErrorSection(pciePtr, 0, p1Inst, pcieErr, sectionStart,
-                                 severity, checkInfo);
+                sectionStart += instVec[idx].number_of_inst;
+            }
         }
 
         amd::ras::util::cper::calculateSeverity(
@@ -1009,16 +1000,11 @@ void Manager::harvestRuntimeErrors(uint8_t errorPollingType,
             pciePtr->PcieErrorData = nullptr;
         }
     }
-    if (errorPollingType != mcaErr)
+    for (size_t idx = 0; idx < instVec.size(); ++idx)
     {
-        if (p0Inst.number_of_inst != 0)
+        if (instVec[idx].number_of_inst != 0)
         {
-            configMgr.incrementCorrectableOtherError(socIndex[0],
-                                                     thresholdCount);
-        }
-        if (p1Inst.number_of_inst != 0)
-        {
-            configMgr.incrementCorrectableOtherError(socIndex[1],
+            configMgr.incrementCorrectableOtherError(socIndex[idx],
                                                      thresholdCount);
         }
     }
@@ -1059,28 +1045,31 @@ oob_status_t Manager::runTimeErrValidityCheck(
 
 void Manager::runTimeErrorInfoCheck(uint8_t errType, uint8_t reqType)
 {
-    struct ras_rt_valid_err_inst p0_inst, p1_inst;
+    std::vector<struct ras_rt_valid_err_inst> instVec(cpuCount);
+    std::vector<oob_status_t> retVec(cpuCount, OOB_MAILBOX_CMD_UNKNOWN);
     struct ras_rt_err_req_type rt_err_category;
-
-    oob_status_t p0_ret = OOB_MAILBOX_CMD_UNKNOWN;
-    oob_status_t p1_ret = OOB_MAILBOX_CMD_UNKNOWN;
 
     rt_err_category.err_type = errType;
     rt_err_category.req_type = reqType;
 
-    memset(&p0_inst, 0, sizeof(p0_inst));
-    memset(&p1_inst, 0, sizeof(p1_inst));
-
-    p0_ret = runTimeErrValidityCheck(socIndex[0], rt_err_category, &p0_inst);
-
-    if (cpuCount == 2)
+    for (size_t i = 0; i < cpuCount; ++i)
     {
-        p1_ret =
-            runTimeErrValidityCheck(socIndex[1], rt_err_category, &p1_inst);
+        memset(&instVec[i], 0, sizeof(instVec[i]));
+        retVec[i] =
+            runTimeErrValidityCheck(socIndex[i], rt_err_category, &instVec[i]);
     }
 
-    if (((p0_ret == OOB_SUCCESS) && (p0_inst.number_of_inst > 0)) ||
-        ((p1_ret == OOB_SUCCESS) && (p1_inst.number_of_inst > 0)))
+    bool hasErrors = false;
+    for (size_t i = 0; i < cpuCount; ++i)
+    {
+        if ((retVec[i] == OOB_SUCCESS) && (instVec[i].number_of_inst > 0))
+        {
+            hasErrors = true;
+            break;
+        }
+    }
+
+    if (hasErrors)
     {
         lg2::info(
             "Harvesting runtime error. Error Type: {ERRTYPE} Request Type: {REQTYPE}",
@@ -1092,19 +1081,18 @@ void Manager::runTimeErrorInfoCheck(uint8_t errType, uint8_t reqType)
             {
                 mcaPtr = std::make_shared<McaRuntimeCperRecord>();
             }
-            harvestRuntimeErrors(errType, p0_inst, p1_inst);
+            harvestRuntimeErrors(errType, instVec);
         }
         else if (errType == dramCeccErr)
         {
             if (reqType == pollingMode)
             {
-                if (p0_inst.number_of_inst != 0)
+                for (size_t i = 0; i < cpuCount; ++i)
                 {
-                    harvestDramCeccErrorCounters(p0_inst, 0);
-                }
-                if (p1_inst.number_of_inst != 0)
-                {
-                    harvestDramCeccErrorCounters(p1_inst, 1);
+                    if (instVec[i].number_of_inst != 0)
+                    {
+                        harvestDramCeccErrorCounters(instVec[i], i);
+                    }
                 }
             }
             else if (reqType == interruptMode)
@@ -1113,7 +1101,7 @@ void Manager::runTimeErrorInfoCheck(uint8_t errType, uint8_t reqType)
                 {
                     dramPtr = std::make_shared<McaRuntimeCperRecord>();
                 }
-                harvestRuntimeErrors(errType, p0_inst, p1_inst);
+                harvestRuntimeErrors(errType, instVec);
             }
         }
         else if (errType == pcieErr)
@@ -1122,7 +1110,7 @@ void Manager::runTimeErrorInfoCheck(uint8_t errType, uint8_t reqType)
             {
                 pciePtr = std::make_shared<PcieRuntimeCperRecord>();
             }
-            harvestRuntimeErrors(errType, p0_inst, p1_inst);
+            harvestRuntimeErrors(errType, instVec);
         }
     }
 }
@@ -2417,8 +2405,8 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
             std::get_if<std::map<std::string, std::string>>(&configSigId);
 
         if ((*aifsArmedFlag == true) &&
-            (amd::ras::util::cper::checkSignatureIdMatch(configSigIdList,
-                                                         rcd) == true))
+            (amd::ras::util::cper::checkSignatureIdMatch(configSigIdList, rcd,
+                                                         cpuCount) == true))
         {
             lg2::info("AIFS armed for the system");
 
@@ -2810,7 +2798,7 @@ bool Manager::decodeInterrupt(uint8_t socNum)
 
                 if ((*aifsArmedFlag == true) &&
                     (amd::ras::util::cper::checkSignatureIdMatch(
-                         configSigIdList, rcd) == true))
+                         configSigIdList, rcd, cpuCount) == true))
                 {
                     lg2::info("AIFS armed for the system");
 

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -361,10 +361,9 @@ void Manager::deleteAll()
     {
         std::string filename = entry.path().filename().string();
 
-        if (node == "1" || node == "2")
+        if (node != "0")
         {
-            if (filename.starts_with("node" + node) &&
-                filename.starts_with("node" + node))
+            if (filename.starts_with("node" + node))
             {
                 lg2::info("{FILE} deleted", "FILE", filename);
                 fs::remove(entry.path());
@@ -419,25 +418,23 @@ void Manager::loadErrorCounts()
         try
         {
             nlohmann::json data = nlohmann::json::parse(file);
-            for (size_t i = 0; i < maxErrorIndex; ++i)
+            for (size_t s = 0; s < maxSockets; ++s)
             {
-                p0CorrectableCPUErrors[i] =
-                    data["p0CorrectableCPUErrors"][i].get<uint64_t>();
-                p0NoncorrectableCPUErrors[i] =
-                    data["p0NoncorrectableCPUErrors"][i].get<uint64_t>();
-                p1CorrectableCPUErrors[i] =
-                    data["p1CorrectableCPUErrors"][i].get<uint64_t>();
-                p1NoncorrectableCPUErrors[i] =
-                    data["p1NoncorrectableCPUErrors"][i].get<uint64_t>();
+                std::string prefix = "p" + std::to_string(s);
+                for (size_t i = 0; i < maxErrorIndex; ++i)
+                {
+                    correctableCPUErrors[s][i] =
+                        data[prefix + "CorrectableCPUErrors"][i]
+                            .get<uint64_t>();
+                    noncorrectableCPUErrors[s][i] =
+                        data[prefix + "NoncorrectableCPUErrors"][i]
+                            .get<uint64_t>();
+                }
+                correctableOtherErrors[s] =
+                    data[prefix + "CorrectableOtherErrors"].get<uint64_t>();
+                noncorrectableOtherErrors[s] =
+                    data[prefix + "NoncorrectableOtherErrors"].get<uint64_t>();
             }
-            p0CorrectableOtherErrors =
-                data["p0CorrectableOtherErrors"].get<uint64_t>();
-            p0NoncorrectableOtherErrors =
-                data["p0NoncorrectableOtherErrors"].get<uint64_t>();
-            p1CorrectableOtherErrors =
-                data["p1CorrectableOtherErrors"].get<uint64_t>();
-            p1NoncorrectableOtherErrors =
-                data["p1NoncorrectableOtherErrors"].get<uint64_t>();
             lg2::info("Error counts loaded from {FILE}", "FILE",
                       errorCountFile);
             updateErrorCountDbus();
@@ -463,14 +460,15 @@ void Manager::saveErrorCounts()
         std::filesystem::path(errorCountFile).parent_path());
 
     nlohmann::json data;
-    data["p0CorrectableCPUErrors"] = p0CorrectableCPUErrors;
-    data["p0NoncorrectableCPUErrors"] = p0NoncorrectableCPUErrors;
-    data["p0CorrectableOtherErrors"] = p0CorrectableOtherErrors;
-    data["p0NoncorrectableOtherErrors"] = p0NoncorrectableOtherErrors;
-    data["p1CorrectableCPUErrors"] = p1CorrectableCPUErrors;
-    data["p1NoncorrectableCPUErrors"] = p1NoncorrectableCPUErrors;
-    data["p1CorrectableOtherErrors"] = p1CorrectableOtherErrors;
-    data["p1NoncorrectableOtherErrors"] = p1NoncorrectableOtherErrors;
+    for (size_t s = 0; s < maxSockets; ++s)
+    {
+        std::string prefix = "p" + std::to_string(s);
+        data[prefix + "CorrectableCPUErrors"] = correctableCPUErrors[s];
+        data[prefix + "NoncorrectableCPUErrors"] = noncorrectableCPUErrors[s];
+        data[prefix + "CorrectableOtherErrors"] = correctableOtherErrors[s];
+        data[prefix + "NoncorrectableOtherErrors"] =
+            noncorrectableOtherErrors[s];
+    }
 
     std::string tmpFile = errorCountFile + ".tmp";
     std::ofstream file(tmpFile);
@@ -504,30 +502,22 @@ void Manager::updateErrorCountDbus()
         return;
     }
 
-    errorCountIface->set_property(
-        "P0CorrectableCPUErrors",
-        std::vector<uint64_t>(p0CorrectableCPUErrors.begin(),
-                              p0CorrectableCPUErrors.end()));
-    errorCountIface->set_property(
-        "P0NoncorrectableCPUErrors",
-        std::vector<uint64_t>(p0NoncorrectableCPUErrors.begin(),
-                              p0NoncorrectableCPUErrors.end()));
-    errorCountIface->set_property("P0CorrectableOtherErrors",
-                                  p0CorrectableOtherErrors);
-    errorCountIface->set_property("P0NoncorrectableOtherErrors",
-                                  p0NoncorrectableOtherErrors);
-    errorCountIface->set_property(
-        "P1CorrectableCPUErrors",
-        std::vector<uint64_t>(p1CorrectableCPUErrors.begin(),
-                              p1CorrectableCPUErrors.end()));
-    errorCountIface->set_property(
-        "P1NoncorrectableCPUErrors",
-        std::vector<uint64_t>(p1NoncorrectableCPUErrors.begin(),
-                              p1NoncorrectableCPUErrors.end()));
-    errorCountIface->set_property("P1CorrectableOtherErrors",
-                                  p1CorrectableOtherErrors);
-    errorCountIface->set_property("P1NoncorrectableOtherErrors",
-                                  p1NoncorrectableOtherErrors);
+    for (size_t s = 0; s < maxSockets; ++s)
+    {
+        std::string prefix = "P" + std::to_string(s);
+        errorCountIface->set_property(
+            prefix + "CorrectableCPUErrors",
+            std::vector<uint64_t>(correctableCPUErrors[s].begin(),
+                                  correctableCPUErrors[s].end()));
+        errorCountIface->set_property(
+            prefix + "NoncorrectableCPUErrors",
+            std::vector<uint64_t>(noncorrectableCPUErrors[s].begin(),
+                                  noncorrectableCPUErrors[s].end()));
+        errorCountIface->set_property(prefix + "CorrectableOtherErrors",
+                                      correctableOtherErrors[s]);
+        errorCountIface->set_property(prefix + "NoncorrectableOtherErrors",
+                                      noncorrectableOtherErrors[s]);
+    }
 }
 
 Manager::Manager(sdbusplus::asio::object_server& objectServer,
@@ -543,29 +533,23 @@ Manager::Manager(sdbusplus::asio::object_server& objectServer,
     errorCountIface =
         objServer.add_interface(errorCountPath, errorCountInterface);
 
-    std::vector<uint64_t> p0CorCPU(p0CorrectableCPUErrors.begin(),
-                                   p0CorrectableCPUErrors.end());
-    std::vector<uint64_t> p0NoncorCPU(p0NoncorrectableCPUErrors.begin(),
-                                      p0NoncorrectableCPUErrors.end());
-    std::vector<uint64_t> p1CorCPU(p1CorrectableCPUErrors.begin(),
-                                   p1CorrectableCPUErrors.end());
-    std::vector<uint64_t> p1NoncorCPU(p1NoncorrectableCPUErrors.begin(),
-                                      p1NoncorrectableCPUErrors.end());
+    for (size_t s = 0; s < maxSockets; ++s)
+    {
+        std::string prefix = "P" + std::to_string(s);
+        std::vector<uint64_t> corCPU(correctableCPUErrors[s].begin(),
+                                     correctableCPUErrors[s].end());
+        std::vector<uint64_t> noncorCPU(noncorrectableCPUErrors[s].begin(),
+                                        noncorrectableCPUErrors[s].end());
 
-    errorCountIface->register_property("P0CorrectableCPUErrors", p0CorCPU);
-    errorCountIface->register_property("P0NoncorrectableCPUErrors",
-                                       p0NoncorCPU);
-    errorCountIface->register_property("P0CorrectableOtherErrors",
-                                       p0CorrectableOtherErrors);
-    errorCountIface->register_property("P0NoncorrectableOtherErrors",
-                                       p0NoncorrectableOtherErrors);
-    errorCountIface->register_property("P1CorrectableCPUErrors", p1CorCPU);
-    errorCountIface->register_property("P1NoncorrectableCPUErrors",
-                                       p1NoncorCPU);
-    errorCountIface->register_property("P1CorrectableOtherErrors",
-                                       p1CorrectableOtherErrors);
-    errorCountIface->register_property("P1NoncorrectableOtherErrors",
-                                       p1NoncorrectableOtherErrors);
+        errorCountIface->register_property(prefix + "CorrectableCPUErrors",
+                                           corCPU);
+        errorCountIface->register_property(prefix + "NoncorrectableCPUErrors",
+                                           noncorCPU);
+        errorCountIface->register_property(prefix + "CorrectableOtherErrors",
+                                           correctableOtherErrors[s]);
+        errorCountIface->register_property(prefix + "NoncorrectableOtherErrors",
+                                           noncorrectableOtherErrors[s]);
+    }
 
     errorCountIface->initialize();
 }

--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -8,6 +8,7 @@
 #include <phosphor-logging/lg2.hpp>
 #include <phosphor-logging/log.hpp>
 
+#include <array>
 #include <filesystem>
 #include <regex>
 
@@ -152,7 +153,7 @@ template void createFile(const std::shared_ptr<CoreDebugDumpCperRecord>&,
 std::string findCperFilename(size_t number, const std::string& node)
 {
     std::regex pattern;
-    if (node == "1" || node == "2")
+    if (node != "0")
     {
         pattern = std::regex(
             ".*" + node + ".*error" + std::to_string(number) + "\\.cper");
@@ -259,7 +260,7 @@ void createRecord(sdbusplus::asio::object_server& objectServer,
 
     if (std::filesystem::exists(std::filesystem::path(RAS_DIR)))
     {
-        if (node == "1" || node == "2")
+        if (node != "0")
         {
             pattern =
                 std::regex("node" + node + ".*ras-error([[:digit:]]+).cper");
@@ -395,25 +396,27 @@ std::string getCperFilename(size_t num)
 }
 
 bool checkSignatureIdMatch(std::map<std::string, std::string>* configSigIdList,
-                           const std::shared_ptr<FatalCperRecord>& rcd)
+                           const std::shared_ptr<FatalCperRecord>& rcd,
+                           size_t cpuCount)
 {
     bool ret = false;
     size_t socNum = 0;
-    uint32_t tempVar[2][8];
+    std::vector<std::array<uint32_t, 8>> tempVar(cpuCount);
 
-    for (socNum = 0; socNum < socket2; socNum++)
+    for (socNum = 0; socNum < cpuCount; socNum++)
     {
-        std::memcpy(tempVar[socNum], rcd->ErrorRecord[socNum].SignatureID,
+        std::memcpy(tempVar[socNum].data(),
+                    rcd->ErrorRecord[socNum].SignatureID,
                     sizeof(tempVar[socNum]));
     }
 
-    for (socNum = 0; socNum < socket2; socNum++)
+    for (socNum = 0; socNum < cpuCount; socNum++)
     {
         bool equal = false;
         for (const auto& pair : *configSigIdList)
         {
-            bool equal =
-                amd::ras::util::compareBitwiseAnd(tempVar[socNum], pair.second);
+            bool equal = amd::ras::util::compareBitwiseAnd(
+                tempVar[socNum].data(), pair.second);
 
             if (equal == true)
             {
@@ -773,7 +776,7 @@ void createFile(const std::shared_ptr<PtrType>& data,
         cperFileName = "core-debug-dump-" + cperFileName;
     }
 
-    if (node == "1" || node == "2")
+    if (node != "0")
     {
         cperFileName = "node" + node + "-" + cperFileName;
     }

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -206,10 +206,10 @@ void triggerWarmReset(std::string& node)
     oob_status_t ret;
     uint32_t ackResp = 0;
     uint8_t socNum = 0;
-    /* In a 2P config, it is recommended to only send this command to P0
+    /* In a multi-host config, it is recommended to only send this command to P0
     Hence, sending the Signal only to socket 0*/
 
-    if (node == "1" || node == "2")
+    if (node != "0")
     {
         socNum = std::stoul(node) - 1;
     }


### PR DESCRIPTION
- Expand socket constants and error-count storage from fixed P0/P1 fields to indexed arrays (maxSockets=4)
- Refactor APML runtime error collection to iterate over per-socket instance vectors instead of hardcoded p0/p1 paths
- Update CPER signature matching to use cpuCount dynamically
- Normalize node-specific file handling by treating any non-zero node as host-specific
- Keep D-Bus error-count properties and JSON persistence in sync for P0..P3