### PR TITLE
Add syncflood fatal-harvest delay override, Asio D-Bus listeners, and watchdog counter reset for reliable RAS config reapply

### DIFF
--- a/config/ras_config.json
+++ b/config/ras_config.json
@@ -69,6 +69,19 @@
             }
         },
         {
+            "FatalHarvestDelayEn": {
+                "Description": "If true, BMC proactively overrides the CPU DelayResetOnSyncflood timer during initialization so the system waits before resetting after a fatal error, giving time to collect MCA data. Requires BIOS Delay Reset After Syncflood to be enabled (any non-zero value).",
+                "Value": true
+            }
+        },
+        {
+            "FatalHarvestDelayMins": {
+                "Description": "Delay value (5-120 mins) sent to the CPU during RAS initialization to override the BIOS-configured Delay Reset After Syncflood value.",
+                "Value": 5,
+                "MaxBoundLimit": 120
+            }
+        },
+        {
             "DramCeccPollingEn": {
                 "Description": "If this field is true, Dynamic Random Access Memory Error Correction Code (DRAM ECC) correctable errors will be polled",
                 "Value": false

--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -10,6 +10,7 @@ extern "C"
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <gpiod.hpp>
+#include <sdbusplus/asio/connection.hpp>
 
 namespace amd
 {
@@ -84,6 +85,7 @@ class Manager : public amd::ras::Manager
     std::mutex dramErrorHarvestMtx;
     std::mutex pcieErrorHarvestMtx;
     std::vector<gpiod::line> gpioLines;
+    std::shared_ptr<sdbusplus::asio::connection> conn;
 
     /**
      * @brief Requests GPIO events for hardware alert handling.
@@ -203,6 +205,14 @@ class Manager : public amd::ras::Manager
      *  @param[in] socNum - Socket number of the processor.
      */
     void clearSbrmiAlertMask(uint8_t socNum);
+
+    /** @brief Proactively set the fatal harvest delay override in the CPU.
+     *
+     *  @details Arms the CPU's DelayResetOnSyncflood counter with the configured
+     *  value so the system waits before resetting after a fatal error, giving the
+     *  BMC time to collect MCA data
+     */
+    void setFatalHarvestDelay();
 
     /** @brief Monitors the current host power state.
      *

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -16,6 +16,8 @@ extern "C"
 #include <phosphor-logging/lg2.hpp>
 #include <phosphor-logging/log.hpp>
 
+#include <unistd.h>
+
 #include <stdexcept>
 
 namespace amd
@@ -113,16 +115,14 @@ Manager::Manager(amd::ras::config::Manager& manager,
     platformInitialized(false), runtimeErrPollingSupported(false),
     McaErrorPollingEvent(nullptr), DramCeccErrorPollingEvent(nullptr),
     PcieAerErrorPollingEvent(nullptr), mcaErrorHarvestMtx(),
-    dramErrorHarvestMtx(), pcieErrorHarvestMtx()
+    dramErrorHarvestMtx(), pcieErrorHarvestMtx(),
+    conn(std::make_shared<sdbusplus::asio::connection>(io))
 {}
 
 void Manager::currentHostStateMonitor()
 {
-    sdbusplus::bus_t bus = sdbusplus::bus::new_default();
-    boost::system::error_code ec;
-
     static auto match = sdbusplus::bus::match_t(
-        bus,
+        *conn,
         "type='signal',member='PropertiesChanged', "
         "interface='org.freedesktop.DBus.Properties', "
         "arg0='xyz.openbmc_project.State.Host'",
@@ -252,6 +252,18 @@ void Manager::platformInitialize()
             lg2::info("Setting MCA and DRAM Error threshold");
 
             setMcaErrThreshold();
+
+            lg2::info("Setting PCIe OOB Config");
+
+            setPcieOobConfig();
+
+            lg2::info("Setting PCIe Error threshold");
+
+            setPcieErrThreshold();
+
+            lg2::info("Setting fatal harvest delay override");
+
+            setFatalHarvestDelay();
         }
     }
 }
@@ -429,11 +441,8 @@ void Manager::init()
 
     platformInitialize();
 
-    sdbusplus::bus_t bus = sdbusplus::bus::new_default();
-    boost::system::error_code ec;
-
     static auto match = sdbusplus::bus::match_t(
-        bus,
+        *conn,
         "type='signal',member='PropertiesChanged', "
         "interface='org.freedesktop.DBus.Properties', "
         "arg0='xyz.openbmc_project.State.Watchdog'",
@@ -478,6 +487,10 @@ void Manager::init()
                 if (currentTimerUse ==
                     "xyz.openbmc_project.State.Watchdog.TimerUse.BIOSFRB2")
                 {
+                    if (watchdogTimerCounter >= 2)
+                    {
+                        watchdogTimerCounter = 0;
+                    }
                     watchdogTimerCounter++;
 
                     /*Watchdog Timer Enable property will be changed twice after
@@ -486,11 +499,22 @@ void Manager::init()
                     if (watchdogTimerCounter == 2)
                     {
                         lg2::info(
+                            "BIOS post complete. Setting MCA and DRAM OOB config");
+                        setMcaOobConfig();
+
+                        lg2::info(
+                            "BIOS post complete. Setting MCA and DRAM error threshold");
+                        setMcaErrThreshold();
+
+                        lg2::info(
                             "BIOS post complete. Setting PCIE OOb config");
                         setPcieOobConfig();
 
                         lg2::info("Setting PCIE Error threshold");
                         setPcieErrThreshold();
+
+                        lg2::info("Setting fatal harvest delay override");
+                        setFatalHarvestDelay();
                     }
                 }
             }
@@ -1578,7 +1602,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
         {
             std::string err_msg =
                 "The APML_ALERT_L is asserted due to MCE error";
-
             amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", err_msg);
 
             uint8_t buffer;
@@ -1624,7 +1647,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
     {
         lg2::debug("Read RAS status register. Value: {BUF}", "BUF", lg2::hex,
                    buf);
-
         // check RAS Status Register
         if (buf & 0xFF)
         {
@@ -1642,7 +1664,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                     std::string rasErrMsg =
                         "Fatal error detected in the control fabric. "
                         "BMC may trigger a reset based on policy set. ";
-
                     amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", rasErrMsg);
 
                     harvestBreakEvent(socNum);
@@ -1654,7 +1675,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                         "System hang while resetting in syncflood."
                         "Suggested next step is to do an additional manual "
                         "immediate reset";
-
                     amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", rasErrMsg);
 
                     fchHangError = true;
@@ -1696,7 +1716,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                 {
                     std::string rasErrMsg =
                         "Non MCA Shutdown error detected in the system";
-
                     amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", rasErrMsg);
 
                     nonMcaShutdownError = true;
@@ -1709,7 +1728,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
 
                         std::string mcaErrOverflowMsg =
                             "MCA runtime error counter overflow occured";
-
                         amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", mcaErrOverflowMsg);
 
                         runtimeError = true;
@@ -1720,7 +1738,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
 
                         std::string dramErrOverlowMsg =
                             "DRAM CECC runtime error counter overflow occured";
-
                         amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", dramErrOverlowMsg);
 
                         runtimeError = true;
@@ -1731,7 +1748,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
 
                         std::string pcieErrOverlowMsg =
                             "PCIE runtime error counter overflow occured";
-
                         amd::ras::util::postRedfishEvent("OpenBMC.0.1.CPUError", pcieErrOverlowMsg);
 
                         runtimeError = true;
@@ -1745,7 +1761,6 @@ bool Manager::decodeInterrupt(uint8_t socNum)
             // 0x4c is a SB-RMI register acting as write to clear
             // check PPR to determine whether potential bug in PPR or in
             // implementation of SMU?
-
             writeOobRegister(socNum, 0x4C, buf);
 
             if (fchHangError == true || runtimeError == true ||
@@ -1915,10 +1930,11 @@ oob_status_t Manager::setRasOobConfig(struct oob_config_d_in oob_config)
         amd::ras::config::Manager::AttributeValue apmlRetry =
             configMgr.getAttribute("ApmlRetries");
         int64_t* retryCount = std::get_if<int64_t>(&apmlRetry);
+        int64_t retryLimit = *retryCount;
 
-        while (*retryCount > 0)
+        while (retryLimit > 0)
         {
-            --(*retryCount);
+            --retryLimit;
             ret = set_bmc_ras_oob_config(socIndex[i], oob_config);
 
             if (ret == OOB_SUCCESS || ret == OOB_MAILBOX_CMD_UNKNOWN)
@@ -1965,6 +1981,8 @@ oob_status_t Manager::getOobRegisters(struct oob_config_d_in* oob_config)
             (dataOut >> MCA_ERR_REPORT_EN & 1);
         oob_config->dram_cecc_oob_ec_mode =
             (dataOut >> DRAM_CECC_OOB_EC_MODE & TRIBBLE_BITS);
+        oob_config->dram_cecc_leak_rate =
+            (dataOut >> DRAM_CECC_LEAK_RATE) & 0x1F;
         oob_config->pcie_err_reporting_en = (dataOut >> PCIE_ERR_REPORT_EN & 1);
         oob_config->mca_oob_misc0_ec_enable = (dataOut & 1);
     }
@@ -2119,6 +2137,10 @@ void Manager::runTimeErrorPolling()
     else
     {
         setPcieErrThreshold();
+
+        lg2::info("Setting fatal harvest delay override");
+
+        setFatalHarvestDelay();
     }
 }
 
@@ -2139,6 +2161,8 @@ oob_status_t Manager::getRasOobConfig(struct oob_config_d_in* oob_config)
             (dataOut >> PCIE_ERR_REPORT_EN & 1);
         oob_config->dram_cecc_oob_ec_mode =
             (dataOut >> DRAM_CECC_OOB_EC_MODE & TRIBBLE_BITS);
+        oob_config->dram_cecc_leak_rate =
+            (dataOut >> DRAM_CECC_LEAK_RATE) & 0x1F;
         oob_config->pcie_err_reporting_en = (dataOut >> PCIE_ERR_REPORT_EN & 1);
         oob_config->mca_oob_misc0_ec_enable = (dataOut & 1);
     }
@@ -2185,6 +2209,24 @@ oob_status_t Manager::setMcaOobConfig()
         oob_config.dram_cecc_leak_rate =
             static_cast<uint8_t>(*dramCeccLeakRate);
     }
+    else
+    {
+        amd::ras::config::Manager::AttributeValue dramCeccOobEcModeVal =
+            configMgr.getAttribute("DramCeccOobEcMode");
+        int64_t* dramCeccOobEcMode =
+            std::get_if<int64_t>(&dramCeccOobEcModeVal);
+
+        amd::ras::config::Manager::AttributeValue dramCeccLeakRateVal =
+            configMgr.getAttribute("DramCeccLeakRate");
+        int64_t* dramCeccLeakRate =
+            std::get_if<int64_t>(&dramCeccLeakRateVal);
+
+        oob_config.dram_cecc_oob_ec_mode =
+            static_cast<uint8_t>(*dramCeccOobEcMode);
+        oob_config.dram_cecc_leak_rate =
+            static_cast<uint8_t>(*dramCeccLeakRate);
+        oob_config.mca_oob_misc0_ec_enable = 1;
+    }
 
     ret = setRasOobConfig(oob_config);
 
@@ -2208,17 +2250,7 @@ oob_status_t Manager::setPcieOobRegisters()
 
 oob_status_t Manager::setPcieOobConfig()
 {
-    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
-
-    amd::ras::config::Manager::AttributeValue PcieAerPolling =
-        configMgr.getAttribute("PcieAerPollingEn");
-    bool* PcieAerPollingEn = std::get_if<bool>(&PcieAerPolling);
-
-    if (*PcieAerPollingEn == true)
-    {
-        ret = setPcieOobRegisters();
-    }
-    return ret;
+    return setPcieOobRegisters();
 }
 
 oob_status_t Manager::setRasErrThreshold(struct run_time_threshold th)
@@ -2230,10 +2262,11 @@ oob_status_t Manager::setRasErrThreshold(struct run_time_threshold th)
         amd::ras::config::Manager::AttributeValue apmlRetry =
             configMgr.getAttribute("ApmlRetries");
         int64_t* retryCount = std::get_if<int64_t>(&apmlRetry);
+        int64_t retryLimit = *retryCount;
 
-        while (*retryCount > 0)
+        while (retryLimit > 0)
         {
-            --(*retryCount);
+            --retryLimit;
             ret = set_bmc_ras_err_threshold(socIndex[i], th);
 
             if (ret != OOB_SUCCESS)
@@ -2249,6 +2282,58 @@ oob_status_t Manager::setRasErrThreshold(struct run_time_threshold th)
         }
     }
     return ret;
+}
+
+void Manager::setFatalHarvestDelay()
+{
+    amd::ras::config::Manager::AttributeValue fatalDelayEnVal =
+        configMgr.getAttribute("FatalHarvestDelayEn");
+    bool* fatalHarvestDelayEn = std::get_if<bool>(&fatalDelayEnVal);
+
+    if (fatalHarvestDelayEn == nullptr || *fatalHarvestDelayEn == false)
+    {
+        return;
+    }
+
+    amd::ras::config::Manager::AttributeValue fatalDelayMinsVal =
+        configMgr.getAttribute("FatalHarvestDelayMins");
+    int64_t* fatalHarvestDelayMins = std::get_if<int64_t>(&fatalDelayMinsVal);
+
+    if (fatalHarvestDelayMins == nullptr)
+    {
+        return;
+    }
+
+    struct ras_override_delay delayDataIn = {0, 0, 0};
+    bool ackResp = false;
+
+    int64_t mins = *fatalHarvestDelayMins;
+    if (mins >= 5 && mins <= 120)
+    {
+        delayDataIn.delay_val_override = static_cast<uint8_t>(mins);
+    }
+    else
+    {
+        delayDataIn.delay_val_override = 5; // minimum safe fallback
+    }
+
+    oob_status_t ret = override_delay_reset_on_sync_flood(
+        socIndex[0], delayDataIn, &ackResp);
+
+    if (ret != OOB_SUCCESS)
+    {
+        lg2::error(
+            "Failed to set fatal harvest delay override ({MINS} mins): {ERR}",
+            "MINS", static_cast<uint32_t>(delayDataIn.delay_val_override),
+            "ERR", ret);
+    }
+    else
+    {
+        lg2::info(
+            "Fatal harvest delay override set to {MINS} mins. "
+            "CPU will wait before resetting after syncflood.",
+            "MINS", static_cast<uint32_t>(delayDataIn.delay_val_override));
+    }
 }
 
 oob_status_t Manager::setPcieErrThreshold()

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -448,7 +448,8 @@ void Manager::init()
         "arg0='xyz.openbmc_project.State.Watchdog'",
         [this](sdbusplus::message_t& message) {
             std::string intfName;
-            std::map<std::string, std::variant<bool>> properties;
+            std::map<std::string, std::variant<bool, std::string, uint64_t>>
+                properties;
 
             try
             {
@@ -464,15 +465,15 @@ void Manager::init()
                 lg2::error("Empty PropertiesChanged signal received");
                 return;
             }
-
-            // We only want to check for currentHostState
-            if (properties.begin()->first != "Enabled")
+.
+            auto enabledIt = properties.find("Enabled");
+            if (enabledIt == properties.end())
             {
                 return;
             }
 
             bool* currentTimerEnable =
-                std::get_if<bool>(&(properties.begin()->second));
+                std::get_if<bool>(&(enabledIt->second));
 
             if (currentTimerEnable == nullptr)
             {

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -474,6 +474,11 @@ void Manager::init()
             bool* currentTimerEnable =
                 std::get_if<bool>(&(properties.begin()->second));
 
+            if (currentTimerEnable == nullptr)
+            {
+                return;
+            }
+
             if (*currentTimerEnable == false)
             {
                 sdbusplus::bus_t bus = sdbusplus::bus::new_default();
@@ -482,7 +487,7 @@ void Manager::init()
                         bus, "xyz.openbmc_project.Watchdog",
                         "/xyz/openbmc_project/watchdog/host0",
                         "xyz.openbmc_project.State.Watchdog",
-                        "currentTimerUse");
+                        "CurrentTimerUse");
 
                 if (currentTimerUse ==
                     "xyz.openbmc_project.State.Watchdog.TimerUse.BIOSFRB2")

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -465,7 +465,7 @@ void Manager::init()
                 lg2::error("Empty PropertiesChanged signal received");
                 return;
             }
-.
+
             auto enabledIt = properties.find("Enabled");
             if (enabledIt == properties.end())
             {

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -487,35 +487,24 @@ void Manager::init()
                 if (currentTimerUse ==
                     "xyz.openbmc_project.State.Watchdog.TimerUse.BIOSFRB2")
                 {
-                    if (watchdogTimerCounter >= 2)
-                    {
-                        watchdogTimerCounter = 0;
-                    }
                     watchdogTimerCounter++;
 
-                    /*Watchdog Timer Enable property will be changed twice after
-                      BIOS post complete. Platform initialization should be
-                      performed only during the second property change*/
-                    if (watchdogTimerCounter == 2)
-                    {
-                        lg2::info(
-                            "BIOS post complete. Setting MCA and DRAM OOB config");
-                        setMcaOobConfig();
+                    lg2::info(
+                        "BIOS post complete. Setting MCA and DRAM OOB config");
+                    setMcaOobConfig();
 
-                        lg2::info(
-                            "BIOS post complete. Setting MCA and DRAM error threshold");
-                        setMcaErrThreshold();
+                    lg2::info(
+                        "BIOS post complete. Setting MCA and DRAM error threshold");
+                    setMcaErrThreshold();
 
-                        lg2::info(
-                            "BIOS post complete. Setting PCIE OOb config");
-                        setPcieOobConfig();
+                    lg2::info("BIOS post complete. Setting PCIE OOb config");
+                    setPcieOobConfig();
 
-                        lg2::info("Setting PCIE Error threshold");
-                        setPcieErrThreshold();
+                    lg2::info("Setting PCIE Error threshold");
+                    setPcieErrThreshold();
 
-                        lg2::info("Setting fatal harvest delay override");
-                        setFatalHarvestDelay();
-                    }
+                    lg2::info("Setting fatal harvest delay override");
+                    setFatalHarvestDelay();
                 }
             }
         });


