### PR TITLE
Enable early sysMgmtCtrlErr handling before PMFW availability

### DIFF
--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -94,12 +94,11 @@ class Manager : public amd::ras::Manager
 
   private:
     sdbusplus::asio::object_server& objectServer;
-    std::shared_ptr<sdbusplus::asio::connection>& systemBus;
 
     size_t contextType;
     size_t watchdogTimerCounter;
     boost::asio::io_context& io;
-    bool apmlInitialized;
+    bool pmfwRuntimeReady;
     bool platformInitialized;
     bool runtimeErrPollingSupported;
     std::vector<bool> cpuAlertProcessed;
@@ -154,6 +153,22 @@ class Manager : public amd::ras::Manager
      */
     void alertEventHandler(boost::asio::posix::stream_descriptor&,
                            const gpiod::line&, size_t);
+
+    /** @brief Handle the transition to the PMFW-ready state.
+     *
+     *  @details Performs the platform initialization that requires PMFW
+     *  (processor info, thresholds, runtime error polling) and reads CPUIDs.
+     *  Deferred until PMFW is ready.
+     */
+    void pmfwReadyHandler() override;
+
+    /** @brief Handle the transition to the PMFW-not-ready state.
+     *
+     *  @details Tears down platform initialization by stopping runtime error
+     *  polling and clearing pmfwRuntimeReady so runtime validity checks are
+     *  skipped until PMFW is ready again.
+     */
+    void pmfwNotReadyHandler() override;
 
     /** @brief Stream descriptor for handling  APML alert events.
      *

--- a/include/base_manager.hpp
+++ b/include/base_manager.hpp
@@ -3,6 +3,9 @@
 #include "config_manager.hpp"
 #include "oem_cper.hpp"
 
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/bus/match.hpp>
+
 #include <algorithm>
 #include <mutex>
 
@@ -15,6 +18,15 @@ namespace amd
 {
 namespace ras
 {
+// PMFW readiness notification contract (single D-Bus signal emitted by
+// amd-host-manager). Shared by the APML and PLDM managers to defer the
+// PMFW-dependent platform initialization until PMFW is ready, and to tear it
+// down when PMFW is not ready. The signal carries the readiness state as a
+// boolean argument (true = ready, false = not ready).
+constexpr auto pmfwStatusInterface = "com.amd.PmfwStatus";
+constexpr auto pmfwStatusPathPrefix = "/com/amd/pmfw/host";
+constexpr auto pmfwStatusSignal = "PmfwStatus";
+
 struct CpuId
 {
     uint32_t eax;
@@ -41,7 +53,8 @@ class Manager
     Manager(const Manager&) = delete;
     Manager(Manager&&) = delete;
     Manager& operator=(Manager&&) = delete;
-    Manager(amd::ras::config::Manager&, std::string&);
+    Manager(amd::ras::config::Manager&,
+            std::shared_ptr<sdbusplus::asio::connection>&, std::string&);
     ~Manager() = default;
 
     /** @brief Initializes the RAS manager class.
@@ -95,6 +108,69 @@ class Manager
     std::vector<uint8_t> blockId;
     std::mutex harvestMutex;
     bool fatalDescriptorsInitialized = false;
+
+    /** @brief Shared D-Bus system bus connection.
+     *
+     *  @details Used by the common PMFW status signal subscription and by
+     *  derived transports for their D-Bus interactions.
+     */
+    std::shared_ptr<sdbusplus::asio::connection> systemBus;
+
+    /** @brief Current PMFW readiness state.
+     *
+     *  @details False until the PMFW ready notification is received. Used to
+     *  gate PMFW-dependent handling and to reflect a single source of truth
+     *  for the PMFW state shared by the APML and PLDM managers.
+     */
+    bool pmfwReady = false;
+
+    /** @brief D-Bus match rule for the PMFW status notification signal. */
+    std::unique_ptr<sdbusplus::bus::match_t> pmfwStatusMatch;
+
+    /** @brief Subscribe to the PMFW status signal from amd-host-manager.
+     *
+     *  @details Registers a single D-Bus signal match for the per-node PMFW
+     *  status object. The signal carries the readiness state as a boolean
+     *  argument; on notification it updates pmfwReady and dispatches to the
+     *  transport-specific handlers via applyPmfwStatus(). Shared by the APML
+     *  and PLDM managers.
+     */
+    void subscribePmfwSignals();
+
+    /** @brief Apply a PMFW readiness state change.
+     *
+     *  @details Common handling shared by the APML and PLDM managers: records
+     *  the new pmfwReady state and dispatches to the transport-specific
+     *  pmfwReadyHandler() or pmfwNotReadyHandler().
+     *
+     *  @param[in] ready - true if PMFW is ready; false otherwise.
+     */
+    void applyPmfwStatus(bool ready);
+
+    /** @brief Reconcile PMFW state when the host is already powered on.
+     *
+     *  @details The PMFW status signal is transient. If the host is already
+     *  powered on when this service starts (e.g. a RAS restart while the host
+     *  is running), the ready notification may have been missed. This common
+     *  helper applies the ready state now so platform initialization is not
+     *  skipped. Shared by the APML and PLDM managers.
+     */
+    void reconcilePmfwState();
+
+    /** @brief Handle the transition to the PMFW-ready state.
+     *
+     *  @details Derived classes override this to perform the transport-specific
+     *  platform initialization that requires PMFW.
+     */
+    virtual void pmfwReadyHandler() = 0;
+
+    /** @brief Handle the transition to the PMFW-not-ready state.
+     *
+     *  @details Derived classes override this to tear down the
+     *  transport-specific platform initialization while keeping the alert
+     *  handlers armed to service system management control errors.
+     */
+    virtual void pmfwNotReadyHandler() = 0;
 
     /** @brief Get the CPU socket information.
      *

--- a/include/base_manager.hpp
+++ b/include/base_manager.hpp
@@ -196,6 +196,18 @@ class Manager
      */
     void currentHostStateMonitor();
 
