### PR TITLE
 Reapply OOB RAS config after a system reboot

### DIFF
--- a/config/ras_config.json
+++ b/config/ras_config.json
@@ -139,7 +139,7 @@
         {
             "PcieAerThresholdEn": {
                 "Description": "If this field is true, error thresholding for PCIE AER errors will be enabled",
-                "Value": false
+                "Value": true
             }
         },
         {
@@ -152,6 +152,48 @@
             "PcieAerErrThresholdCnt": {
                 "Description": "Error threshold count for PCIE AER errors",
                 "Value": 1
+            }
+        },
+        {
+            "PostCompleteMonitorEn": {
+                "Description": "Enable post-complete monitoring for reapplying RAS configuration",
+                "Value": true
+            }
+        },
+        {
+            "PostCompleteMonitorI2CBus": {
+                "Description": "I2C bus used to read the post-complete status register",
+                "Value": 6
+            }
+        },
+        {
+            "PostCompleteMonitorDeviceAddress": {
+                "Description": "CPLD I2C device address for the post-complete status register",
+                "Value": 32
+            }
+        },
+        {
+            "PostCompleteMonitorRegister": {
+                "Description": "CPLD register offset that carries the post-complete bit",
+                "Value": 70
+            }
+        },
+        {
+            "PostCompleteMonitorBit": {
+                "Description": "Bit position of the post-complete signal within the register",
+                "Value": 0
+            }
+        },
+        {
+            "PostCompleteMonitorActiveLow": {
+                "Description": "Whether the monitored bit is active-low",
+                "Value": true
+            }
+        },
+        {
+            "PostCompleteMonitorPollPeriodSec": {
+                "Description": "Polling interval in seconds for the post-complete monitor",
+                "Value": 2
             }
         }
     ]

