### PR TITLE
Fix runtime MCA error counting to handle multi-socket layout

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -856,15 +856,19 @@ void Manager::harvestRuntimeErrors(
                                            objectServer, systemBus, node);
         amd::ras::util::cper::updateIndexFile(errCount, node);
 
-        // Per-core CPU error counting for runtime MCA errors
-        if (p0Inst.number_of_inst != 0)
+        // Per-socket CPU error counting for runtime MCA errors.
+        // Sections were packed in socket order, so walk the same layout here.
+        uint16_t socketSectionStart = 0;
+        for (size_t idx = 0; idx < instVec.size(); ++idx)
         {
-            countRuntimeMcaErrors(socIndex[0], 0, p0Inst.number_of_inst);
-        }
-        if (p1Inst.number_of_inst != 0)
-        {
-            uint16_t p1Start = sectionCount - p1Inst.number_of_inst;
-            countRuntimeMcaErrors(socIndex[1], p1Start, sectionCount);
+            if (instVec[idx].number_of_inst != 0)
+            {
+                uint16_t socketSectionEnd =
+                    socketSectionStart + instVec[idx].number_of_inst;
+                countRuntimeMcaErrors(socIndex[idx], socketSectionStart,
+                                      socketSectionEnd);
+                socketSectionStart = socketSectionEnd;
+            }
         }
 
         thresholdCount = configMgr.getThresholdCount("McaErrThresholdEnable",


### PR DESCRIPTION
Fix runtime MCA error counting logic by refactoring the handling to iterate per socket using instVec instead of hardcoded p0/p1 ranges.

The previous implementation assumed a fixed two-socket layout and used explicit p0/p1 section boundaries. During a recent merge, the correct per-socket handling logic was missed, resulting in invalid section indexing and build failure.

Update the implementation to:
- Iterate over instVec entries
- Dynamically track section offsets using socketSectionStart
- Compute per-socket section ranges based on instance counts
- Invoke countRuntimeMcaErrors() for each valid socket