+    /** @brief Query whether the host is currently powered on.
+     *
+     *  @details Reads the CurrentHostState property of the per-node
+     *  xyz.openbmc_project.State.Host object. Used to avoid blocking SBRMI
+     *  access while the host is off and to reconcile PMFW state on a RAS
+     *  restart (the PMFW ready/off signals are transient).
+     *
+     *  @return true if the host is not in the Off state; false on Off or on
+     *  query failure.
+     */
+    bool isHostPoweredOn();
+
     /** @brief Called when the host power state changes.
      *
      *  @details Derived classes override this to perform

--- a/include/pldm_manager.hpp
+++ b/include/pldm_manager.hpp
@@ -99,7 +99,6 @@ class Manager : public amd::ras::Manager
 
   private:
     sdbusplus::asio::object_server& objectServer;
-    std::shared_ptr<sdbusplus::asio::connection>& systemBus;
     boost::asio::io_context& io;
 
     // Indicates whether the PLDM subsystem has been initialized
@@ -136,6 +135,19 @@ class Manager : public amd::ras::Manager
      *  error reporting.
      */
     void platformInitialize();
+
+    /** @brief Handle the transition to the PMFW-ready state.
+     *
+     *  @details Performs the platform initialization that requires PMFW.
+     *  Deferred until PMFW is ready.
+     */
+    void pmfwReadyHandler() override;
+
+    /** @brief Handle the transition to the PMFW-not-ready state.
+     *
+     *  @details Marks the platform uninitialized.
+     */
+    void pmfwNotReadyHandler() override;
 
     /** @brief Handles incoming PLDM RAS event signals.
      *

--- a/service_files/com.amd.RAS@.service
+++ b/service_files/com.amd.RAS@.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=AMD RAS Manager
 After=multi-host-config.service
-After=amd-host-mgr@.service
 ConditionPathExists=/etc/amd/hosts.d/host%i.conf
 
 [Service]

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -112,18 +112,17 @@ Manager::Manager(amd::ras::config::Manager& manager,
                  sdbusplus::asio::object_server& objectServer,
                  std::shared_ptr<sdbusplus::asio::connection>& systemBus,
                  boost::asio::io_context& io, std::string& node) :
-    amd::ras::Manager(manager, node), objectServer(objectServer),
-    systemBus(systemBus), watchdogTimerCounter(0), io(io),
-    apmlInitialized(false), platformInitialized(false),
-    runtimeErrPollingSupported(false), McaErrorPollingEvent(nullptr),
-    DramCeccErrorPollingEvent(nullptr), PcieAerErrorPollingEvent(nullptr),
-    ApmlAlertEvent(nullptr), mcaErrorHarvestMtx(), dramErrorHarvestMtx(),
-    pcieErrorHarvestMtx()
+    amd::ras::Manager(manager, systemBus, node), objectServer(objectServer),
+    watchdogTimerCounter(0), io(io), pmfwRuntimeReady(false),
+    platformInitialized(false), runtimeErrPollingSupported(false),
+    McaErrorPollingEvent(nullptr), DramCeccErrorPollingEvent(nullptr),
+    PcieAerErrorPollingEvent(nullptr), ApmlAlertEvent(nullptr),
+    mcaErrorHarvestMtx(), dramErrorHarvestMtx(), pcieErrorHarvestMtx()
 {}
 
 void Manager::onHostStateChanged(bool hostOff)
 {
-    apmlInitialized = false;
+    pmfwRuntimeReady = false;
 
     if (!hostOff)
     {
@@ -192,7 +191,7 @@ void Manager::platformInitialize()
             }
 
             platformInitialized = true;
-            apmlInitialized = true;
+            pmfwRuntimeReady = true;
         }
         else
         {
@@ -201,22 +200,19 @@ void Manager::platformInitialize()
     }
     else
     {
-        apmlInitialized = true;
+        pmfwRuntimeReady = true;
 
         for (size_t i : socIndex)
         {
             clearSbrmiAlertMask(i);
         }
 
+        // On re-ready after a PMFW off, the runtime polling timers were
+        // cancelled in pmfwNotReadyHandler(). Re-arm them here (the first
+        // initialization above starts them via runTimeErrorPolling()).
         if (runtimeErrPollingSupported == true)
         {
-            lg2::info("Setting MCA and DRAM OOB Config");
-
-            setMcaOobConfig();
-
-            lg2::info("Setting MCA and DRAM Error threshold");
-
-            setMcaErrThreshold();
+            runTimeErrorPolling();
         }
     }
 }
@@ -325,8 +321,6 @@ void Manager::pcieAerErrorPollingHandler(int64_t* pollingPeriod)
 void Manager::init()
 {
     lg2::info("APML MANAGER INIT");
-    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
-    uint32_t dataOut = 0;
 
     getCpuSocketInfo();
 
@@ -349,20 +343,14 @@ void Manager::init()
         throw std::runtime_error("Failed to copy gpio config file");
     }
 
-    while (ret != OOB_SUCCESS)
-    {
-        ret = get_bmc_ras_oob_config(0, &dataOut);
-
-        if (ret == OOB_MAILBOX_CMD_UNKNOWN)
-        {
-            ret = esmi_get_processor_info(0, plat_info);
-        }
-        sleep(1);
-    }
-
+    // Load platform metadata (Model, FamilyID, DebugLogID) from JSON. This
+    // does not require PMFW and is needed by alert handling and the deferred
+    // platform initialization performed when PMFW becomes ready.
     loadPlatformConfig();
 
-    platformInitialize();
+    // Platform initialization (processor info, thresholds, runtime error
+    // polling) and CPUID reads require PMFW. They are deferred until the PMFW
+    // ready signal is received from amd-host-manager.
 
     sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
     boost::system::error_code ec;
@@ -431,6 +419,34 @@ void Manager::init()
             }
         });
 
+    // Subscribe for PMFW readiness notifications from amd-host-manager. The
+    // deferred platform initialization runs when the ready signal arrives.
+    subscribePmfwSignals();
+}
+
+void Manager::pmfwReadyHandler()
+{
+    // Perform platform initialization now that the PMFW mailbox is available.
+    // Guard against exceptions (e.g. unsupported family) so the service keeps
+    // running to service system management control errors. platformInitialize()
+    // starts runtime error polling on first init and re-arms it on re-ready.
+    try
+    {
+        platformInitialize();
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Platform initialization failed on PMFW ready: {ERROR}",
+                   "ERROR", e.what());
+        return;
+    }
+
+    if (pmfwRuntimeReady == false)
+    {
+        lg2::error("Platform initialization did not complete on PMFW ready");
+        return;
+    }
+
     /*Read CpuID*/
     for (size_t i = 0; i < cpuCount; i++)
     {
@@ -448,6 +464,28 @@ void Manager::init()
         {
             lg2::error("Failed to get the CPUID for socket {CPU}", "CPU", i);
         }
+    }
+}
+
+void Manager::pmfwNotReadyHandler()
+{
+    // Keep the alert handlers armed so system management control errors are
+    // still serviced without PMFW, but tear down platform initialization:
+    // stop runtime error polling and clear pmfwRuntimeReady so runtime
+    // validity checks are skipped until PMFW is ready again.
+    pmfwRuntimeReady = false;
+
+    if (McaErrorPollingEvent != nullptr)
+    {
+        McaErrorPollingEvent->cancel();
+    }
+    if (DramCeccErrorPollingEvent != nullptr)
+    {
+        DramCeccErrorPollingEvent->cancel();
+    }
+    if (PcieAerErrorPollingEvent != nullptr)
+    {
+        PcieAerErrorPollingEvent->cancel();
     }
 }
 
