### PR TITLE
Add support for Santabarbara model

### DIFF
--- a/config/platform_default.json
+++ b/config/platform_default.json
@@ -1,6 +1,6 @@
 {
   "CpuCount": 1,
-  "Model": "0x50",
+  "Model": ["0x50", "0x51"],
   "FamilyID": "0x1A",
   "DebugLogID": [
     1,

--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -66,7 +66,7 @@ class Manager : public amd::ras::Manager
 
   private:
     size_t whFamilyId;
-    size_t whModel;
+    std::vector<size_t> whModels;
     uint8_t progId;
     size_t contextType;
     uint64_t recordId;

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -206,8 +206,9 @@ void Manager::platformInitialize()
 
         if (ret == OOB_SUCCESS)
         {
-            if ((platInfo->family == whFamilyId) &&
-                (platInfo->model == whModel))
+            bool modelMatch = std::find(whModels.begin(), whModels.end(),
+                                        platInfo->model) != whModels.end();
+            if ((platInfo->family == whFamilyId) && modelMatch)
             {
                 currentHostStateMonitor();
                 for (size_t i : socIndex)
@@ -419,8 +420,20 @@ void Manager::init()
 
     if (jsonData.contains("Model"))
     {
-        std::string modelStr = jsonData["Model"];
-        whModel = std::stoi(modelStr, nullptr, 16);
+        const auto& modelVal = jsonData["Model"];
+        if (modelVal.is_array())
+        {
+            for (const auto& m : modelVal)
+            {
+                std::string modelStr = m.get<std::string>();
+                whModels.push_back(std::stoi(modelStr, nullptr, 16));
+            }
+        }
+        else
+        {
+            std::string modelStr = modelVal.get<std::string>();
+            whModels.push_back(std::stoi(modelStr, nullptr, 16));
+        }
     }
 
     if (jsonData.contains("FamilyID"))


### PR DESCRIPTION
**Description**
Change platform model matching to accept a list of models instead of a single value, allowing SOC model 0x51 to be supported alongside 0x50.

**Changes**
- Replace singular whModel with a whModels vector and parse the "Model" JSON field as a single value or array.
- platformInitialize() now matches the detected model against the list, extending platform support to SOC model 0x51 without altering error detection or CPER generation.