### PR TITLE
Add DRAM CECC and fatal harvest delay config options

### DIFF
--- a/config/ras_config.json
+++ b/config/ras_config.json
@@ -76,9 +76,36 @@
             }
         },
         {
+            "FatalHarvestDelayEn": {
+                "Description": "Enable fatal error harvest delay to preserve time for MCA data collection prior to reset after a fatal CPU error.",
+                "Value": true
+            }
+        },
+        {
+            "FatalHarvestDelayMins": {
+                "Description": "Reset delay in minutes after a fatal CPU error to allow MCA data collection (5-120).",
+                "Value": 5,
+                "MaxBoundLimit": 120
+            }
+        },
+        {
             "DramCeccPollingEn": {
                 "Description": "If this field is true, Dynamic Random Access Memory Error Correction Code (DRAM ECC) correctable errors will be polled",
                 "Value": false
+            }
+        },
+        {
+            "DramCeccOobEcMode": {
+                "Description": "DRAM CECC OOB error counter mode: 0=disabled, 1=no-leak mode, 2=leaky bucket mode",
+                "Value": 2,
+                "MaxBoundLimit": 2
+            }
+        },
+        {
+            "DramCeccLeakRate": {
+                "Description": "DRAM CECC leaky bucket leak rate (0x00-0x1F). Only used when DramCeccOobEcMode=2",
+                "Value": 20,
+                "MaxBoundLimit": 31
             }
         },
         {

--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -251,6 +251,14 @@ class Manager : public amd::ras::Manager
      */
     oob_status_t setPcieErrThreshold();
 
+    /** @brief Set fatal harvest delay override.
+     *
+     *  @details Sends override_delay_reset_on_sync_flood command to CPU
+     *  so the system waits (configurable 5-120 mins) before resetting
+     *  after a syncflood, giving BMC time to harvest MCA data.
+     */
+    void setFatalHarvestDelay();
+
     /** @brief Clear the SBRMI alert mask bit.
      *
      *  @details Clears alert mask bit in SBRMI control register

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -212,6 +212,18 @@ void Manager::platformInitialize()
         if (runtimeErrPollingSupported == true)
         {
             runTimeErrorPolling();
+
+            lg2::info("Setting MCA and DRAM OOB Config");
+
+            setMcaOobConfig();
+
+            lg2::info("Setting MCA and DRAM Error threshold");
+
+            setMcaErrThreshold();
+
+            lg2::info("Setting fatal harvest delay override");
+
+            setFatalHarvestDelay();
         }
     }
 }
@@ -413,6 +425,9 @@ void Manager::init()
 
                         lg2::info("Setting PCIE Error threshold");
                         setPcieErrThreshold();
+
+                        lg2::info("Setting fatal harvest delay override");
+                        setFatalHarvestDelay();
                     }
                 }
             }
@@ -2931,6 +2946,8 @@ oob_status_t Manager::getOobRegisters(struct oob_config_d_in* oob_config)
             (dataOut >> MCA_ERR_REPORT_EN & 1);
         oob_config->dram_cecc_oob_ec_mode =
             (dataOut >> DRAM_CECC_OOB_EC_MODE & TRIBBLE_BITS);
+        oob_config->dram_cecc_leak_rate =
+            (dataOut >> DRAM_CECC_LEAK_RATE) & 0x1F;
         oob_config->pcie_err_reporting_en = (dataOut >> PCIE_ERR_REPORT_EN & 1);
         oob_config->mca_oob_misc0_ec_enable = (dataOut & 1);
     }
@@ -3039,7 +3056,19 @@ oob_status_t Manager::setMcaErrThreshold()
 
         getOobRegisters(&oob_config);
 
-        oob_config.dram_cecc_oob_ec_mode = 1;
+        amd::ras::config::Manager::AttributeValue dramCeccOobEcModeVal =
+            configMgr.getAttribute("DramCeccOobEcMode");
+        int64_t* dramCeccOobEcMode =
+            std::get_if<int64_t>(&dramCeccOobEcModeVal);
+
+        amd::ras::config::Manager::AttributeValue dramCeccLeakRateVal =
+            configMgr.getAttribute("DramCeccLeakRate");
+        int64_t* dramCeccLeakRate = std::get_if<int64_t>(&dramCeccLeakRateVal);
+
+        oob_config.dram_cecc_oob_ec_mode =
+            static_cast<uint8_t>(*dramCeccOobEcMode);
+        oob_config.dram_cecc_leak_rate =
+            static_cast<uint8_t>(*dramCeccLeakRate);
         oob_config.mca_oob_misc0_ec_enable = 1;
 
         ret = setRasOobConfig(oob_config);
@@ -3122,6 +3151,10 @@ void Manager::runTimeErrorPolling()
                        "Error code: {ERR}",
                        "ERR", ret);
         }
+
+        lg2::info("Setting fatal harvest delay override");
+
+        setFatalHarvestDelay();
     }
 }
 
@@ -3142,6 +3175,8 @@ oob_status_t Manager::getRasOobConfig(struct oob_config_d_in* oob_config)
             (dataOut >> PCIE_ERR_REPORT_EN & 1);
         oob_config->dram_cecc_oob_ec_mode =
             (dataOut >> DRAM_CECC_OOB_EC_MODE & TRIBBLE_BITS);
+        oob_config->dram_cecc_leak_rate =
+            (dataOut >> DRAM_CECC_LEAK_RATE) & 0x1F;
         oob_config->pcie_err_reporting_en = (dataOut >> PCIE_ERR_REPORT_EN & 1);
         oob_config->mca_oob_misc0_ec_enable = (dataOut & 1);
     }
@@ -3172,8 +3207,37 @@ oob_status_t Manager::setMcaOobConfig()
     if (*dramCeccPollingEn == true)
     {
         /* DRAM CECC OOB Error Counter Mode */
+        amd::ras::config::Manager::AttributeValue dramCeccOobEcModeVal =
+            configMgr.getAttribute("DramCeccOobEcMode");
+        int64_t* dramCeccOobEcMode =
+            std::get_if<int64_t>(&dramCeccOobEcModeVal);
+
+        amd::ras::config::Manager::AttributeValue dramCeccLeakRateVal =
+            configMgr.getAttribute("DramCeccLeakRate");
+        int64_t* dramCeccLeakRate = std::get_if<int64_t>(&dramCeccLeakRateVal);
+
         oob_config.core_mca_err_reporting_en = 1;
-        oob_config.dram_cecc_oob_ec_mode = 1; /*Enabled in No leak mode*/
+        oob_config.dram_cecc_oob_ec_mode =
+            static_cast<uint8_t>(*dramCeccOobEcMode);
+        oob_config.dram_cecc_leak_rate =
+            static_cast<uint8_t>(*dramCeccLeakRate);
+    }
+    else
+    {
+        amd::ras::config::Manager::AttributeValue dramCeccOobEcModeVal =
+            configMgr.getAttribute("DramCeccOobEcMode");
+        int64_t* dramCeccOobEcMode =
+            std::get_if<int64_t>(&dramCeccOobEcModeVal);
+
+        amd::ras::config::Manager::AttributeValue dramCeccLeakRateVal =
+            configMgr.getAttribute("DramCeccLeakRate");
+        int64_t* dramCeccLeakRate = std::get_if<int64_t>(&dramCeccLeakRateVal);
+
+        oob_config.dram_cecc_oob_ec_mode =
+            static_cast<uint8_t>(*dramCeccOobEcMode);
+        oob_config.dram_cecc_leak_rate =
+            static_cast<uint8_t>(*dramCeccLeakRate);
+        oob_config.mca_oob_misc0_ec_enable = 1;
     }
 
     ret = setRasOobConfig(oob_config);