@@ -557,6 +595,8 @@ void Manager::registerEventHandler()
                               gpioLines[i], gpioEventDescriptors[i]);
         }
     }
+
+    reconcilePmfwState();
 }
 
 void Manager::releaseUdevReSrc()
@@ -1001,7 +1041,7 @@ oob_status_t Manager::runTimeErrValidityCheck(
 {
     oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
 
-    if (apmlInitialized == true)
+    if (pmfwRuntimeReady == true)
     {
         ret =
             get_bmc_ras_run_time_err_validity_ck(socNum, rt_err_category, inst);

--- a/src/base_manager.cpp
+++ b/src/base_manager.cpp
@@ -130,19 +130,17 @@ void Manager::getCpuSocketInfo()
             {
                 try
                 {
-                    uint32_t microCode =
-                        amd::ras::util::getProperty<uint32_t>(
-                            bus, inventoryService.data(),
-                            inventoryPath[i].c_str(),
-                            inventoryInterface.data(), "Microcode");
+                    uint32_t microCode = amd::ras::util::getProperty<uint32_t>(
+                        bus, inventoryService.data(), inventoryPath[i].c_str(),
+                        inventoryInterface.data(), "Microcode");
 
                     uCode[i] = microCode;
                     lg2::info("Microcode = {VAL}", "VAL", lg2::hex, microCode);
                 }
                 catch (const std::exception& e)
                 {
-                    lg2::error("Failed to get Microcode property: {ERR}",
-                               "ERR", e.what());
+                    lg2::error("Failed to get Microcode property: {ERR}", "ERR",
+                               e.what());
                 }
             }
 
@@ -151,8 +149,7 @@ void Manager::getCpuSocketInfo()
                 try
                 {
                     uint64_t ppinVal = amd::ras::util::getProperty<uint64_t>(
-                        bus, inventoryService.data(),
-                        inventoryPath[i].c_str(),
+                        bus, inventoryService.data(), inventoryPath[i].c_str(),
                         inventoryInterface.data(), "Id");
 
                     ppin[i] = ppinVal;
@@ -169,11 +166,77 @@ void Manager::getCpuSocketInfo()
     amd::ras::util::cper::createIndexFile(errCount, node);
 }
 
-Manager::Manager(amd::ras::config::Manager& manager, std::string& node) :
+Manager::Manager(amd::ras::config::Manager& manager,
+                 std::shared_ptr<sdbusplus::asio::connection>& systemBus,
+                 std::string& node) :
     errCount(0), progId(1), recordId(1), configMgr(manager), rcd(nullptr),
     mcaPtr(nullptr), dramPtr(nullptr), pciePtr(nullptr),
-    coreDebugDumpPtr(nullptr), node(node), whFamilyId(0)
+    coreDebugDumpPtr(nullptr), node(node), whFamilyId(0), systemBus(systemBus)
 {}
+
+void Manager::subscribePmfwSignals()
+{
+    std::string pmfwPath = std::string(pmfwStatusPathPrefix) + node;
+
+    std::string matchRule =
+        "type='signal',interface='" + std::string(pmfwStatusInterface) +
+        "',path='" + pmfwPath + "',member='" + std::string(pmfwStatusSignal) +
+        "'";
+
+    try
+    {
+        pmfwStatusMatch = std::make_unique<sdbusplus::bus::match_t>(
+            static_cast<sdbusplus::bus_t&>(*systemBus), matchRule,
+            [this](sdbusplus::message_t& msg) {
+                bool ready = false;
+                try
+                {
+                    msg.read(ready);
+                }
+                catch (const std::exception& e)
+                {
+                    lg2::error("Failed to read PMFW status signal for node "
+                               "{NODE}: {ERROR}",
+                               "NODE", node, "ERROR", e.what());
+                    return;
+                }
+
+                lg2::info("PMFW status notification received for node {NODE}: "
+                          "ready={READY}",
+                          "NODE", node, "READY", ready);
+                applyPmfwStatus(ready);
+            });
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed to subscribe to PMFW status signal on {PATH}: "
+                   "{ERROR}",
+                   "PATH", pmfwPath, "ERROR", e.what());
+        return;
+    }
+
+    lg2::info("Subscribed to PMFW status signal on {PATH}", "PATH", pmfwPath);
+}
+
+void Manager::applyPmfwStatus(bool ready)
+{
+    pmfwReady = ready;
+
+    if (ready)
+    {
+        pmfwReadyHandler();
+    }
+    else
+    {
+        pmfwNotReadyHandler();
+    }
+}
+
+void Manager::reconcilePmfwState()
+{
+    // TODO:  Implement a method to reconcile Pmfw State if the host is already
+    // powered on when this service starts.
+}
 
 void Manager::loadPlatformConfig()
 {

--- a/src/base_manager.cpp
+++ b/src/base_manager.cpp
@@ -234,8 +234,18 @@ void Manager::applyPmfwStatus(bool ready)
 
 void Manager::reconcilePmfwState()
 {
-    // TODO:  Implement a method to reconcile Pmfw State if the host is already
-    // powered on when this service starts.
+    // The PMFW status signal is transient. If the host is already powered on
+    // when this service starts (e.g. a RAS restart while the host is running),
+    // the ready notification may have been emitted and missed. Reconcile by
+    // applying the ready state now. Platform initialization is idempotent, so
+    // a subsequent ready signal is harmless.
+    if (isHostPoweredOn())
+    {
+        lg2::info("Host already powered on at startup; reconciling PMFW ready "
+                  "state for node {NODE}",
+                  "NODE", node);
+        applyPmfwStatus(true);
+    }
 }
 
 void Manager::loadPlatformConfig()
@@ -337,6 +347,29 @@ void Manager::currentHostStateMonitor()
                             "xyz.openbmc_project.State.Host.HostState.Off");
             onHostStateChanged(hostOff);
         });