### PR DESCRIPTION
***Description***
Add syncflood fatal-harvest delay override, Asio D-Bus listeners, and watchdog counter reset for reliable RAS config reapply

***Changes***
1. Fatal harvest delay override (APML)
- Added `setFatalHarvestDelay()` which sends `override_delay_reset_on_sync_flood` so the CPU waits (configurable 5–120 min) before resetting after a syncflood, giving the BMC time to harvest MCA data.
- Added FatalHarvestDelayEn / FatalHarvestDelayMins config keys; called on init, reapply, and the watchdog BIOSFRB2 path.

2. Asio D-Bus listeners
- Replaced the non-Asio `sdbusplus::bus::new_default()` match listeners with a shared `sdbusplus::asio::connection` bound to the daemon `io` context.
- Fixes silently-dropped PropertiesChanged signals

3. Watchdog counter reset
- Reset `watchdogTimerCounter` to 0 when it reaches 2  before incrementing.
- Ensures the BIOSFRB2 "second toggle" reapply re-triggers on every subsequent reboot/syncflood instead of only the first boot.

***Testing***
1. Fatal harvest delay override

> journalctl | grep -i amd-ras-manager
Jun 21 19:21:01 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: Start amd ras service for host : 0
Jun 21 19:21:01 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: PARSE CONFIGURATION
Jun 21 19:21:01 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: APML MANAGER INIT
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: PLATFORM INIT
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: Setting MCA and DRAM OOB Config
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: BMC RAS oob configuration set successfully for the processor P0
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: Setting PCIE OOB Config
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: BMC RAS oob configuration set successfully for the processor P0
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: Starting seprate threads to perform runtime error polling as per user settings
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: BMC RAS oob configuration set successfully for the processor P0
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: Setting MCA error threshold
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: BMC RAS oob configuration set successfully for the processor P0
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: Setting Dram Cecc Error threshold
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: BMC RAS oob configuration set successfully for the processor P0
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: Setting PCIE error threshold
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: Setting fatal harvest delay override
Jun 21 19:21:02 bmc-heliosp-2b805-d7-2 amd-ras-manager[23230]: Fatal harvest delay override set to 5 mins. CPU will wait before resetting after syncflood.

2. Reapply RAS config on system reset and reboot
<img width="959" height="364" alt="image" src="https://github.com/user-attachments/assets/8b8119bb-bf67-4ad0-b852-e1a3f74facf8" />
