### PR TITLE
add PLDM sysMgmtCtrlErr break-event handling

### DIFF
--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -329,21 +329,6 @@ class Manager : public amd::ras::Manager
      */
     void runTimeErrorInfoCheck(uint8_t, uint8_t);
 
-    /** @brief Harvest break event data for a given socket.
-     *
-     * @details This function collects and logs register data related to
-     * a break event from a specific SoC (socket). It initializes the
-     * error record and section descriptor structures if not already
-     * allocated, and populates them with CPER-compliant data including
-     * processor error and context information. It reads a set of
-     * registers via OOB access and stores the resulting 64-bit value
-     * into the MCA data fields of the error record.
-     *
-     * @param[in] socNum - The socket number for which the break event
-     *                     data is to be harvested.
-     */
-    void harvestBreakEvent(uint8_t socNum);
-
     /** @brief Harvest MCA data banks.
      *
      * @details This function collects data from the MCA banks.

--- a/include/base_manager.hpp
+++ b/include/base_manager.hpp
@@ -160,6 +160,15 @@ class Manager
      */
     void processMcaBankSignatures(uint8_t socNum, uint16_t numBanks);
 
+    /** @brief Harvest break-event data from OOB registers.
+     *
+     *  @details Builds a fatal CPER break-event section by reading
+     *  SBRMI OOB registers `0x80-0x87` for the specified socket.
+     *
+     *  @param[in] socNum - Socket number.
+     */
+    void harvestBreakEvent(uint8_t socNum);
+
     /** @brief Clean up the fatal CPER record.
      *
      *  @details Frees the SectionDescriptor and ErrorRecord arrays

--- a/include/pldm_manager.hpp
+++ b/include/pldm_manager.hpp
@@ -3,9 +3,21 @@
 #include "base_manager.hpp"
 
 #include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
+#include <gpiod.hpp>
 #include <sdbusplus/asio/connection.hpp>
 #include <sdbusplus/asio/object_server.hpp>
 #include <sdbusplus/bus/match.hpp>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+extern "C"
+{
+#include "apml_alertl_uevent.h"
+}
 
 namespace amd
 {
@@ -97,6 +109,14 @@ class Manager : public amd::ras::Manager
     // D-Bus match rule for PLDM message poll events
     std::unique_ptr<sdbusplus::bus::match_t> pldmEventMatch;
 
+    // Alert reception mode for sysMgmtCtrlErr (UEVENT or GPIO)
+    std::string alertHandleMode;
+    std::vector<std::string> socketNames;
+    std::vector<gpiod::line> gpioLines;
+    std::vector<boost::asio::posix::stream_descriptor> gpioEventDescriptors;
+    std::vector<apml_udev_monitor> udevMonitors;
+    std::vector<std::unique_ptr<boost::asio::deadline_timer>> udevPollTimers;
+
     /** @brief Called when the host power state changes.
      *
      *  @details Performs PLDM-specific actions on host state transitions,
@@ -125,6 +145,29 @@ class Manager : public amd::ras::Manager
      */
     void handlePldmRasEvent(sdbusplus::message_t& msg);
 
+    /** @brief Read GPIO/UEVENT alert config for sysMgmtCtrlErr reception. */
+    void configureSysMgmtCtrlErrAlertHandling();
+
+    /** @brief Register GPIO/UEVENT handlers for sysMgmtCtrlErr reception. */
+    void registerSysMgmtCtrlErrAlertHandler();
+
+    /** @brief Poll UEVENT source for sysMgmtCtrlErr alerts. */
+    void pollSysMgmtCtrlErrUevent(size_t socketIdx);
+
+    /** @brief Configure one GPIO line watcher for sysMgmtCtrlErr alerts. */
+    void requestSysMgmtCtrlErrGPIOEvents(
+        const std::string& name, const std::function<void()>& handler,
+        gpiod::line& gpioLine,
+        boost::asio::posix::stream_descriptor& gpioEventDescriptor);
+
+    /** @brief Handle GPIO edge events for sysMgmtCtrlErr alerts. */
+    void handleSysMgmtCtrlErrGPIOEvent(
+        boost::asio::posix::stream_descriptor& alertEvent,
+        const gpiod::line& alertLine, size_t socketIdx);
+
+    /** @brief Clear SBRMI alert mask bits needed for alert delivery. */
+    void clearSbrmiAlertMask(uint8_t socNum);
+
     /** @brief Reads event data from a file descriptor.
      *
      *  @details Performs a complete read of eventDataSize bytes from
@@ -152,6 +195,16 @@ class Manager : public amd::ras::Manager
      */
     void handleFatalOrShutdownError(const std::vector<uint8_t>& eventData,
                                     uint8_t socNum, size_t contextType);