+}
+
+bool Manager::isHostPoweredOn()
+{
+    try
+    {
+        std::string hostService = "xyz.openbmc_project.State.Host" + node;
+        std::string hostPath = "/xyz/openbmc_project/state/host" + node;
+
+        sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
+        std::string currentHostState = amd::ras::util::getProperty<std::string>(
+            bus, hostService.c_str(), hostPath.c_str(),
+            "xyz.openbmc_project.State.Host", "CurrentHostState");
+
+        return currentHostState !=
+               "xyz.openbmc_project.State.Host.HostState.Off";
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed to query host power state: {ERROR}", "ERROR",
+                   e.what());
+        return false;
+    }
 }
 
 void Manager::handleFchError(uint8_t socNum)

--- a/src/pldm_manager.cpp
+++ b/src/pldm_manager.cpp
@@ -155,9 +155,9 @@ Manager::Manager(amd::ras::config::Manager& manager,
                  sdbusplus::asio::object_server& objectServer,
                  std::shared_ptr<sdbusplus::asio::connection>& systemBus,
                  boost::asio::io_context& io, std::string& node) :
-    amd::ras::Manager(manager, node), objectServer(objectServer),
-    systemBus(systemBus), io(io), pldmInitialized(false),
-    platformInitialized(false), runtimeErrSupported(false)
+    amd::ras::Manager(manager, systemBus, node), objectServer(objectServer),
+    io(io), pldmInitialized(false), platformInitialized(false),
+    runtimeErrSupported(false)
 {}
 
 void Manager::onHostStateChanged(bool hostOff)
