### PR TITLE
Revert "Update PCIe error severity from Root Error Status"

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -95,10 +95,6 @@ constexpr size_t blockId25 = 25;
 constexpr uint16_t coreMcaHardwareId = 0xb0;
 constexpr size_t coresPerCcd = 32;
 constexpr size_t maxCoreIndex = 256;
-constexpr uint32_t rootErrStatusOffset = 52;
-constexpr uint32_t fatalErrMsgRcvd = (1 << 6);
-constexpr uint32_t nonfatalErrMsgRcvd = (1 << 5);
-constexpr uint32_t errCorrRcvd = (1 << 0);
 
 void writeOobRegister(uint8_t info, uint32_t reg, uint32_t value)
 {
@@ -3380,7 +3376,7 @@ void Manager::dumpProcErrorSection(
                     dumpIndex++;
                 }
 
-                if (dataIn.offset == rootErrStatusOffset)
+                if (dataIn.offset == 0)
                 {
                     rootErrStatus = dataOut;
                     continue;
@@ -3446,18 +3442,7 @@ void Manager::dumpProcErrorSection(
         }
         else if (category == 2) // PCIE error
         {
-            if (rootErrStatus & fatalErrMsgRcvd)
-            {
-                Severity[section] = 1; // Fatal
-            }
-            else if (rootErrStatus & nonfatalErrMsgRcvd)
-            {
-                Severity[section] = 0; // Non-fatal uncorrected
-            }
-            else if (rootErrStatus & errCorrRcvd)
-            {
-                Severity[section] = 2; // Corrected
-            }
+            Severity[section] = rootErrStatus & 0xFF;
         }
         n++;
         section++;


### PR DESCRIPTION
This reverts commit 517f9b7dc2cbba2817b15d27c16d16f282745950.

Reverting this commit as PMFW and CPER analyser tool changes are not implemented yet.