--- a/config/ras_config.json
+++ b/config/ras_config.json
@@ -69,6 +69,19 @@
             }
         },
         {
+            "FatalHarvestDelayEn": {
+                "Description": "If true, BMC proactively overrides the CPU DelayResetOnSyncflood timer during initialization so the system waits before resetting after a fatal error, giving time to collect MCA data. Requires BIOS Delay Reset After Syncflood to be enabled (any non-zero value).",
+                "Value": true
+            }
+        },
+        {
+            "FatalHarvestDelayMins": {
+                "Description": "Delay value (5-120 mins) sent to the CPU during RAS initialization to override the BIOS-configured Delay Reset After Syncflood value.",
+                "Value": 5,
+                "MaxBoundLimit": 120
+            }
+        },
+        {
             "DramCeccPollingEn": {
                 "Description": "If this field is true, Dynamic Random Access Memory Error Correction Code (DRAM ECC) correctable errors will be polled",
                 "Value": false

--- a/config/ras_config.json
+++ b/config/ras_config.json
@@ -168,45 +168,15 @@
             }
         },
         {
-            "PostCompleteMonitorEn": {
-                "Description": "Enable post-complete monitoring for reapplying RAS configuration",
+            "PostCompleteGpioEn": {
+                "Description": "Enable POST complete GPIO monitoring to reapply RAS config after reboot or reset",
                 "Value": true
             }
         },
         {
-            "PostCompleteMonitorI2CBus": {
-                "Description": "I2C bus used to read the post-complete status register",
-                "Value": 6
-            }
-        },
-        {
-            "PostCompleteMonitorDeviceAddress": {
-                "Description": "CPLD I2C device address for the post-complete status register",
-                "Value": 32
-            }
-        },
-        {
-            "PostCompleteMonitorRegister": {
-                "Description": "CPLD register offset that carries the post-complete bit",
-                "Value": 70
-            }
-        },
-        {
-            "PostCompleteMonitorBit": {
-                "Description": "Bit position of the post-complete signal within the register",
-                "Value": 0
-            }
-        },
-        {
-            "PostCompleteMonitorActiveLow": {
-                "Description": "Whether the monitored bit is active-low",
-                "Value": true
-            }
-        },
-        {
-            "PostCompleteMonitorPollPeriodSec": {
-                "Description": "Polling interval in seconds for the post-complete monitor",
-                "Value": 2
+            "PostCompleteGpioLine": {
+                "Description": "GPIO line name for BIOS POST complete signal (active-low _N suffix). Run gpiofind to confirm the name on your platform.",
+                "Value": "FM_BIOS_POST_CMPLT_R_N"
             }
         }
     ]

--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -17,6 +17,18 @@ namespace ras
 {
 namespace apml
 {
+struct PostCompleteMonitorConfig
+{
+  bool enabled{false};
+  std::string name;
+  int64_t i2cBus{0};
+  int64_t i2cAddress{0};
+  int64_t registerOffset{0};
+  uint8_t bit{0};
+  bool activeLow{true};
+  int64_t pollPeriodSec{2};
+};
+
 /** @brief Manages RAS (Reliability, Availability, and Serviceability)
  * operations for APML.
  *
@@ -75,10 +87,14 @@ class Manager : public amd::ras::Manager
     bool apmlInitialized;
     bool platformInitialized;
     bool runtimeErrPollingSupported;
+    bool postCompleteStateInitialized;
+    bool postCompleteLastState;
     std::vector<bool> cpuAlertProcessed;
     boost::asio::steady_timer* McaErrorPollingEvent;
     boost::asio::steady_timer* DramCeccErrorPollingEvent;
     boost::asio::steady_timer* PcieAerErrorPollingEvent;
+    boost::asio::steady_timer* PostCompletePollingEvent;
+    PostCompleteMonitorConfig postCompleteMonitorConfig;
     std::mutex harvestMutex;
     std::mutex mcaErrorHarvestMtx;
     std::mutex dramErrorHarvestMtx;
@@ -203,6 +219,18 @@ class Manager : public amd::ras::Manager
      *  @param[in] socNum - Socket number of the processor.
      */
     void clearSbrmiAlertMask(uint8_t socNum);
+
+    /** @brief Load the CPLD post-complete monitor mapping from JSON.
+     */
+    void loadPostCompleteMonitorConfig();
+
+    /** @brief Poll the configured post-complete register and reapply RAS config.
+     */
+    void postCompleteMonitorHandler();
+
+    /** @brief Read the configured post-complete state from CPLD/I2C.
+     */
+    bool readPostCompleteMonitorState(bool* postCompleteState);
 
     /** @brief Monitors the current host power state.
      *

--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -18,17 +18,6 @@ namespace ras
 {
 namespace apml
 {
-struct PostCompleteMonitorConfig
-{
-  bool enabled{false};
-  std::string name;
-  int64_t i2cBus{0};
-  int64_t i2cAddress{0};
-  int64_t registerOffset{0};
-  uint8_t bit{0};
-  bool activeLow{true};
-  int64_t pollPeriodSec{2};
-};
 
 /** @brief Manages RAS (Reliability, Availability, and Serviceability)
  * operations for APML.
@@ -88,14 +77,13 @@ class Manager : public amd::ras::Manager
     bool apmlInitialized;
     bool platformInitialized;
     bool runtimeErrPollingSupported;
-    bool postCompleteStateInitialized;
-    bool postCompleteLastState;
+    bool postCompleteLineHigh;
     std::vector<bool> cpuAlertProcessed;
     boost::asio::steady_timer* McaErrorPollingEvent;
     boost::asio::steady_timer* DramCeccErrorPollingEvent;
     boost::asio::steady_timer* PcieAerErrorPollingEvent;
-    boost::asio::steady_timer* PostCompletePollingEvent;
-    PostCompleteMonitorConfig postCompleteMonitorConfig;
+    gpiod::line postCompleteGpioLine;
+    boost::asio::posix::stream_descriptor* postCompleteEventDescriptor;
     std::mutex harvestMutex;
     std::mutex mcaErrorHarvestMtx;
     std::mutex dramErrorHarvestMtx;
@@ -222,23 +210,18 @@ class Manager : public amd::ras::Manager
      */
     void clearSbrmiAlertMask(uint8_t socNum);
 
-    /** @brief Load the CPLD post-complete monitor mapping from JSON.
+    /** @brief Set up GPIO-based POST complete monitor to reapply RAS config on reboot.
      */
-    void loadPostCompleteMonitorConfig();
+    void setupPostCompleteMonitor();
 
-    /** @brief Poll the configured post-complete register and reapply RAS config.
+    /** @brief Handle POST complete GPIO edge events.
      */
-    void postCompleteMonitorHandler();
-
-    /** @brief Read the configured post-complete state from CPLD/I2C.
-     */
-    bool readPostCompleteMonitorState(bool* postCompleteState);
+    void postCompleteEventHandler(boost::asio::posix::stream_descriptor&,
+                                  const gpiod::line&);
 
     /** @brief Proactively set the fatal harvest delay override in the CPU.
      *
-     *  @details Arms the CPU's DelayResetOnSyncflood counter with the configured
-     *  value so the system waits before resetting after a fatal error, giving the
-     *  BMC time to collect MCA data
+     *  @details Called during initialization and on every RAS config reapply.
      */
     void setFatalHarvestDelay();
 

--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -10,6 +10,7 @@ extern "C"
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <gpiod.hpp>
+#include <sdbusplus/asio/connection.hpp>
 
 namespace amd
 {
@@ -100,6 +101,7 @@ class Manager : public amd::ras::Manager
     std::mutex dramErrorHarvestMtx;
     std::mutex pcieErrorHarvestMtx;
     std::vector<gpiod::line> gpioLines;
+    std::shared_ptr<sdbusplus::asio::connection> conn;
 
     /**
      * @brief Requests GPIO events for hardware alert handling.
@@ -231,6 +233,14 @@ class Manager : public amd::ras::Manager
     /** @brief Read the configured post-complete state from CPLD/I2C.
      */
     bool readPostCompleteMonitorState(bool* postCompleteState);
+
+    /** @brief Proactively set the fatal harvest delay override in the CPU.
+     *
+     *  @details Arms the CPU's DelayResetOnSyncflood counter with the configured
+     *  value so the system waits before resetting after a fatal error, giving the
+     *  BMC time to collect MCA data
+     */
+    void setFatalHarvestDelay();
 
     /** @brief Monitors the current host power state.
      *

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -179,7 +179,8 @@ Manager::Manager(amd::ras::config::Manager& manager,
     McaErrorPollingEvent(nullptr), DramCeccErrorPollingEvent(nullptr),
     PcieAerErrorPollingEvent(nullptr), PostCompletePollingEvent(nullptr),
     mcaErrorHarvestMtx(),
-    dramErrorHarvestMtx(), pcieErrorHarvestMtx()
+    dramErrorHarvestMtx(), pcieErrorHarvestMtx(),
+    conn(std::make_shared<sdbusplus::asio::connection>(io))
 {}
 
 void Manager::loadPostCompleteMonitorConfig()
@@ -323,10 +324,8 @@ void Manager::postCompleteMonitorHandler()
 
 void Manager::currentHostStateMonitor()
 {
-    static auto bus = sdbusplus::bus::new_default();
-
     static auto match = sdbusplus::bus::match_t(
-        bus,
+        *conn,
         "type='signal',member='PropertiesChanged', "
         "interface='org.freedesktop.DBus.Properties', "
         "arg0='xyz.openbmc_project.State.Host'",
@@ -652,10 +651,8 @@ void Manager::init()
         postCompleteMonitorHandler();
     }
 
-    static auto bus = sdbusplus::bus::new_default();
-
     static auto match = sdbusplus::bus::match_t(
-        bus,
+        *conn,
         "type='signal',member='PropertiesChanged', "
         "interface='org.freedesktop.DBus.Properties', "
         "arg0='xyz.openbmc_project.State.Watchdog'",

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -16,9 +16,6 @@ extern "C"
 #include <phosphor-logging/lg2.hpp>
 #include <phosphor-logging/log.hpp>
 
-#include <fcntl.h>
-#include <linux/i2c-dev.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 
 #include <stdexcept>
@@ -29,65 +26,6 @@ namespace ras
 {
 namespace apml
 {
-namespace
-{
-bool readCpldRegister(const PostCompleteMonitorConfig& cfg, uint8_t* value)
-{
-    if (value == nullptr)
-    {
-        return false;
-    }
-
-    const std::string devPath = "/dev/i2c-" + std::to_string(cfg.i2cBus);
-    int fd = open(devPath.c_str(), O_RDWR);
-    if (fd < 0)
-    {
-        lg2::error("Failed to open I2C device {DEV}: {ERR}", "DEV",
-                   devPath, "ERR", strerror(errno));
-        return false;
-    }
-
-    const auto closeFd = [&fd]() {
-        if (fd >= 0)
-        {
-            close(fd);
-            fd = -1;
-        }
-    };
-
-    if (ioctl(fd, I2C_SLAVE, static_cast<int>(cfg.i2cAddress)) < 0)
-    {
-        lg2::error("Failed to select I2C address {ADDR} on {DEV}: {ERR}",
-                   "ADDR", lg2::hex, static_cast<uint32_t>(cfg.i2cAddress),
-                   "DEV", devPath, "ERR", strerror(errno));
-        closeFd();
-        return false;
-    }
-
-    uint8_t reg = static_cast<uint8_t>(cfg.registerOffset);
-    if (write(fd, &reg, 1) != 1)
-    {
-        lg2::error("Failed to write CPLD register offset {REG} on {DEV}: {ERR}",
-                   "REG", lg2::hex, static_cast<uint32_t>(reg), "DEV",
-                   devPath, "ERR", strerror(errno));
-        closeFd();
-        return false;
-    }
-
-    if (read(fd, value, 1) != 1)
-    {
-        lg2::error("Failed to read CPLD register {REG} on {DEV}: {ERR}",
-                   "REG", lg2::hex, static_cast<uint32_t>(reg), "DEV",
-                   devPath, "ERR", strerror(errno));
-        closeFd();
-        return false;
-    }
-
-    closeFd();
-    return true;
-}
-} // namespace
-
 constexpr size_t sbrmiControlRegister = 0x1;
 constexpr size_t sysMgmtCtrlErr = 0x4;
 constexpr size_t shutdownError = 0x40;
@@ -175,150 +113,122 @@ Manager::Manager(amd::ras::config::Manager& manager,
     amd::ras::Manager(manager, node), progId(1), recordId(1),
     watchdogTimerCounter(0), io(io), apmlInitialized(false),
     platformInitialized(false), runtimeErrPollingSupported(false),
-    postCompleteStateInitialized(false), postCompleteLastState(false),
+    postCompleteLineHigh(false),
     McaErrorPollingEvent(nullptr), DramCeccErrorPollingEvent(nullptr),
-    PcieAerErrorPollingEvent(nullptr), PostCompletePollingEvent(nullptr),
+    PcieAerErrorPollingEvent(nullptr),
+    postCompleteEventDescriptor(nullptr),
     mcaErrorHarvestMtx(),
     dramErrorHarvestMtx(), pcieErrorHarvestMtx(),
     conn(std::make_shared<sdbusplus::asio::connection>(io))
 {}
 
-void Manager::loadPostCompleteMonitorConfig()
+void Manager::setupPostCompleteMonitor()
 {
-    postCompleteMonitorConfig = {};
-
     try
     {
-        auto monitorEnVal = configMgr.getAttribute("PostCompleteMonitorEn");
-        auto* monitorEn = std::get_if<bool>(&monitorEnVal);
-        if (monitorEn == nullptr || *monitorEn == false)
+        auto enVal = configMgr.getAttribute("PostCompleteGpioEn");
+        bool* en = std::get_if<bool>(&enVal);
+        if (en == nullptr || *en == false)
         {
             return;
         }
 
-        postCompleteMonitorConfig.enabled = true;
-
-        auto i2cBusVal = configMgr.getAttribute("PostCompleteMonitorI2CBus");
-        auto* i2cBus = std::get_if<int64_t>(&i2cBusVal);
-        auto deviceAddrVal =
-            configMgr.getAttribute("PostCompleteMonitorDeviceAddress");
-        auto* deviceAddr = std::get_if<int64_t>(&deviceAddrVal);
-        auto regVal = configMgr.getAttribute("PostCompleteMonitorRegister");
-        auto* reg = std::get_if<int64_t>(&regVal);
-        auto bitVal = configMgr.getAttribute("PostCompleteMonitorBit");
-        auto* bit = std::get_if<int64_t>(&bitVal);
-        auto activeLowVal =
-            configMgr.getAttribute("PostCompleteMonitorActiveLow");
-        auto* activeLow = std::get_if<bool>(&activeLowVal);
-        auto pollPeriodVal =
-            configMgr.getAttribute("PostCompleteMonitorPollPeriodSec");
-        auto* pollPeriod = std::get_if<int64_t>(&pollPeriodVal);
-
-        if (i2cBus == nullptr || deviceAddr == nullptr || reg == nullptr ||
-            bit == nullptr || activeLow == nullptr || pollPeriod == nullptr)
+        auto lineNameVal = configMgr.getAttribute("PostCompleteGpioLine");
+        std::string* lineName = std::get_if<std::string>(&lineNameVal);
+        if (lineName == nullptr || lineName->empty())
         {
-            lg2::error("Post-complete monitor config contains invalid values");
-            postCompleteMonitorConfig.enabled = false;
+            lg2::error("PostCompleteGpioLine config is missing or empty");
             return;
         }
 
-        postCompleteMonitorConfig.name = "ras_config";
-        postCompleteMonitorConfig.i2cBus = *i2cBus;
-        postCompleteMonitorConfig.i2cAddress = *deviceAddr;
-        postCompleteMonitorConfig.registerOffset = *reg;
-        postCompleteMonitorConfig.bit = static_cast<uint8_t>(*bit);
-        postCompleteMonitorConfig.activeLow = *activeLow;
-        postCompleteMonitorConfig.pollPeriodSec = *pollPeriod;
+        postCompleteGpioLine = gpiod::find_line(*lineName);
+        if (!postCompleteGpioLine)
+        {
+            lg2::error("Failed to find POST complete GPIO line: {LINE}",
+                       "LINE", *lineName);
+            return;
+        }
+
+        postCompleteGpioLine.request(
+            {"RAS-POST-COMPLETE", gpiod::line_request::EVENT_BOTH_EDGES, 0});
+
+        /* Seed the flag from current line level to handle BMC-boots-while-host-off:
+             HIGH (host off/resetting) → postCompleteLineHigh=true
+                                       → first falling edge after host boots is valid
+             LOW  (host already up)    → postCompleteLineHigh=false
+                                       → init() already applied config, wait for reboot */
+        postCompleteLineHigh = (postCompleteGpioLine.get_value() == 1);
 
         lg2::info(
-            "Loaded post-complete monitor config: bus={BUS} addr=0x{ADDR} reg=0x{REG} bit={BIT} activeLow={LOW}",
-            "BUS", static_cast<uint32_t>(postCompleteMonitorConfig.i2cBus),
-            "ADDR", lg2::hex,
-            static_cast<uint32_t>(postCompleteMonitorConfig.i2cAddress),
-            "REG", lg2::hex,
-            static_cast<uint32_t>(postCompleteMonitorConfig.registerOffset),
-            "BIT", static_cast<uint32_t>(postCompleteMonitorConfig.bit),
-            "LOW", postCompleteMonitorConfig.activeLow);
+            "POST complete GPIO monitor armed on line {LINE}, "
+            "initial state={VAL}",
+            "LINE", *lineName,
+            "VAL", postCompleteLineHigh ? "HIGH(host-off)" : "LOW(host-up)");
+
+        if (postCompleteEventDescriptor != nullptr)
+        {
+            delete postCompleteEventDescriptor;
+        }
+        postCompleteEventDescriptor =
+            new boost::asio::posix::stream_descriptor(io);
+        postCompleteEventDescriptor->assign(
+            postCompleteGpioLine.event_get_fd());
+
+        postCompleteEventDescriptor->async_wait(
+            boost::asio::posix::stream_descriptor::wait_read,
+            [this](const boost::system::error_code ec) {
+                if (ec)
+                {
+                    lg2::error("POST complete GPIO wait error: {ERR}",
+                               "ERR", ec.message());
+                    return;
+                }
+                postCompleteEventHandler(*postCompleteEventDescriptor,
+                                         postCompleteGpioLine);
+            });
     }
     catch (const std::exception& e)
     {
-        lg2::error("Failed to load post-complete monitor config: {ERR}",
+        lg2::error("Failed to setup POST complete GPIO monitor: {ERR}",
                    "ERR", e.what());
-        postCompleteMonitorConfig.enabled = false;
     }
 }
 
-bool Manager::readPostCompleteMonitorState(bool* postCompleteState)
+void Manager::postCompleteEventHandler(
+    boost::asio::posix::stream_descriptor& eventDesc,
+    const gpiod::line& line)
 {
-    if (postCompleteState == nullptr || !postCompleteMonitorConfig.enabled)
+    gpiod::line_event gpioEvent = line.event_read();
+
+    if (gpioEvent.event_type == gpiod::line_event::RISING_EDGE)
     {
-        return false;
+        postCompleteLineHigh = true;
+        lg2::debug(
+            "POST complete GPIO: rising edge — reboot/reset in progress");
+    }
+    else if (gpioEvent.event_type == gpiod::line_event::FALLING_EDGE)
+    {
+        if (postCompleteLineHigh)
+        {
+            lg2::info(
+                "POST complete GPIO: BIOS POST done after reboot/reset. "
+                "Reapplying RAS config.");
+            postCompleteLineHigh = false;
+            watchdogTimerCounter = 0;
+            platformInitialize();
+        }
     }
 
-    uint8_t rawValue = 0;
-    if (!readCpldRegister(postCompleteMonitorConfig, &rawValue))
-    {
-        return false;
-    }
-
-    bool bitSet = ((rawValue >> postCompleteMonitorConfig.bit) & 0x1) != 0;
-    *postCompleteState = postCompleteMonitorConfig.activeLow ? !bitSet : bitSet;
-
-    lg2::debug("Post-complete monitor {MAP}: raw=0x{RAW} logicalComplete={STATE}",
-               "MAP", postCompleteMonitorConfig.name,
-               "RAW", lg2::hex, static_cast<uint32_t>(rawValue),
-               "STATE", *postCompleteState);
-
-    return true;
-}
-
-void Manager::postCompleteMonitorHandler()
-{
-    if (PostCompletePollingEvent != nullptr)
-    {
-        delete PostCompletePollingEvent;
-    }
-
-    if (!postCompleteMonitorConfig.enabled)
-    {
-        return;
-    }
-
-    PostCompletePollingEvent = new boost::asio::steady_timer(
-        io, std::chrono::seconds(postCompleteMonitorConfig.pollPeriodSec));
-
-    PostCompletePollingEvent->async_wait(
-        [this](const boost::system::error_code ec) {
+    eventDesc.async_wait(
+        boost::asio::posix::stream_descriptor::wait_read,
+        [this, &eventDesc, &line](const boost::system::error_code ec) {
             if (ec)
             {
+                lg2::error("POST complete GPIO handler error: {ERR}",
+                           "ERR", ec.message());
                 return;
             }
-
-            bool postCompleteState = false;
-            if (readPostCompleteMonitorState(&postCompleteState))
-            {
-                if (postCompleteStateInitialized == false)
-                {
-                    postCompleteLastState = postCompleteState;
-                    postCompleteStateInitialized = true;
-                }
-                else if (postCompleteState == true &&
-                         postCompleteLastState == false)
-                {
-                    lg2::info(
-                        "Post-complete detected for mapping {MAP}. Reapplying RAS config.",
-                        "MAP", postCompleteMonitorConfig.name);
-                    watchdogTimerCounter = 0;
-                    platformInitialize();
-                    postCompleteLastState = postCompleteState;
-                }
-                else
-                {
-                    postCompleteLastState = postCompleteState;
-                }
-            }
-
-            postCompleteMonitorHandler();
+            postCompleteEventHandler(eventDesc, line);
         });
 }
 
@@ -642,14 +552,9 @@ void Manager::init()
 
     file.close();
 
-    loadPostCompleteMonitorConfig();
-
     platformInitialize();
 
-    if (postCompleteMonitorConfig.enabled)
-    {
-        postCompleteMonitorHandler();
-    }
+    setupPostCompleteMonitor();
 
     static auto match = sdbusplus::bus::match_t(
         *conn,
@@ -704,8 +609,7 @@ void Manager::init()
                     watchdogTimerCounter++;
 
                     /*Watchdog Timer Enable property will be changed twice after
-                      BIOS post complete. Platform initialization should be
-                      performed only during the second property change*/
+                      BIOS post complete.*/
                     if (watchdogTimerCounter == 2)
                     {
                         lg2::info(

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -2407,6 +2407,24 @@ oob_status_t Manager::setMcaOobConfig()
         oob_config.dram_cecc_leak_rate =
             static_cast<uint8_t>(*dramCeccLeakRate);
     }
+    else
+    {
+        amd::ras::config::Manager::AttributeValue dramCeccOobEcModeVal =
+            configMgr.getAttribute("DramCeccOobEcMode");
+        int64_t* dramCeccOobEcMode =
+            std::get_if<int64_t>(&dramCeccOobEcModeVal);
+
+        amd::ras::config::Manager::AttributeValue dramCeccLeakRateVal =
+            configMgr.getAttribute("DramCeccLeakRate");
+        int64_t* dramCeccLeakRate =
+            std::get_if<int64_t>(&dramCeccLeakRateVal);
+
+        oob_config.dram_cecc_oob_ec_mode =
+            static_cast<uint8_t>(*dramCeccOobEcMode);
+        oob_config.dram_cecc_leak_rate =
+            static_cast<uint8_t>(*dramCeccLeakRate);
+        oob_config.mca_oob_misc0_ec_enable = 1;
+    }
 
     ret = setRasOobConfig(oob_config);
 

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -464,6 +464,10 @@ void Manager::platformInitialize()
             lg2::info("Setting PCIe Error threshold");
 
             setPcieErrThreshold();
+
+            lg2::info("Setting fatal harvest delay override");
+
+            setFatalHarvestDelay();
         }
     }
 }
@@ -717,6 +721,9 @@ void Manager::init()
 
                         lg2::info("Setting PCIE Error threshold");
                         setPcieErrThreshold();
+
+                        lg2::info("Setting fatal harvest delay override");
+                        setFatalHarvestDelay();
                     }
                 }
             }