@@ -526,7 +526,31 @@ void Manager::init()
 
     loadPlatformConfig();
 
-    platformInitialize();
+    // Platform initialization requires PMFW. It is deferred until the PMFW
+    // ready signal is received from amd-host-manager.
+    subscribePmfwSignals();
+}
+
+void Manager::pmfwReadyHandler()
+{
+    // Perform platform initialization now that the PMFW mailbox is available.
+    // Guard against exceptions (e.g. unsupported family) so the service keeps
+    // running.
+    try
+    {
+        platformInitialize();
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Platform initialization failed on PMFW ready: {ERROR}",
+                   "ERROR", e.what());
+    }
+}
+
+void Manager::pmfwNotReadyHandler()
+{
+    // Mark PLDM/platform uninitialized.
+    pldmInitialized = false;
 }
 
 void Manager::configure()
@@ -562,123 +586,29 @@ void Manager::registerEventHandler()
     lg2::info("Registered PLDM RAS event signal monitor");
 
     registerSysMgmtCtrlErrAlertHandler();
+
+    reconcilePmfwState();
 }
 
 void Manager::configureSysMgmtCtrlErrAlertHandling()
 {
-    const std::string primaryPath =
-        "/var/lib/amd-bmc-ras/amd_ras_gpio_config" + node + ".json";
-    const std::string fallbackPath =
-        "/usr/share/amd-bmc-ras/amd_ras_gpio_config" + node + ".json";
-
-    std::ifstream jsonFile(primaryPath);
-    std::string cfgPath = primaryPath;
-
-    if (!jsonFile.is_open())
-    {
-        jsonFile.open(fallbackPath);
-        cfgPath = fallbackPath;
-    }
-
-    if (!jsonFile.is_open())
-    {
-        throw sdbusplus::xyz::openbmc_project::Common::File::Error::Open();
-    }
-
-    if (jsonFile.peek() == std::ifstream::traits_type::eof())
-    {
-        jsonFile.close();
-        lg2::error("GPIO config file is empty: {FILE}", "FILE", cfgPath);
-        throw std::runtime_error("GPIO config file is empty");
-    }
-
-    nlohmann::json config;
-    jsonFile >> config;
-    jsonFile.close();
-
-    alertHandleMode.clear();
-    socketNames.clear();
-
-    if (config.contains("Alert_Config") && config["Alert_Config"].is_array())
-    {
-        for (const auto& entry : config["Alert_Config"])
-        {
-            if (entry.contains("AlertHandle"))
-            {
-                const auto& alertCfg = entry["AlertHandle"];
-                if (alertCfg.contains("Value"))
-                {
-                    alertHandleMode = alertCfg["Value"].get<std::string>();
-                }
-            }
-
-            if (alertHandleMode == "GPIO" &&
-                entry.contains("GPIO_ALERT_LINES") &&
-                entry["GPIO_ALERT_LINES"].is_array())
-            {
-                socketNames =
-                    entry["GPIO_ALERT_LINES"].get<std::vector<std::string>>();
-            }
-        }
-    }
-
-    if (alertHandleMode != "UEVENT" && alertHandleMode != "GPIO")
-    {
-        throw std::runtime_error("Invalid mode of Alert handling");
-    }
-
-    if (alertHandleMode == "GPIO" && socketNames.size() < cpuCount)
-    {
-        throw std::runtime_error(
-            "Insufficient GPIO_ALERT_LINES entries in gpio_config.json");
-    }
-
-    lg2::info("PLDM sysMgmtCtrlErr alert mode: {MODE}", "MODE",
-              alertHandleMode);
+    // System management control error handling is not supported over the PLDM
+    // transport (the ASP endpoint does not generate PLDM events for
+    // system/control fabric errors), so there is no alert-handling
+    // configuration to apply here.
+    lg2::info("System management control error handling is not supported over "
+              "PLDM; skipping alert handling configuration");
 }
 
 void Manager::registerSysMgmtCtrlErrAlertHandler()
 {
-    if (alertHandleMode == "UEVENT")
-    {
-        udevMonitors.resize(cpuCount);
-        udevPollTimers.resize(cpuCount);
-
-        for (size_t i = 0; i < cpuCount; ++i)
-        {
-            apml_register_udev_monitor(&udevMonitors[i]);
-
-            if (!udevMonitors[i].udev || !udevMonitors[i].mon)
-            {
-                lg2::error(
-                    "Failed to initialize udev monitor for socket idx {IDX}",
-                    "IDX", i);
-                apml_unregister_udev_monitor(&udevMonitors[i]);
-                continue;
-            }
-
-            lg2::info(
-                "Registered UEVENT monitor for PLDM sysMgmtCtrlErr on socket idx {IDX}",
-                "IDX", i);
-            pollSysMgmtCtrlErrUevent(i);
-        }
-        return;
-    }
-
-    gpioLines.resize(cpuCount);
-    gpioEventDescriptors.reserve(cpuCount);
-
-    for (size_t i = 0; i < cpuCount; ++i)
-    {
-        gpioEventDescriptors.emplace_back(io);
-
-        requestSysMgmtCtrlErrGPIOEvents(
-            socketNames[i],
-            std::bind(&ras::pldm::Manager::handleSysMgmtCtrlErrGPIOEvent, this,
-                      std::ref(gpioEventDescriptors[i]), std::ref(gpioLines[i]),
-                      i),
-            gpioLines[i], gpioEventDescriptors[i]);
-    }
+    // System management control (control-fabric) errors are delivered to the
+    // BMC out-of-band alert path (SBRMI/APML). In PLDM mode the ASP endpoint
+    // does not generate PLDM events for system/control fabric errors, so
+    // amd-ras cannot receive them over PLDM. This handling is therefore not
+    // supported for the PLDM transport.
+    lg2::info("System management control error handling is not supported over "
+              "PLDM");
 }
 
 void Manager::pollSysMgmtCtrlErrUevent(size_t socketIdx)


### PR DESCRIPTION
Allow system management control errors to be detected and serviced before PMFW is ready, while ensuring APML and PLDM initialization happens only after PMFW becomes available.

- Subscribe to PMFW Ready/Off D-Bus signals from amd-host-manager
- Move PMFW-dependent initialization to onPmfwReady()
- Tear down runtime polling and transport initialization on PMFW Off
- Reconcile PMFW state during RAS service restart when host is already on
- Enable early sysMgmtCtrlErr handling prior to PMFW readiness
- Gate PMFW-dependent interrupt decoding until initialization completes
- Remove service dependency on amd-host-manager startup ordering

Tests:
Verified the functionality successfully.