### PR TITLE
amd-ras: Socket0 FruTxt overwriting with Socket1

### DIFF
--- a/include/base_manager.hpp
+++ b/include/base_manager.hpp
@@ -92,6 +92,7 @@ class Manager
     std::vector<size_t> whModels;
     std::vector<uint8_t> blockId;
     std::mutex harvestMutex;
+    bool fatalDescriptorsInitialized = false;
 
     /** @brief Get the CPU socket information.
      *

--- a/src/base_manager.cpp
+++ b/src/base_manager.cpp
@@ -276,6 +276,7 @@ void Manager::handleFchError(uint8_t socNum)
 
 void Manager::cleanupFatalCperRecord()
 {
+    fatalDescriptorsInitialized = false;
     if (rcd != nullptr)
     {
         if (rcd->SectionDescriptor != nullptr)
@@ -310,10 +311,14 @@ void Manager::initFatalCperRecord(uint16_t sectionCount)
                     sectionCount * sizeof(EFI_AMD_FATAL_ERROR_DATA));
     }
 
-    amd::ras::util::cper::dumpHeader(rcd, sectionCount, errorSeverity, fatalErr,
-                                     boardId, recordId);
-    amd::ras::util::cper::dumpErrorDescriptor(rcd, sectionCount, fatalErr,
-                                              &errorSeverity, progId);
+    if (!fatalDescriptorsInitialized)
+    {
+        amd::ras::util::cper::dumpHeader(rcd, sectionCount, errorSeverity,
+                                         fatalErr, boardId, recordId);
+        amd::ras::util::cper::dumpErrorDescriptor(rcd, sectionCount, fatalErr,
+                                                  &errorSeverity, progId);
+        fatalDescriptorsInitialized = true;
+    }
 }
 
 void Manager::processMcaBankSignatures(uint8_t socNum, uint16_t numBanks)

--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -608,8 +608,10 @@ void dumpErrorDescriptor(const std::shared_ptr<PtrType>& data,
 
             data->SectionDescriptor[i].Severity = singleBit; // 1 = Fatal
 
+            std::memset(data->SectionDescriptor[i].FruString, 0, 20);
             data->SectionDescriptor[i].FruString[0] = 'P';
             data->SectionDescriptor[i].FruString[1] = '0' + i;
+            data->SectionDescriptor[i].FruString[2] = '\0';
         }
         else if ((errorType == runtimeMcaErr) || (errorType == runtimeDramErr))
         {


### PR DESCRIPTION
Socket0 FruTxt is getting overwritten by FruTxt of Socket1 due to improper temination of the FruTxt String. This change initialises the string with empty characters and terminates gracefully with '\0'.

Tested: Tested on Nigeria.
Hexdump clearly shows Perr:CPU0 when MCA Frutxt is True in CBS. When MCA FruTxt is disbaled, it shows P0.

root@nigeria-2593:/var/lib/amd-bmc-ras# hexdump -C ras-error3.cper 
00000000  43 50 45 52 00 01 ff ff  ff ff 02 00 01 00 00 00  |CPER............| 00000010  03 00 00 00 10 01 02 00  1d 30 11 01 0b 03 19 15  |.........0......| 00000020  40 84 27 6e 00 00 00 00  00 00 00 00 00 00 00 00  |@.'n............| 00000030  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................| 00000040  ac 3f fa 61 80 cb 92 42  8b fb d6 43 b1 de 17 f4  |.?.a...B...C....| 00000050  fe 6f f5 e8 9c 91 c5 4c  ba 88 65 ab e1 49 13 bb  |.o.....L..e..I..| 00000060  01 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................| 00000070  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................| 00000080  10 01 00 00 00 00 01 00  0c 31 03 00 01 00 00 00  |.........1......| 00000090  78 0c ac 32 23 26 f6 48  b0 d0 73 65 72 5f d6 ae  |x..2#&.H..ser_..| 000000a0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................| 000000b0  01 00 00 00 50 65 72 72  3a 20 43 50 55 30 20 00  |....**Perr: CPU0** .| 000000c0  00 00 00 00 00 00 00 00  10 01 01 00 00 00 01 00  |................|