@@ -2339,6 +2346,10 @@ void Manager::runTimeErrorPolling()
     else
     {
         setPcieErrThreshold();
+
+        lg2::info("Setting fatal harvest delay override");
+
+        setFatalHarvestDelay();
     }
 }
 
@@ -2480,6 +2491,58 @@ oob_status_t Manager::setRasErrThreshold(struct run_time_threshold th)
         }
     }
     return ret;
+}
+
+void Manager::setFatalHarvestDelay()
+{
+    amd::ras::config::Manager::AttributeValue fatalDelayEnVal =
+        configMgr.getAttribute("FatalHarvestDelayEn");
+    bool* fatalHarvestDelayEn = std::get_if<bool>(&fatalDelayEnVal);
+
+    if (fatalHarvestDelayEn == nullptr || *fatalHarvestDelayEn == false)
+    {
+        return;
+    }
+
+    amd::ras::config::Manager::AttributeValue fatalDelayMinsVal =
+        configMgr.getAttribute("FatalHarvestDelayMins");
+    int64_t* fatalHarvestDelayMins = std::get_if<int64_t>(&fatalDelayMinsVal);
+
+    if (fatalHarvestDelayMins == nullptr)
+    {
+        return;
+    }
+
+    struct ras_override_delay delayDataIn = {0, 0, 0};
+    bool ackResp = false;
+
+    int64_t mins = *fatalHarvestDelayMins;
+    if (mins >= 5 && mins <= 120)
+    {
+        delayDataIn.delay_val_override = static_cast<uint8_t>(mins);
+    }
+    else
+    {
+        delayDataIn.delay_val_override = 5; // minimum safe fallback
+    }
+
+    oob_status_t ret = override_delay_reset_on_sync_flood(
+        socIndex[0], delayDataIn, &ackResp);
+
+    if (ret != OOB_SUCCESS)
+    {
+        lg2::error(
+            "Failed to set fatal harvest delay override ({MINS} mins): {ERR}",
+            "MINS", static_cast<uint32_t>(delayDataIn.delay_val_override),
+            "ERR", ret);
+    }
+    else
+    {
+        lg2::info(
+            "Fatal harvest delay override set to {MINS} mins. "
+            "CPU will wait before resetting after syncflood.",
+            "MINS", static_cast<uint32_t>(delayDataIn.delay_val_override));
+    }
 }
 
 oob_status_t Manager::setPcieErrThreshold()

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -16,6 +16,11 @@ extern "C"
 #include <phosphor-logging/lg2.hpp>
 #include <phosphor-logging/log.hpp>
 
