### PR TITLE
add informational severity handling for runtime records

### DIFF
--- a/include/utils/cper.hpp
+++ b/include/utils/cper.hpp
@@ -19,6 +19,7 @@ namespace cper
 
 constexpr uint8_t sevNonFatalUncorrected = 0;
 constexpr uint8_t sevNonFatalCorrected = 2;
+constexpr uint8_t sevInformational = 3;
 
 constexpr uint8_t cperValidPlatformId = 0x1;
 constexpr uint8_t cperValidTimestamp = 0x2;
@@ -228,7 +229,8 @@ bool checkSignatureIdMatch(std::map<std::string, std::string>*,
  *
  *  @details Evaluates the severity levels of different sections and returns the
  * highest severity. The severity order is: Fatal > non-fatal uncorrected >
- * corrected. Logs an error if a fatal severity is found in a runtime CPER.
+ * corrected > informational. Logs an error if a fatal severity is found in a
+ * non-PCIe runtime CPER.
  *
  *  @param[in] severity - Pointer to an array of severity values.
  *  @param[in] sectionCount - The number of sections to evaluate.

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -1581,8 +1581,7 @@ void Manager::harvestX86ExceptionData(uint8_t socNum)
     std::memset(coreDebugDumpPtr->DebugDumpSection, 0,
                 sectionCount * sizeof(CoreDebugDumpSection));
 
-    /* Informational severity = 3 */
-    uint32_t errorSeverity = 3;
+    uint32_t errorSeverity = amd::ras::util::cper::sevInformational;
     amd::ras::util::cper::dumpHeader(coreDebugDumpPtr, sectionCount,
                                      errorSeverity, coreDebugDumpErr, boardId,
                                      recordId);
@@ -1590,7 +1589,7 @@ void Manager::harvestX86ExceptionData(uint8_t socNum)
     uint32_t* severity = new uint32_t[sectionCount];
     for (uint16_t i = 0; i < sectionCount; i++)
     {
-        severity[i] = 3; // Informational
+        severity[i] = amd::ras::util::cper::sevInformational;
     }
     amd::ras::util::cper::dumpErrorDescriptor(
         coreDebugDumpPtr, sectionCount, coreDebugDumpErr, severity, progId);

--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -432,14 +432,15 @@ bool checkSignatureIdMatch(std::map<std::string, std::string>* configSigIdList,
 }
 
 /*The function returns the highest severity out of all Section Severity for CPER
-  header Severity Order = Fatal > non-fatal uncorrected > corrected*/
+    header Severity Order = Fatal > non-fatal uncorrected > corrected >
+    informational*/
 bool calculateSeverity(uint32_t* severity, uint16_t sectionCount,
                        uint32_t* highestSeverity,
                        const std::string_view& errorType)
 {
     bool rc = true;
 
-    *highestSeverity = sevNonFatalCorrected;
+    *highestSeverity = sevInformational;
 
     for (size_t i = 0; i < sectionCount; i++)
     {
@@ -461,6 +462,10 @@ bool calculateSeverity(uint32_t* severity, uint16_t sectionCount,
         {
             *highestSeverity = sevNonFatalUncorrected;
             break;
+        }
+        else if (severity[i] == sevNonFatalCorrected)
+        {
+            *highestSeverity = sevNonFatalCorrected;
         }
     }
     return rc;
@@ -511,7 +516,8 @@ void dumpHeader(const std::shared_ptr<PtrType>& data, uint16_t sectionCount,
     /*Number of valid sections associated with the record*/
     data->Header.SectionCount = sectionCount;
 
-    /*0 - Non-fatal uncorrected ; 1 - Fatal ; 2 - Corrected*/
+    /*0 - Non-fatal uncorrected ; 1 - Fatal ; 2 - Corrected ;
+        3 - Informational*/
     data->Header.ErrorSeverity = errorSeverity;
 
     /*Bit 0 = 1 -> PlatformID field contains valid info
@@ -673,8 +679,7 @@ void dumpErrorDescriptor(const std::shared_ptr<PtrType>& data,
             memcpy(&data->SectionDescriptor[i].SectionType,
                    &gEfiCoreDebugDumpSectionGuid, sizeof(EFI_GUID));
 
-            /* Informational severity = 3 */
-            data->SectionDescriptor[i].Severity = 3;
+            data->SectionDescriptor[i].Severity = sevInformational;
 
             std::strncpy(data->SectionDescriptor[i].FruString, "CoreDebugDump",
                          nineteen);


### PR DESCRIPTION
Introduce `sevInformational` in CPER utilities and replace hardcoded severity value `3` with the named constant.

Also update runtime severity evaluation so informational sections are handled explicitly:
- initialize highest severity to informational in `calculateSeverity()`
- promote to corrected/uncorrected/fatal as needed
- classify PCIe runtime errors as informational when no fatal/nonfatal/ corrected root-error bits are set