+
+    /** @brief Handles PLDM sysMgmtCtrlErr (control fabric) errors.
+     *
+     *  @details Generates a fatal CPER record for control fabric errors,
+     *  updates error counters, exports the record, and applies the configured
+     *  recovery action.
+     *
+     *  @param[in] socNum - Socket number derived from terminus info.
+     */
+    void handleSysMgmtCtrlError(uint8_t socNum);
 
     /** @brief Extracts socket number from PLDM terminus name.
      *

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -88,8 +88,6 @@ constexpr size_t mcaIpidHiOffset = 0x2C;
 constexpr uint32_t umcHardwareId = 0x96;
 constexpr size_t crashdump = 1;
 constexpr size_t shutdown = 2;
-constexpr size_t breakEvent = 3;
-constexpr uint16_t breakEventBanks = 1;
 constexpr size_t index28 = 28;
 constexpr size_t blockId25 = 25;
 constexpr uint16_t coreMcaHardwareId = 0xb0;
@@ -108,33 +106,6 @@ void writeOobRegister(uint8_t info, uint32_t reg, uint32_t value)
     }
     lg2::debug("Write to register {REGISTER} is successful", "REGISTER",
                lg2::hex, reg);
-}
-
-oob_status_t readOobRegister(uint8_t info, uint32_t reg, uint8_t* value)
-{
-    oob_status_t ret;
-    uint16_t retryCount = 10;
-
-    while (retryCount > 0)
-    {
-        ret = esmi_oob_read_byte(info, reg, SBRMI, value);
-        if (ret == OOB_SUCCESS)
-        {
-            break;
-        }
-
-        lg2::error("Failed to read register: {REGISTER} Retrying\n", "REGISTER",
-                   lg2::hex, reg);
-        sleep(1);
-        retryCount--;
-    }
-    if (ret != OOB_SUCCESS)
-    {
-        lg2::error("Failed to read register: {REGISTER}\n", "REGISTER",
-                   lg2::hex, reg);
-    }
-
-    return ret;
 }
 
 Manager::Manager(amd::ras::config::Manager& manager,
@@ -1424,59 +1395,6 @@ void Manager::harvestDebugLogDump(
             }
         }
     }
-}
-
-void Manager::harvestBreakEvent(uint8_t socNum)
-{
-    constexpr uint16_t sectionCount = 2; // Standard section count is 2
-    uint32_t errorSeverity = 1;          // Error severity for fatal error is 1
-    uint8_t baseReg = 0x80;
-    int regCount = 8;
-    uint8_t buff;
-    oob_status_t ret;
-
-    if (rcd->SectionDescriptor == nullptr)
-    {
-        rcd->SectionDescriptor = new EFI_ERROR_SECTION_DESCRIPTOR[sectionCount];
-        std::memset(rcd->SectionDescriptor, 0,
-                    sectionCount * sizeof(EFI_ERROR_SECTION_DESCRIPTOR));
-    }
-
-    if (rcd->ErrorRecord == nullptr)
-    {
-        rcd->ErrorRecord = new EFI_AMD_FATAL_ERROR_DATA[sectionCount];
-        std::memset(rcd->ErrorRecord, 0,
-                    sectionCount * sizeof(EFI_AMD_FATAL_ERROR_DATA));
-    }
-
-    amd::ras::util::cper::dumpHeader(rcd, sectionCount, errorSeverity, fatalErr,
-                                     boardId, recordId);
-    amd::ras::util::cper::dumpErrorDescriptor(rcd, sectionCount, fatalErr,
-                                              &errorSeverity, progId);
-    amd::ras::util::cper::dumpProcessorError(rcd, socNum, cpuId, socIndex,
-                                             breakEventBanks);
-    amd::ras::util::cper::dumpContext(rcd, breakEventBanks, 0, socNum, ppin,
-                                      uCode, breakEvent);
-    memcpy(rcd->SectionDescriptor[socNum].FruString, &socNum, sizeof(socNum));
-
-    for (int offset : std::views::iota(0, regCount))
-    {
-        ret = readOobRegister(socNum, baseReg + offset, &buff);
-        if (ret != OOB_SUCCESS)
-        {
-            lg2::error("Socket {SOC}: Failed to read register: {REGISTER}\n",
-                       "SOC", socNum, "REGISTER", lg2::hex, baseReg + offset);
-            rcd->ErrorRecord[socNum].CrashDumpData[0].McaData[offset] = badData;
-            continue;
-        }
-        rcd->ErrorRecord[socNum].CrashDumpData[0].McaData[offset] = buff;
-
-        lg2::debug("Register {REG}: Read Value: {VAL}\n", "REG", lg2::hex,
-                   baseReg + offset, "VAL", lg2::hex, buff);
-    }
-
-    constexpr uint8_t crashDataSize = 32;
-    rcd->ErrorRecord[socNum].RegisterArraySize = crashDataSize;
 }
 
 void Manager::harvestX86ExceptionData(uint8_t socNum)

--- a/src/base_manager.cpp
+++ b/src/base_manager.cpp
@@ -3,7 +3,15 @@
 #include "utils/cper.hpp"
 #include "utils/util.hpp"
 
+extern "C"
+{
+#include "apml.h"
+#include "esmi_cpuid_msr.h"
+#include "linux/amd-apml.h"
+}
+
 #include <systemd/sd-journal.h>
+#include <unistd.h>
 
 #include <boost/asio/io_context.hpp>
 #include <nlohmann/json.hpp>
@@ -13,6 +21,9 @@
 #include <fstream>
 
 constexpr size_t base16 = 16;
+constexpr uint32_t badData = 0xBAADDA7A;
+constexpr size_t breakEventContext = 3;
+constexpr uint16_t breakEventBanks = 1;
 
 namespace amd
 {
@@ -385,6 +396,62 @@ void Manager::processMcaBankSignatures(uint8_t socNum, uint16_t numBanks)
                 mcaPspSynd2Lo, mcaPspSynd2Hi);
         }
     }
+}
+
+void Manager::harvestBreakEvent(uint8_t socNum)
+{
+    constexpr uint16_t sectionCount = 2;
+    constexpr uint8_t baseReg = 0x80;
+    constexpr size_t regCount = 8;
+
+    if (rcd == nullptr)
+    {
+        rcd = std::make_shared<FatalCperRecord>();
+    }
+
+    initFatalCperRecord(sectionCount);
+
+    amd::ras::util::cper::dumpProcessorError(rcd, socNum, cpuId, socIndex,
+                                             breakEventBanks);
+    amd::ras::util::cper::dumpContext(rcd, breakEventBanks, 0, socNum, ppin,
+                                      uCode, breakEventContext);
+    std::memcpy(rcd->SectionDescriptor[socNum].FruString, &socNum,
+                sizeof(socNum));
+
+    for (size_t offset = 0; offset < regCount; ++offset)
+    {
+        uint8_t regValue = 0;
+        const uint32_t reg = static_cast<uint32_t>(baseReg + offset);
+        oob_status_t ret = esmi_oob_read_byte(socNum, reg, SBRMI, &regValue);
+
+        if (ret != OOB_SUCCESS)
+        {
+            uint16_t retryCount = 10;
+            while (retryCount > 0)
+            {
+                ret = esmi_oob_read_byte(socNum, reg, SBRMI, &regValue);
+                if (ret == OOB_SUCCESS)
+                {
+                    break;
+                }
+                retryCount--;
+                sleep(1);
+            }
+        }
+
+        if (ret != OOB_SUCCESS)
+        {
+            lg2::error("Socket {SOC}: Failed to read register: {REGISTER}",
+                       "SOC", socNum, "REGISTER", lg2::hex, reg);
+            rcd->ErrorRecord[socNum].CrashDumpData[0].McaData[offset] = badData;
+            continue;
+        }
+
+        rcd->ErrorRecord[socNum].CrashDumpData[0].McaData[offset] = regValue;
+    }
+
+    // Keep break-event records aligned with existing APML/PLDM CPER format.
+    rcd->ErrorRecord[socNum].RegisterArraySize = 32;
 }
 
 } // namespace ras

--- a/src/pldm_manager.cpp
+++ b/src/pldm_manager.cpp
@@ -9,6 +9,8 @@ extern "C"
 {
 #include "esmi_cpuid_msr.h"
 #include "esmi_mailbox.h"
+#include "esmi_rmi.h"
+#include "linux/amd-apml.h"
 }
 
 #include <unistd.h>
@@ -19,6 +21,7 @@ extern "C"
 
 #include <cerrno>
 #include <cstring>
+#include <fstream>
 
 namespace amd
 {
@@ -28,6 +31,9 @@ namespace pldm
 {
 
 constexpr uint32_t badData = 0xBAADDA7A;
+constexpr uint8_t sysMgmtCtrlErr = 0x4;
+constexpr uint8_t cfError = 0x6;
+constexpr uint8_t sbrmiControlRegister = 0x1;
 
 Manager::Manager(amd::ras::config::Manager& manager,
                  sdbusplus::asio::object_server& objectServer,
@@ -77,6 +83,11 @@ void Manager::platformInitialize()
         {
             currentHostStateMonitor();
 
+            for (size_t i : socIndex)
+            {
+                clearSbrmiAlertMask(static_cast<uint8_t>(i));
+            }
+
             // TODO: Add support for runtime error polling for PLDM when the API
             // is available.
             runtimeErrPollingSupported = true;
@@ -94,6 +105,12 @@ void Manager::platformInitialize()
     else
     {
         pldmInitialized = true;
+
+        for (size_t i : socIndex)
+        {
+            clearSbrmiAlertMask(static_cast<uint8_t>(i));
+        }
+
         if (runtimeErrPollingSupported == true)
         {
             lg2::info("Setting MCA and DRAM OOB Config");
@@ -105,6 +122,48 @@ void Manager::platformInitialize()
             // PLDM when the API is available.
         }
     }
+}
+
+void Manager::clearSbrmiAlertMask(uint8_t socNum)
+{
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+    uint8_t buffer = 0;
+    size_t retryCount = 10;
+
+    while (retryCount > 0)
+    {
+        ret = esmi_oob_read_byte(socNum, sbrmiControlRegister, SBRMI, &buffer);
+        if (ret == OOB_SUCCESS)
+        {
+            break;
+        }
+
+        lg2::error("Failed to read register: {REGISTER} Retrying", "REGISTER",
+                   lg2::hex, sbrmiControlRegister);
+        sleep(1);
+        retryCount--;
+    }
+
+    if (ret != OOB_SUCCESS)
+    {
+        lg2::error("Failed to read register: {REGISTER}", "REGISTER", lg2::hex,
+                   sbrmiControlRegister);
+        return;
+    }
+
+    // Match APML path: clear alert mask bits required for RAS alert delivery.
+    buffer = buffer & 0xBE;
+
+    ret = esmi_oob_write_byte(socNum, sbrmiControlRegister, SBRMI, buffer);
+    if (ret != OOB_SUCCESS)
+    {
+        lg2::error("Failed to write register: {REGISTER}", "REGISTER", lg2::hex,
+                   sbrmiControlRegister);
+        return;
+    }
+
+    lg2::debug("Write to register {REGISTER} is successful", "REGISTER",
+               lg2::hex, sbrmiControlRegister);
 }
 
 void Manager::init()
@@ -121,6 +180,7 @@ void Manager::init()
 void Manager::configure()
 {
     lg2::info("PLDM MANAGER CONFIGURE");
+    configureSysMgmtCtrlErrAlertHandling();
 }
 
 void Manager::registerEventHandler()
@@ -139,6 +199,254 @@ void Manager::registerEventHandler()
         [this](sdbusplus::message_t& msg) { handlePldmRasEvent(msg); });
 
     lg2::info("Registered PLDM RAS event signal monitor");
+
+    registerSysMgmtCtrlErrAlertHandler();
+}
+
+void Manager::configureSysMgmtCtrlErrAlertHandling()
+{
+    const std::string primaryPath =
+        "/var/lib/amd-bmc-ras/amd_ras_gpio_config" + node + ".json";
+    const std::string fallbackPath =
+        "/usr/share/amd-bmc-ras/amd_ras_gpio_config" + node + ".json";
+
+    std::ifstream jsonFile(primaryPath);
+    std::string cfgPath = primaryPath;
+
+    if (!jsonFile.is_open())
+    {
+        jsonFile.open(fallbackPath);
+        cfgPath = fallbackPath;
+    }
+
+    if (!jsonFile.is_open())
+    {
+        throw sdbusplus::xyz::openbmc_project::Common::File::Error::Open();
+    }
+
+    if (jsonFile.peek() == std::ifstream::traits_type::eof())
+    {
+        jsonFile.close();
+        lg2::error("GPIO config file is empty: {FILE}", "FILE", cfgPath);
+        throw std::runtime_error("GPIO config file is empty");
+    }
+
+    nlohmann::json config;
+    jsonFile >> config;
+    jsonFile.close();
+
+    alertHandleMode.clear();
+    socketNames.clear();
+
+    if (config.contains("Alert_Config") && config["Alert_Config"].is_array())
+    {
+        for (const auto& entry : config["Alert_Config"])
+        {
+            if (entry.contains("AlertHandle"))
+            {
+                const auto& alertCfg = entry["AlertHandle"];
+                if (alertCfg.contains("Value"))
+                {
+                    alertHandleMode = alertCfg["Value"].get<std::string>();
+                }
+            }
+
+            if (alertHandleMode == "GPIO" &&
+                entry.contains("GPIO_ALERT_LINES") &&
+                entry["GPIO_ALERT_LINES"].is_array())
+            {
+                socketNames =
+                    entry["GPIO_ALERT_LINES"].get<std::vector<std::string>>();
+            }
+        }
+    }
+
+    if (alertHandleMode != "UEVENT" && alertHandleMode != "GPIO")
+    {
+        throw std::runtime_error("Invalid mode of Alert handling");
+    }
+
+    if (alertHandleMode == "GPIO" && socketNames.size() < cpuCount)
+    {
+        throw std::runtime_error(
+            "Insufficient GPIO_ALERT_LINES entries in gpio_config.json");
+    }
+
+    lg2::info("PLDM sysMgmtCtrlErr alert mode: {MODE}", "MODE",
+              alertHandleMode);
+}
+
+void Manager::registerSysMgmtCtrlErrAlertHandler()
+{
+    if (alertHandleMode == "UEVENT")
+    {
+        udevMonitors.resize(cpuCount);
+        udevPollTimers.resize(cpuCount);
+
+        for (size_t i = 0; i < cpuCount; ++i)
+        {
+            apml_register_udev_monitor(&udevMonitors[i]);
+
+            if (!udevMonitors[i].udev || !udevMonitors[i].mon)
+            {
+                lg2::error(
+                    "Failed to initialize udev monitor for socket idx {IDX}",
+                    "IDX", i);
+                apml_unregister_udev_monitor(&udevMonitors[i]);
+                continue;
+            }
+
+            lg2::info(
+                "Registered UEVENT monitor for PLDM sysMgmtCtrlErr on socket idx {IDX}",
+                "IDX", i);
+            pollSysMgmtCtrlErrUevent(i);
+        }
+        return;
+    }
+
+    gpioLines.resize(cpuCount);
+    gpioEventDescriptors.reserve(cpuCount);
+
+    for (size_t i = 0; i < cpuCount; ++i)
+    {
+        gpioEventDescriptors.emplace_back(io);
+
+        requestSysMgmtCtrlErrGPIOEvents(
+            socketNames[i],
+            std::bind(&ras::pldm::Manager::handleSysMgmtCtrlErrGPIOEvent, this,
+                      std::ref(gpioEventDescriptors[i]), std::ref(gpioLines[i]),
+                      i),
+            gpioLines[i], gpioEventDescriptors[i]);
+    }
+}
+
+void Manager::pollSysMgmtCtrlErrUevent(size_t socketIdx)
+{
+    if (socketIdx >= udevMonitors.size() || socketIdx >= socIndex.size())
+    {
+        return;
+    }
+
+    uint8_t socNum = static_cast<uint8_t>(socIndex[socketIdx]);
+    uint32_t src = 0;
+    const bool block = false;
+    const oob_status_t ret =
+        monitor_ras_alert(udevMonitors[socketIdx].mon, block, &socNum, &src);
+
+    if (ret == OOB_SUCCESS)
+    {
+        lg2::info("PLDM UEVENT alert: soc={SOC}, src=0x{SRC}", "SOC", socNum,
+                  "SRC", lg2::hex, src);
+
+        if ((socNum == static_cast<uint8_t>(socIndex[socketIdx])) &&
+            (src & cfError) && (src & sysMgmtCtrlErr))
+        {
+            handleSysMgmtCtrlError(socNum);
+        }
+    }
+    else if (ret == OOB_FILE_ERROR || ret == OOB_INTERRUPTED)
+    {
+        lg2::error("PLDM UEVENT monitor error for socket idx {IDX}: {RET}",
+                   "IDX", socketIdx, "RET", ret);
+    }
+
+    udevPollTimers[socketIdx] = std::make_unique<boost::asio::deadline_timer>(
+        io, boost::posix_time::seconds(1));
+    udevPollTimers[socketIdx]->async_wait(
+        [this, socketIdx](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                lg2::error("PLDM UEVENT polling timer error: {MSG}", "MSG",
+                           ec.message().c_str());
+                return;
+            }
+            pollSysMgmtCtrlErrUevent(socketIdx);
+        });
+}
+
+void Manager::requestSysMgmtCtrlErrGPIOEvents(
+    const std::string& name, const std::function<void()>& handler,
+    gpiod::line& gpioLine,
+    boost::asio::posix::stream_descriptor& gpioEventDescriptor)
+{
+    try
+    {
+        gpioLine = gpiod::find_line(name);
+        if (!gpioLine)
+        {
+            throw std::runtime_error("Failed to find GPIO line: " + name);
+        }
+
+        gpioLine.request({"RAS", gpiod::line_request::EVENT_BOTH_EDGES, 0});
+
+        const int gpioFd = gpioLine.event_get_fd();
+        if (gpioFd < 0)
+        {
+            throw std::runtime_error("Failed to get GPIO line fd: " + name);
+        }
+
+        gpioEventDescriptor.assign(gpioFd);
+        gpioEventDescriptor.async_wait(
+            boost::asio::posix::stream_descriptor::wait_read,
+            [handler](const boost::system::error_code& ec) {
+                if (ec)
+                {
+                    throw std::runtime_error(
+                        "GPIO wait error: " + ec.message());
+                }
+                handler();
+            });
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed to register GPIO alert {LINE}: {ERROR}", "LINE",
+                   name, "ERROR", e.what());
+    }
+}
+
+void Manager::handleSysMgmtCtrlErrGPIOEvent(
+    boost::asio::posix::stream_descriptor& alertEvent,
+    const gpiod::line& alertLine, size_t socketIdx)
+{
+    const gpiod::line_event gpioLineEvent = alertLine.event_read();
+
+    if (gpioLineEvent.event_type == gpiod::line_event::FALLING_EDGE)
+    {
+        if (socketIdx < socIndex.size())
+        {
+            const uint8_t socNum = static_cast<uint8_t>(socIndex[socketIdx]);
+            uint8_t rasStatus = 0;
+
+            if (read_sbrmi_ras_status(socNum, &rasStatus) == OOB_SUCCESS)
+            {
+                lg2::info("PLDM GPIO alert: soc={SOC}, rasStatus=0x{STATUS}",
+                          "SOC", socNum, "STATUS", lg2::hex, rasStatus);
+
+                if ((rasStatus & cfError) && (rasStatus & sysMgmtCtrlErr))
+                {
+                    handleSysMgmtCtrlError(socNum);
+                }
+            }
+            else
+            {
+                lg2::error("Failed to read RAS status for socket {SOC}", "SOC",
+                           socNum);
+            }
+        }
+    }
+
+    alertEvent.async_wait(
+        boost::asio::posix::stream_descriptor::wait_read,
+        [this, alertLine, socketIdx, alertEventPtr = &alertEvent](
+            const boost::system::error_code& ec) mutable {
+            if (ec)
+            {
+                lg2::error("PLDM GPIO alert handler error: {ERROR}", "ERROR",
+                           ec.message().c_str());
+                return;
+            }
+            handleSysMgmtCtrlErrGPIOEvent(*alertEventPtr, alertLine, socketIdx);
+        });
 }
 
 void Manager::handlePldmRasEvent(sdbusplus::message_t& msg)
@@ -306,6 +614,47 @@ void Manager::handleFatalOrShutdownError(const std::vector<uint8_t>& eventData,
     std::string* systemRecovery = std::get_if<std::string>(&SystemRecoveryVal);
 
     amd::ras::util::rasRecoveryAction(node, rasStatusByte, systemRecovery,
+                                      resetSignal);
+
+    cleanupFatalCperRecord();
+}
+
+void Manager::handleSysMgmtCtrlError(uint8_t socNum)
+{
+    std::unique_lock lock(harvestMutex);
+
+    std::string rasErrMsg = "Fatal error detected in the control fabric. "
+                            "BMC may trigger a reset based on policy set. ";
+
+    sd_journal_send("MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
+                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
+                    "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+
+    if (rcd == nullptr)
+    {
+        rcd = std::make_shared<FatalCperRecord>();
+    }
+
+    harvestBreakEvent(socNum);
+
+    configMgr.incrementNoncorrectableOtherError(socNum);
+    configMgr.updateErrorCountDbus();
+    configMgr.saveErrorCounts();
+
+    amd::ras::util::cper::createFile(rcd, fatalErr, 2, errCount, node);
+    amd::ras::util::cper::exportToDBus(errCount, rcd->Header.TimeStamp,
+                                       objectServer, systemBus, node);
+    amd::ras::util::cper::updateIndexFile(errCount, node);
+
+    amd::ras::config::Manager::AttributeValue resetSignalVal =
+        configMgr.getAttribute("ResetSignalType");
+    std::string* resetSignal = std::get_if<std::string>(&resetSignalVal);
+
+    amd::ras::config::Manager::AttributeValue systemRecoveryVal =
+        configMgr.getAttribute("SystemRecoveryMode");
+    std::string* systemRecovery = std::get_if<std::string>(&systemRecoveryVal);
+
+    amd::ras::util::rasRecoveryAction(node, sysMgmtCtrlErr, systemRecovery,
                                       resetSignal);
 
     cleanupFatalCperRecord();

--- a/src/utils/cper.cpp
+++ b/src/utils/cper.cpp
@@ -800,8 +800,6 @@ void createFile(const std::shared_ptr<PtrType>& data,
     }
 
     std::string cperFilePath = RAS_DIR + cperFileName;
-    lg2::info("Creating CPER file: {CPERFILE}", "CPERFILE",
-              cperFilePath.c_str());
 
     file = fopen(cperFilePath.c_str(), "w");
 


### PR DESCRIPTION
Move break-event CPER harvesting from the APML manager into the common base manager and add PLDM handling for sysMgmtCtrlErr alerts.

Reason:
- Break-event harvesting was implemented only in the APML path, which prevented the PLDM path from reusing the same CPER generation flow for control fabric fatal errors.
- PLDM also needs a mechanism to detect sysMgmtCtrlErr alerts through platform- specific sources such as GPIO or UEVENT and convert them into fatal CPER records.
- Centralizing the break-event harvesting logic avoids duplicate implementations and keeps fatal error record generation consistent across APML and PLDM flows.

Impact:
- PLDM can now detect sysMgmtCtrlErr/control-fabric fatal errors and generate CPER records using the same break-event format already used by the APML path.
- Fatal error handling becomes more consistent and maintainable across managers.
- Platform alert handling becomes configurable through GPIO or UEVENT without changing the core error-processing flow.
- Improves recovery readiness by ensuring fatal PLDM control-fabric errors are counted, logged, exported, and acted on through the configured system policy. ``
Testes:
Verified the sysMgmtCtrlErr handling successfully