### PR TITLE
Set FruString to "SmnError" for break events

### DIFF
--- a/src/base_manager.cpp
+++ b/src/base_manager.cpp
@@ -415,8 +415,13 @@ void Manager::harvestBreakEvent(uint8_t socNum)
                                              breakEventBanks);
     amd::ras::util::cper::dumpContext(rcd, breakEventBanks, 0, socNum, ppin,
                                       uCode, breakEventContext);
-    std::memcpy(rcd->SectionDescriptor[socNum].FruString, &socNum,
-                sizeof(socNum));
+
+    for (uint16_t section = 0; section < sectionCount; ++section)
+    {
+        std::memset(rcd->SectionDescriptor[section].FruString, 0, 20);
+        std::strncpy(rcd->SectionDescriptor[section].FruString, "SmnError", 19);
+        rcd->SectionDescriptor[section].FruString[19] = '\0';
+    }
 
     for (size_t offset = 0; offset < regCount; ++offset)
     {


### PR DESCRIPTION
Align with the in-band BERT implementation, which reports the FruString field as "SmnError" for break events.

Previously, harvestBreakEvent() populated the FruString field of each section descriptor by copying the raw socket number. Update the implementation to populate the FruString field of all section descriptors with the "SmnError" label instead, ensuring consistent event reporting across implementations.

Tests:
Verified the FRU string updated as expected in CPER of break events.