@@ -3307,6 +3371,58 @@ oob_status_t Manager::setPcieErrThreshold()
         }
     }
     return ret;
+}
+
+void Manager::setFatalHarvestDelay()
+{
+    amd::ras::config::Manager::AttributeValue fatalDelayEnVal =
+        configMgr.getAttribute("FatalHarvestDelayEn");
+    bool* fatalHarvestDelayEn = std::get_if<bool>(&fatalDelayEnVal);
+
+    if (fatalHarvestDelayEn == nullptr || *fatalHarvestDelayEn == false)
+    {
+        return;
+    }
+
+    amd::ras::config::Manager::AttributeValue fatalDelayMinsVal =
+        configMgr.getAttribute("FatalHarvestDelayMins");
+    int64_t* fatalHarvestDelayMins = std::get_if<int64_t>(&fatalDelayMinsVal);
+
+    if (fatalHarvestDelayMins == nullptr)
+    {
+        return;
+    }
+
+    struct ras_override_delay delayDataIn = {0, 0, 0};
+    bool ackResp = false;
+
+    int64_t mins = *fatalHarvestDelayMins;
+    if (mins >= 5 && mins <= 120)
+    {
+        delayDataIn.delay_val_override = static_cast<uint8_t>(mins);
+    }
+    else
+    {
+        delayDataIn.delay_val_override = 5; // minimum safe fallback
+    }
+
+    oob_status_t ret =
+        override_delay_reset_on_sync_flood(socIndex[0], delayDataIn, &ackResp);
+
+    if (ret != OOB_SUCCESS)
+    {
+        lg2::error(
+            "Failed to set fatal harvest delay override ({MINS} mins): {ERR}",
+            "MINS", static_cast<uint32_t>(delayDataIn.delay_val_override),
+            "ERR", ret);
+    }
+    else
+    {
+        lg2::info("Fatal harvest delay override set to {MINS} mins. "
+                  "CPU will wait before resetting after syncflood.",
+                  "MINS",
+                  static_cast<uint32_t>(delayDataIn.delay_val_override));
+    }
 }
 
 template <typename PtrType>


### PR DESCRIPTION
**Description**
Add configurable DRAM CECC OOB error counter mode and fatal harvest delay override to ras_config.json.

**Changes**
  1. DRAM CECC OOB Config
     - Added `DramCeccOobEcMode` config (0=disabled, 1=no-leak, 2=leaky bucket)
     - Added `DramCeccLeakRate` config (0x00-0x1F leak rate)
     - Replaces hardcoded `dram_cecc_oob_ec_mode = 1` with configurable values

  2. Fatal Harvest Delay Override
     - Added `setFatalHarvestDelay()` to call `override_delay_reset_on_sync_flood`
     - Added `FatalHarvestDelayEn` / `FatalHarvestDelayMins` config keys
     - Called on init, reconfig, and watchdog BIOSFRB2 path
     - Gives BMC time (5-120 mins) to harvest MCA data before syncflood reset

 **Testing**
  - JSON validated
  - Tested on the MI450 Platform
  - ***Fatal delay harvest override taking effect*** - 
[Fatal harvest delay test log.txt](https://github.com/user-attachments/files/30725523/Fatal.harvest.delay.test.log.txt)

**References**
https://github.com/AMDESE/amd-bmc-ras/pull/154
https://github.com/AMDESE/amd-bmc-ras/pull/179