+#include <fcntl.h>
+#include <linux/i2c-dev.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
 #include <stdexcept>
 
 namespace amd
@@ -24,6 +29,65 @@ namespace ras
 {
 namespace apml
 {
+namespace
+{
+bool readCpldRegister(const PostCompleteMonitorConfig& cfg, uint8_t* value)
+{
+    if (value == nullptr)
+    {
+        return false;
+    }
+
+    const std::string devPath = "/dev/i2c-" + std::to_string(cfg.i2cBus);
+    int fd = open(devPath.c_str(), O_RDWR);
+    if (fd < 0)
+    {
+        lg2::error("Failed to open I2C device {DEV}: {ERR}", "DEV",
+                   devPath, "ERR", strerror(errno));
+        return false;
+    }
+
+    const auto closeFd = [&fd]() {
+        if (fd >= 0)
+        {
+            close(fd);
+            fd = -1;
+        }
+    };
+
+    if (ioctl(fd, I2C_SLAVE, static_cast<int>(cfg.i2cAddress)) < 0)
+    {
+        lg2::error("Failed to select I2C address {ADDR} on {DEV}: {ERR}",
+                   "ADDR", lg2::hex, static_cast<uint32_t>(cfg.i2cAddress),
+                   "DEV", devPath, "ERR", strerror(errno));
+        closeFd();
+        return false;
+    }
+
+    uint8_t reg = static_cast<uint8_t>(cfg.registerOffset);
+    if (write(fd, &reg, 1) != 1)
+    {
+        lg2::error("Failed to write CPLD register offset {REG} on {DEV}: {ERR}",
+                   "REG", lg2::hex, static_cast<uint32_t>(reg), "DEV",
+                   devPath, "ERR", strerror(errno));
+        closeFd();
+        return false;
+    }
+
+    if (read(fd, value, 1) != 1)
+    {
+        lg2::error("Failed to read CPLD register {REG} on {DEV}: {ERR}",
+                   "REG", lg2::hex, static_cast<uint32_t>(reg), "DEV",
+                   devPath, "ERR", strerror(errno));
+        closeFd();
+        return false;
+    }
+
+    closeFd();
+    return true;
+}
+} // namespace
+
 constexpr size_t sbrmiControlRegister = 0x1;
 constexpr size_t sysMgmtCtrlErr = 0x4;
 constexpr size_t shutdownError = 0x40;
@@ -111,15 +175,155 @@ Manager::Manager(amd::ras::config::Manager& manager,
     amd::ras::Manager(manager, node), progId(1), recordId(1),
     watchdogTimerCounter(0), io(io), apmlInitialized(false),
     platformInitialized(false), runtimeErrPollingSupported(false),
+    postCompleteStateInitialized(false), postCompleteLastState(false),
     McaErrorPollingEvent(nullptr), DramCeccErrorPollingEvent(nullptr),
-    PcieAerErrorPollingEvent(nullptr), mcaErrorHarvestMtx(),
+    PcieAerErrorPollingEvent(nullptr), PostCompletePollingEvent(nullptr),
+    mcaErrorHarvestMtx(),
     dramErrorHarvestMtx(), pcieErrorHarvestMtx()
 {}
 
+void Manager::loadPostCompleteMonitorConfig()
+{
+    postCompleteMonitorConfig = {};
+
+    try
+    {
+        auto monitorEnVal = configMgr.getAttribute("PostCompleteMonitorEn");
+        auto* monitorEn = std::get_if<bool>(&monitorEnVal);
+        if (monitorEn == nullptr || *monitorEn == false)
+        {
+            return;
+        }
+
+        postCompleteMonitorConfig.enabled = true;
+
+        auto i2cBusVal = configMgr.getAttribute("PostCompleteMonitorI2CBus");
+        auto* i2cBus = std::get_if<int64_t>(&i2cBusVal);
+        auto deviceAddrVal =
+            configMgr.getAttribute("PostCompleteMonitorDeviceAddress");
+        auto* deviceAddr = std::get_if<int64_t>(&deviceAddrVal);
+        auto regVal = configMgr.getAttribute("PostCompleteMonitorRegister");
+        auto* reg = std::get_if<int64_t>(&regVal);
+        auto bitVal = configMgr.getAttribute("PostCompleteMonitorBit");
+        auto* bit = std::get_if<int64_t>(&bitVal);
+        auto activeLowVal =
+            configMgr.getAttribute("PostCompleteMonitorActiveLow");
+        auto* activeLow = std::get_if<bool>(&activeLowVal);
+        auto pollPeriodVal =
+            configMgr.getAttribute("PostCompleteMonitorPollPeriodSec");
+        auto* pollPeriod = std::get_if<int64_t>(&pollPeriodVal);
+
+        if (i2cBus == nullptr || deviceAddr == nullptr || reg == nullptr ||
+            bit == nullptr || activeLow == nullptr || pollPeriod == nullptr)
+        {
+            lg2::error("Post-complete monitor config contains invalid values");
+            postCompleteMonitorConfig.enabled = false;
+            return;
+        }
+
+        postCompleteMonitorConfig.name = "ras_config";
+        postCompleteMonitorConfig.i2cBus = *i2cBus;
+        postCompleteMonitorConfig.i2cAddress = *deviceAddr;
+        postCompleteMonitorConfig.registerOffset = *reg;
+        postCompleteMonitorConfig.bit = static_cast<uint8_t>(*bit);
+        postCompleteMonitorConfig.activeLow = *activeLow;
+        postCompleteMonitorConfig.pollPeriodSec = *pollPeriod;
+
+        lg2::info(
+            "Loaded post-complete monitor config: bus={BUS} addr=0x{ADDR} reg=0x{REG} bit={BIT} activeLow={LOW}",
+            "BUS", static_cast<uint32_t>(postCompleteMonitorConfig.i2cBus),
+            "ADDR", lg2::hex,
+            static_cast<uint32_t>(postCompleteMonitorConfig.i2cAddress),
+            "REG", lg2::hex,
+            static_cast<uint32_t>(postCompleteMonitorConfig.registerOffset),
+            "BIT", static_cast<uint32_t>(postCompleteMonitorConfig.bit),
+            "LOW", postCompleteMonitorConfig.activeLow);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed to load post-complete monitor config: {ERR}",
+                   "ERR", e.what());
+        postCompleteMonitorConfig.enabled = false;
+    }
+}
+
+bool Manager::readPostCompleteMonitorState(bool* postCompleteState)
+{
+    if (postCompleteState == nullptr || !postCompleteMonitorConfig.enabled)
+    {
+        return false;
+    }
+
+    uint8_t rawValue = 0;
+    if (!readCpldRegister(postCompleteMonitorConfig, &rawValue))
+    {
+        return false;
+    }
+
+    bool bitSet = ((rawValue >> postCompleteMonitorConfig.bit) & 0x1) != 0;
+    *postCompleteState = postCompleteMonitorConfig.activeLow ? !bitSet : bitSet;
+
+    lg2::debug("Post-complete monitor {MAP}: raw=0x{RAW} logicalComplete={STATE}",
+               "MAP", postCompleteMonitorConfig.name,
+               "RAW", lg2::hex, static_cast<uint32_t>(rawValue),
+               "STATE", *postCompleteState);
+
+    return true;
+}
+
+void Manager::postCompleteMonitorHandler()
+{
+    if (PostCompletePollingEvent != nullptr)
+    {
+        delete PostCompletePollingEvent;
+    }
+
+    if (!postCompleteMonitorConfig.enabled)
+    {
+        return;
+    }
+
+    PostCompletePollingEvent = new boost::asio::steady_timer(
+        io, std::chrono::seconds(postCompleteMonitorConfig.pollPeriodSec));
+
+    PostCompletePollingEvent->async_wait(
+        [this](const boost::system::error_code ec) {
+            if (ec)
+            {
+                return;
+            }
+
+            bool postCompleteState = false;
+            if (readPostCompleteMonitorState(&postCompleteState))
+            {
+                if (postCompleteStateInitialized == false)
+                {
+                    postCompleteLastState = postCompleteState;
+                    postCompleteStateInitialized = true;
+                }
+                else if (postCompleteState == true &&
+                         postCompleteLastState == false)
+                {
+                    lg2::info(
+                        "Post-complete detected for mapping {MAP}. Reapplying RAS config.",
+                        "MAP", postCompleteMonitorConfig.name);
+                    watchdogTimerCounter = 0;
+                    platformInitialize();
+                    postCompleteLastState = postCompleteState;
+                }
+                else
+                {
+                    postCompleteLastState = postCompleteState;
+                }
+            }
+
+            postCompleteMonitorHandler();
+        });
+}
+
 void Manager::currentHostStateMonitor()
 {
-    sdbusplus::bus_t bus = sdbusplus::bus::new_default();
-    boost::system::error_code ec;
+    static auto bus = sdbusplus::bus::new_default();
 
     static auto match = sdbusplus::bus::match_t(
         bus,
@@ -252,6 +456,14 @@ void Manager::platformInitialize()
             lg2::info("Setting MCA and DRAM Error threshold");
 
             setMcaErrThreshold();
+
+            lg2::info("Setting PCIe OOB Config");
+
+            setPcieOobConfig();
+
+            lg2::info("Setting PCIe Error threshold");
+
+            setPcieErrThreshold();
         }
     }
 }
@@ -427,10 +639,16 @@ void Manager::init()
 
     file.close();
 
+    loadPostCompleteMonitorConfig();
+
     platformInitialize();
 
-    sdbusplus::bus_t bus = sdbusplus::bus::new_default();
-    boost::system::error_code ec;
+    if (postCompleteMonitorConfig.enabled)
+    {
+        postCompleteMonitorHandler();
+    }
+
+    static auto bus = sdbusplus::bus::new_default();
 
     static auto match = sdbusplus::bus::match_t(
         bus,
@@ -485,6 +703,14 @@ void Manager::init()
                       performed only during the second property change*/
                     if (watchdogTimerCounter == 2)
                     {
+                        lg2::info(
+                            "BIOS post complete. Setting MCA and DRAM OOB config");
+                        setMcaOobConfig();
+
+                        lg2::info(
+                            "BIOS post complete. Setting MCA and DRAM error threshold");
+                        setMcaErrThreshold();
+
                         lg2::info(
                             "BIOS post complete. Setting PCIE OOb config");
                         setPcieOobConfig();
@@ -1578,7 +1804,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
         {
             std::string err_msg =
                 "The APML_ALERT_L is asserted due to MCE error";
-
             amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", err_msg);
 
             uint8_t buffer;
@@ -1624,7 +1849,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
     {
         lg2::debug("Read RAS status register. Value: {BUF}", "BUF", lg2::hex,
                    buf);
-
         // check RAS Status Register
         if (buf & 0xFF)
         {
@@ -1642,7 +1866,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                     std::string rasErrMsg =
                         "Fatal error detected in the control fabric. "
                         "BMC may trigger a reset based on policy set. ";
-
                     amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", rasErrMsg);
 
                     harvestBreakEvent(socNum);
@@ -1654,7 +1877,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                         "System hang while resetting in syncflood."
                         "Suggested next step is to do an additional manual "
                         "immediate reset";
-
                     amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", rasErrMsg);
 
                     fchHangError = true;
@@ -1696,7 +1918,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                 {
                     std::string rasErrMsg =
                         "Non MCA Shutdown error detected in the system";
-
                     amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", rasErrMsg);
 
                     nonMcaShutdownError = true;
@@ -1709,7 +1930,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
 
                         std::string mcaErrOverflowMsg =
                             "MCA runtime error counter overflow occured";
-
                         amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", mcaErrOverflowMsg);
 
                         runtimeError = true;
@@ -1720,7 +1940,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
 
                         std::string dramErrOverlowMsg =
                             "DRAM CECC runtime error counter overflow occured";
-
                         amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", dramErrOverlowMsg);
 
                         runtimeError = true;
@@ -1731,7 +1950,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
 
                         std::string pcieErrOverlowMsg =
                             "PCIE runtime error counter overflow occured";
-
                         amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", pcieErrOverlowMsg);
 
                         runtimeError = true;
@@ -1745,7 +1963,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
             // 0x4c is a SB-RMI register acting as write to clear
             // check PPR to determine whether potential bug in PPR or in
             // implementation of SMU?
-
             writeOobRegister(socNum, 0x4C, buf);
 
             if (fchHangError == true || runtimeError == true ||
@@ -1915,10 +2132,11 @@ oob_status_t Manager::setRasOobConfig(struct oob_config_d_in oob_config)
         amd::ras::config::Manager::AttributeValue apmlRetry =
             configMgr.getAttribute("ApmlRetries");
         int64_t* retryCount = std::get_if<int64_t>(&apmlRetry);
+        int64_t retryLimit = *retryCount;
 
-        while (*retryCount > 0)
+        while (retryLimit > 0)
         {
-            --(*retryCount);
+            --retryLimit;
             ret = set_bmc_ras_oob_config(socIndex[i], oob_config);
 
             if (ret == OOB_SUCCESS || ret == OOB_MAILBOX_CMD_UNKNOWN)
@@ -1965,6 +2183,8 @@ oob_status_t Manager::getOobRegisters(struct oob_config_d_in* oob_config)
             (dataOut >> MCA_ERR_REPORT_EN & 1);
         oob_config->dram_cecc_oob_ec_mode =
             (dataOut >> DRAM_CECC_OOB_EC_MODE & TRIBBLE_BITS);
+        oob_config->dram_cecc_leak_rate =
+            (dataOut >> DRAM_CECC_LEAK_RATE) & 0x1F;
         oob_config->pcie_err_reporting_en = (dataOut >> PCIE_ERR_REPORT_EN & 1);
         oob_config->mca_oob_misc0_ec_enable = (dataOut & 1);
     }
@@ -2139,6 +2359,8 @@ oob_status_t Manager::getRasOobConfig(struct oob_config_d_in* oob_config)
             (dataOut >> PCIE_ERR_REPORT_EN & 1);
         oob_config->dram_cecc_oob_ec_mode =
             (dataOut >> DRAM_CECC_OOB_EC_MODE & TRIBBLE_BITS);
+        oob_config->dram_cecc_leak_rate =
+            (dataOut >> DRAM_CECC_LEAK_RATE) & 0x1F;
         oob_config->pcie_err_reporting_en = (dataOut >> PCIE_ERR_REPORT_EN & 1);
         oob_config->mca_oob_misc0_ec_enable = (dataOut & 1);
     }
@@ -2208,17 +2430,7 @@ oob_status_t Manager::setPcieOobRegisters()
 
 oob_status_t Manager::setPcieOobConfig()
 {
-    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
-
-    amd::ras::config::Manager::AttributeValue PcieAerPolling =
-        configMgr.getAttribute("PcieAerPollingEn");
-    bool* PcieAerPollingEn = std::get_if<bool>(&PcieAerPolling);
-
-    if (*PcieAerPollingEn == true)
-    {
-        ret = setPcieOobRegisters();
-    }
-    return ret;
+    return setPcieOobRegisters();
 }
 
 oob_status_t Manager::setRasErrThreshold(struct run_time_threshold th)
@@ -2230,10 +2442,11 @@ oob_status_t Manager::setRasErrThreshold(struct run_time_threshold th)
         amd::ras::config::Manager::AttributeValue apmlRetry =
             configMgr.getAttribute("ApmlRetries");
         int64_t* retryCount = std::get_if<int64_t>(&apmlRetry);
+        int64_t retryLimit = *retryCount;
 
-        while (*retryCount > 0)
+        while (retryLimit > 0)
         {
-            --(*retryCount);
+            --retryLimit;
             ret = set_bmc_ras_err_threshold(socIndex[i], th);
 
             if (ret != OOB_SUCCESS)

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -697,6 +697,10 @@ void Manager::init()
                 if (currentTimerUse ==
                     "xyz.openbmc_project.State.Watchdog.TimerUse.BIOSFRB2")
                 {
+                    if (watchdogTimerCounter >= 2)
+                    {
+                        watchdogTimerCounter = 0;
+                    }
                     watchdogTimerCounter++;
 
                     /*Watchdog Timer Enable property will be changed twice after


### PR DESCRIPTION
 Changes:
    1. Monitor CPLD register bit "FM_BIOS_POST_CMPLT_R_N" to check the post status change.
    2. Based on the status change reapply the RAS OOB Config which detects the system reboot.
    3. This eliminates the need to restarting the RAS service to force the config after a system reboot.

    Testing
    Run system reboot and check if the oobrasconfig is reconfigured using apml

    [root@heliosp-2b805-d7-2 aasaitha]# reboot

    apml_tool 0 --getrasoobconfig

    ================================= APML System Management Interface ====================================
    -------------------------------------------------------------
    | MCA OOB Err Counter                            | Enabled  |
    | DRAM CECC OOB CECC Err Counter Mode            | 2        |
    | DRAM CECC OOB Leak Rate                        | 0x14     |
    | PCIe OOB Error Reporting Enable                | Disabled |
    | MCA Thresholding Interrupt Enable              | Enabled  |
    | DRAM CECC Thresholding Interrupt Enable        | Enabled  |
    | PCIE Thresholding Interrupt Enable             | Disabled |
    | MCA Max Interrupt Rate                         | 0x1      |
    | DRAM CECC Max Interrupt Rate                   | 0x1      |
    | PCIe Max Interrupt Rate                        | 0x0      |
    | MCA OOB Error Reporting Enable                 | Enabled  |
    -------------------------------------------------------------

    ========================================== End of APML SMI ============================================
    
    ***Logs***: 
[Working re-apply config sets for MCA and DRAM after system reboot.txt](https://github.com/user-attachments/files/28794133/Working.re-apply.config.sets.for.MCA.and.DRAM.after.system.reboot.txt)
