### PR TITLE
amd-ras: Fix PPIN and uCode harvest

### DIFF
--- a/src/base_manager.cpp
+++ b/src/base_manager.cpp
@@ -35,6 +35,7 @@ constexpr std::string_view inventoryService =
     "xyz.openbmc_project.Inventory.Item.Cpu_info";
 constexpr std::string_view inventoryInterface =
     "xyz.openbmc_project.Inventory.Item.Cpu";
+constexpr int inventoryHarvestDelaySec = 5;
 
 void Manager::getCpuSocketInfo()
 {
@@ -102,7 +103,7 @@ void Manager::getCpuSocketInfo()
     std::memset(uCode.get(), 0, cpuCount * sizeof(uint32_t));
 
     ppin = std::make_unique<uint64_t[]>(cpuCount);
-    std::memset(uCode.get(), 0, cpuCount * sizeof(uint64_t));
+    std::memset(ppin.get(), 0, cpuCount * sizeof(uint64_t));
 
     inventoryPath = std::make_unique<std::string[]>(cpuCount);
 
@@ -116,48 +117,57 @@ void Manager::getCpuSocketInfo()
         configMgr.getAttribute("HarvestMicrocode");
     bool* uCodeVersionFlag = std::get_if<bool>(&uCodeVersion);
 
-    if (*uCodeVersionFlag == true)
-    {
-        sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
-
-        for (size_t i = 0; i < cpuCount; i++)
-        {
-            std::string microCode = amd::ras::util::getProperty<std::string>(
-                bus, inventoryService.data(), inventoryPath[i].c_str(),
-                inventoryInterface.data(), "Microcode");
-
-            if (microCode.empty())
-            {
-                lg2::error("Failed to read ucode revision");
-            }
-            else
-            {
-                uCode[i] = std::stoul(microCode, nullptr, base16);
-            }
-        }
-    }
-
     amd::ras::config::Manager::AttributeValue harvestPpin =
         configMgr.getAttribute("HarvestPPIN");
     bool* harvestPpinFlag = std::get_if<bool>(&harvestPpin);
 
-    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
-
-    if (*harvestPpinFlag == true)
+    if (*uCodeVersionFlag == true || *harvestPpinFlag == true)
     {
+        sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+
+        sleep(inventoryHarvestDelaySec);
+
         for (size_t i = 0; i < cpuCount; i++)
         {
-            std::string ppinStr = amd::ras::util::getProperty<std::string>(
-                bus, inventoryService.data(), inventoryPath[i].c_str(),
-                inventoryInterface.data(), "Id");
+            if (*uCodeVersionFlag == true)
+            {
+                uint32_t microCode = amd::ras::util::getProperty<uint32_t>(
+                    bus, inventoryService.data(), inventoryPath[i].c_str(),
+                    inventoryInterface.data(), "Microcode");
 
-            if (ppinStr.empty())
-            {
-                lg2::error("Failed to read ppin");
+                if (microCode == 0)
+                {
+                    lg2::error(
+                        "Failed to read ucode revision for socket {SOC} from {PATH}",
+                        "SOC", socIndex[i], "PATH", inventoryPath[i]);
+                }
+                else
+                {
+                    uCode[i] = microCode;
+                    lg2::info(
+                        "Read ucode revision for socket {SOC}: {UCODE}",
+                        "SOC", socIndex[i], "UCODE", lg2::hex, microCode);
+                }
             }
-            else
+
+            if (*harvestPpinFlag == true)
             {
-                ppin[i] = std::stoul(ppinStr, nullptr, base16);
+                uint64_t ppinVal = amd::ras::util::getProperty<uint64_t>(
+                    bus, inventoryService.data(), inventoryPath[i].c_str(),
+                    inventoryInterface.data(), "Id");
+
+                if (ppinVal == 0)
+                {
+                    lg2::error(
+                        "Failed to read ppin for socket {SOC} from {PATH}",
+                        "SOC", socIndex[i], "PATH", inventoryPath[i]);
+                }
+                else
+                {
+                    ppin[i] = ppinVal;
+                    lg2::info("Read ppin for socket {SOC}: {PPIN}", "SOC",
+                              socIndex[i], "PPIN", lg2::hex, ppinVal);
+                }
             }
         }
     }

--- a/src/base_manager.cpp
+++ b/src/base_manager.cpp
@@ -35,7 +35,6 @@ constexpr std::string_view inventoryService =
     "xyz.openbmc_project.Inventory.Item.Cpu_info";
 constexpr std::string_view inventoryInterface =
     "xyz.openbmc_project.Inventory.Item.Cpu";
-constexpr int inventoryHarvestDelaySec = 5;
 
 void Manager::getCpuSocketInfo()
 {
@@ -124,8 +123,6 @@ void Manager::getCpuSocketInfo()
     if (*uCodeVersionFlag == true || *harvestPpinFlag == true)
     {
         sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
-
-        sleep(inventoryHarvestDelaySec);
 
         for (size_t i = 0; i < cpuCount; i++)
         {

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -294,7 +294,6 @@ ReturnType getProperty(sdbusplus::bus::bus& bus, const char* service,
     {
         lg2::info("GetProperty call failed");
     }
-
     return std::get<ReturnType>(value);
 }
 

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -267,6 +267,14 @@ template uint16_t getProperty(sdbusplus::bus::bus& bus, const char* service,
                               const char* path, const char* interface,
                               const char* propertyName);
 
+template uint32_t getProperty(sdbusplus::bus::bus& bus, const char* service,
+                              const char* path, const char* interface,
+                              const char* propertyName);
+
+template uint64_t getProperty(sdbusplus::bus::bus& bus, const char* service,
+                              const char* path, const char* interface,
+                              const char* propertyName);
+
 template <typename ReturnType>
 ReturnType getProperty(sdbusplus::bus::bus& bus, const char* service,
                        const char* path, const char* interface,
@@ -286,6 +294,7 @@ ReturnType getProperty(sdbusplus::bus::bus& bus, const char* service,
     {
         lg2::info("GetProperty call failed");
     }
+
     return std::get<ReturnType>(value);
 }
 


### PR DESCRIPTION
getCpuSocketInfo() read Microcode and Id (PPIN) as std::string, but the xyz.openbmc_project.Inventory.Item.Cpu interface defines them as uint32_t and uint64_t. D-Bus GetProperty failed on type mismatch, producing "Failed to read ppin" and "Failed to read ucode revision" even when cpu-info had valid values.

Read both properties with the correct numeric types via getProperty<uint32_t> and getProperty<uint64_t>. Add explicit template instantiations.

Tested:
- Tested on SP7
- ucode and PPIN available in journal logs