### PR TITLE
Support node-specific host reset operations

### DIFF
--- a/include/utils/util.hpp
+++ b/include/utils/util.hpp
@@ -58,22 +58,24 @@ bool compareBitwiseAnd(const uint32_t*, const std::string& hexString);
  * @details This function handles various host state transitions as specified by
  * the command string.
  *
+ * @param node The host state instance suffix ("0" in normal mode, "1"/"2" in
+ * 2*1P mode) used to select xyz.openbmc_project.State.Host{node}.
  * @param command The command string specifying the desired host state
  * transition.
  */
-void requestHostTransition(std::string);
+void requestHostTransition(const std::string& node, std::string);
 
 /** @brief Triggers RSMRST signal.
  *
  * @details This function triggers a reset of the RSMRST (Resume Reset) signal.
  */
-void triggerRsmrstReset();
+void triggerRsmrstReset(const std::string& node);
 
 /** @brief Initiates a system reset.
  *
  * @details This function triggers system reset using D-Bus calls.
  */
-void triggerSysReset();
+void triggerSysReset(const std::string& node);
 
 /** @brief Triggers a cold reset.
  *
@@ -81,7 +83,7 @@ void triggerSysReset();
  *
  * @param Type of the cold reset signal to be executed.
  */
-void triggerColdReset(const std::string*);
+void triggerColdReset(const std::string& node, const std::string*);
 
 /** @brief Initiates a warm reset.
  *

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -129,12 +129,15 @@ bool compareBitwiseAnd(const uint32_t* Var, const std::string& hexString)
 constexpr size_t sysMgmtCtrlErr = 0x4;
 constexpr size_t socket0 = 0;
 
-void requestHostTransition(std::string command)
+void requestHostTransition(const std::string& node, std::string command)
 {
     boost::system::error_code ec;
     boost::asio::io_context io;
     auto conn = std::make_shared<sdbusplus::asio::connection>(io);
 
+    std::string hostService = "xyz.openbmc_project.State.Host" + node;
+    std::string hostPath = "/xyz/openbmc_project/state/host" + node;
+
     conn->async_method_call(
         [](boost::system::error_code ec) {
             if (ec)
@@ -142,18 +145,22 @@ void requestHostTransition(std::string command)
                 lg2::error("Failed to trigger cold reset of the system\n");
             }
         },
-        "xyz.openbmc_project.State.Host", "/xyz/openbmc_project/state/host0",
-        "org.freedesktop.DBus.Properties", "Set",
+        hostService, hostPath, "org.freedesktop.DBus.Properties", "Set",
         "xyz.openbmc_project.State.Host", "RequestedHostTransition",
         std::variant<std::string>{command});
 }
 
-void triggerRsmrstReset()
+void triggerRsmrstReset(const std::string& node)
 {
     boost::system::error_code ec;
     boost::asio::io_context io_conn;
     auto conn = std::make_shared<sdbusplus::asio::connection>(io_conn);
 
+    std::string hostService = "xyz.openbmc_project.State.Host" + node;
+    std::string hostPath = "/xyz/openbmc_project/state/host" + node;
+    std::string socResetPath =
+        "/xyz/openbmc_project/control/host" + node + "/SOCReset";
+
     conn->async_method_call(
         [](boost::system::error_code ec) {
             if (ec)
@@ -161,43 +168,41 @@ void triggerRsmrstReset()
                 lg2::error("Failed to trigger cold reset of the system\n");
             }
         },
-        "xyz.openbmc_project.State.Host",
-        "/xyz/openbmc_project/control/host0/SOCReset",
-        "xyz.openbmc_project.Control.Host.SOCReset", "SOCReset");
+        hostService, socResetPath, "xyz.openbmc_project.Control.Host.SOCReset",
+        "SOCReset");
 
     sleep(1);
     sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
     std::string currentHostState = amd::ras::util::getProperty<std::string>(
-        bus, "xyz.openbmc_project.State.Host",
-        "/xyz/openbmc_project/state/host0", "xyz.openbmc_project.State.Host",
-        "currentHostState");
+        bus, hostService.c_str(), hostPath.c_str(),
+        "xyz.openbmc_project.State.Host", "currentHostState");
 
     if (currentHostState.compare(
             "xyz.openbmc_project.State.Host.HostState.Off") == 0)
     {
         std::string command = "xyz.openbmc_project.State.Host.Transition.On";
-        requestHostTransition(command);
+        requestHostTransition(node, command);
     }
 }
 
-void triggerSysReset()
+void triggerSysReset(const std::string& node)
 {
     std::string command = "xyz.openbmc_project.State.Host.Transition.Reboot";
 
-    requestHostTransition(command);
+    requestHostTransition(node, command);
 }
 
-void triggerColdReset(const std::string* resetSignal)
+void triggerColdReset(const std::string& node, const std::string* resetSignal)
 {
     if (*resetSignal == "RSMRST")
     {
         lg2::info("RSMRST reset triggered");
-        triggerRsmrstReset();
+        triggerRsmrstReset(node);
     }
     else if (*resetSignal == "SYS_RST")
     {
         lg2::info("SYS_RST signal triggered");
-        triggerSysReset();
+        triggerSysReset(node);
     }
 }
 
@@ -238,7 +243,7 @@ void rasRecoveryAction(std::string& node, uint8_t buf,
     {
         if ((buf & sysMgmtCtrlErr))
         {
-            triggerColdReset(resetSignal);
+            triggerColdReset(node, resetSignal);
         }
         else
         {
@@ -247,7 +252,7 @@ void rasRecoveryAction(std::string& node, uint8_t buf,
     }
     else if (*systemRecovery == "COLD_RESET")
     {
-        triggerColdReset(resetSignal);
+        triggerColdReset(node, resetSignal);
     }
     else if (*systemRecovery == "NO_RESET")
     {


### PR DESCRIPTION
Add a node parameter to host transition and reset helper functions to support multi-host configurations (e.g. 2x1P systems).

Changes:
- Pass node identifier to requestHostTransition()
- Update RSMRST and SYS_RST reset handlers to use node-specific D-Bus service and object paths

Impact:
- Enables reset and host state operations on the correct host instance instead of being hardcoded to host0

Tests:
Verified the reset functionality successfully.