### PR TITLE
Fix PCIe CPER generation by excluding AMD severity

### DIFF
--- a/include/oem_cper.hpp
+++ b/include/oem_cper.hpp
@@ -15,6 +15,9 @@ constexpr size_t length4 = 4;
 constexpr size_t length8 = 8;
 constexpr size_t length32 = 32;
 constexpr size_t length96 = 96;
+// Number of 32-bit words in the AMD PCIe error data buffer
+// (AmdPcieErrorData::PcieData below). The PMFW reports a fixed-size PCIe
+// error record of 91 DWORDs (364 bytes), so this bounds the PcieData array.
 constexpr size_t length91 = 91;
 
 struct CrashdumpData

--- a/include/utils/cper.hpp
+++ b/include/utils/cper.hpp
@@ -21,6 +21,17 @@ constexpr uint8_t sevNonFatalUncorrected = 0;
 constexpr uint8_t sevNonFatalCorrected = 2;
 constexpr uint8_t sevInformational = 3;
 
+// The PCIe error severity is carried in the low byte of the AMD custom first
+// DWORD. Mask with this to extract the severity code (used by both APML and
+// PLDM PCIe harvest paths).
+constexpr uint32_t severityByteMask = 0xFF;
+
+// AMD custom PCIe first-DWORD field layout (each field is one byte):
+//   [7:0]=severity  [15:8]=root port  [23:16]=PCIe controller  [31:24]=IOD
+constexpr uint32_t pcieRootPortShift = 8;
+constexpr uint32_t pcieControllerShift = 16;
+constexpr uint32_t pcieIodShift = 24;
+
 constexpr uint8_t cperValidPlatformId = 0x1;
 constexpr uint8_t cperValidTimestamp = 0x2;
 constexpr uint8_t addcGenNumber3 = 0x03;

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -88,7 +88,6 @@ constexpr size_t mcaIpidHiOffset = 0x2C;
 constexpr uint32_t umcHardwareId = 0x96;
 constexpr size_t crashdump = 1;
 constexpr size_t shutdown = 2;
-constexpr size_t index28 = 28;
 constexpr size_t blockId25 = 25;
 constexpr uint16_t coreMcaHardwareId = 0xb0;
 constexpr size_t coresPerCcd = 32;
@@ -3376,8 +3375,22 @@ void Manager::dumpProcErrorSection(
                 }
                 else if (PciePtr)
                 {
-                    PciePtr->PcieErrorData[section].PcieData[dumpIndex] =
-                        badData;
+                    // The first DWORD is AMD custom data (severity) that is
+                    // discarded from the standard UEFI PCIe error section.
+                    // Keep it out of PcieData even when the read fails.
+                    if (dataIn.offset == 0)
+                    {
+                        rootErrStatus = badData;
+                        continue;
+                    }
+                    // Discarding the custom DWORD shifts the write index, so
+                    // guard against overrunning the fixed-size PcieData[]
+                    // array (length91 words).
+                    if (dumpIndex < length91)
+                    {
+                        PciePtr->PcieErrorData[section].PcieData[dumpIndex] =
+                            badData;
+                    }
                 }
                 dumpIndex++;
                 continue;
@@ -3424,19 +3437,36 @@ void Manager::dumpProcErrorSection(
             }
             else if (PciePtr)
             {
-                if (dumpIndex == index28)
-                {
-                    PciePtr->PcieErrorData[section].PcieData[dumpIndex] =
-                        rootErrStatus;
-                    dumpIndex++;
-                }
-
                 if (dataIn.offset == 0)
                 {
+                    // The first 4 bytes returned by PMFW are AMD custom data
+                    // carrying the PCIe error severity. They are not part of
+                    // the standard UEFI PCIe error section, so capture them
+                    // for the section severity (extracted below) and debug
+                    // logging, then discard them from the CPER body.
                     rootErrStatus = dataOut;
+                    lg2::info(
+                        "Socket {SOCKET}: PCIe Error collected on Root Port "
+                        "{ROOTPORT}, PCIe Controller {CONTROLLER}, IOD {IOD}, "
+                        "severity {SEVERITY}",
+                        "SOCKET", socNum, "ROOTPORT",
+                        (dataOut >> amd::ras::util::cper::pcieRootPortShift) &
+                            amd::ras::util::cper::severityByteMask,
+                        "CONTROLLER",
+                        (dataOut >> amd::ras::util::cper::pcieControllerShift) &
+                            amd::ras::util::cper::severityByteMask,
+                        "IOD",
+                        (dataOut >> amd::ras::util::cper::pcieIodShift) &
+                            amd::ras::util::cper::severityByteMask,
+                        "SEVERITY",
+                        dataOut & amd::ras::util::cper::severityByteMask);
                     continue;
                 }
-                else
+
+                // Discarding the custom DWORD shifts the write index, so guard
+                // against overrunning the fixed-size PcieData[] array
+                // (length91 words).
+                if (dumpIndex < length91)
                 {
                     PciePtr->PcieErrorData[section].PcieData[dumpIndex] =
                         dataOut;
@@ -3497,7 +3527,11 @@ void Manager::dumpProcErrorSection(
         }
         else if (category == 2) // PCIE error
         {
-            Severity[section] = rootErrStatus & 0xFF;
+            // Severity is carried in the AMD custom first DWORD (discarded
+            // from the CPER body above). The severity code occupies the low
+            // byte of that DWORD, so mask with severityByteMask to extract it.
+            Severity[section] = rootErrStatus &
+                                amd::ras::util::cper::severityByteMask;
         }
         n++;
         section++;

--- a/src/pldm_manager.cpp
+++ b/src/pldm_manager.cpp
@@ -1511,17 +1511,54 @@ bool Manager::harvestRuntimeOverflowSections(
 
     std::vector<uint32_t> severity(sectionCount, 2);
 
+    // The first 4 bytes of each PCIe section returned by PMFW are AMD custom
+    // data carrying the error severity. They are not part of the standard UEFI
+    // PCIe error section, so they are discarded from the CPER body; only the
+    // standard PCIe error info that follows is copied.
+    constexpr uint32_t amdCustomDataLen = sizeof(uint32_t);
+    constexpr uint32_t pcieStdDataLen = pcieDataBankLen - amdCustomDataLen;
+
     for (uint16_t i = 0; i < sectionCount; i++)
     {
         size_t sectionStart =
             dataOffset + static_cast<size_t>(i) * pcieDataBankLen;
-        size_t available = 0;
-        if (sectionStart < eventData.size())
+
+        // Extract the AMD custom severity dword and log it for debug before
+        // discarding it from the CPER body.
+        uint32_t rootErrStatus = badData;
+        if (sectionStart + amdCustomDataLen <= eventData.size())
         {
-            available = std::min(static_cast<size_t>(pcieDataBankLen),
-                                 eventData.size() - sectionStart);
+            std::memcpy(&rootErrStatus, &eventData[sectionStart],
+                        amdCustomDataLen);
+        }
+
+        lg2::info(
+            "Socket {SOCKET}: PCIe Error collected on Root Port "
+            "{ROOTPORT}, PCIe Controller {CONTROLLER}, IOD {IOD}, "
+            "severity {SEVERITY}",
+            "SOCKET", socNum, "ROOTPORT",
+            (rootErrStatus >> amd::ras::util::cper::pcieRootPortShift) &
+                amd::ras::util::cper::severityByteMask,
+            "CONTROLLER",
+            (rootErrStatus >> amd::ras::util::cper::pcieControllerShift) &
+                amd::ras::util::cper::severityByteMask,
+            "IOD",
+            (rootErrStatus >> amd::ras::util::cper::pcieIodShift) &
+                amd::ras::util::cper::severityByteMask,
+            "SEVERITY", rootErrStatus & amd::ras::util::cper::severityByteMask);
+
+        // Extract the severity code from the low byte of the custom DWORD.
+        severity[i] = rootErrStatus & amd::ras::util::cper::severityByteMask;
+
+        // Copy only the standard PCIe error info that follows the custom dword.
+        size_t pcieDataStart = sectionStart + amdCustomDataLen;
+        size_t available = 0;
+        if (pcieDataStart < eventData.size())
+        {
+            available = std::min(static_cast<size_t>(pcieStdDataLen),
+                                 eventData.size() - pcieDataStart);
             std::memcpy(ptr->PcieErrorData[i].PcieData,
-                        &eventData[sectionStart], available);
+                        &eventData[pcieDataStart], available);
         }
 
         if (available < pcieDataBankLen)
@@ -1532,11 +1569,6 @@ bool Manager::harvestRuntimeOverflowSections(
                 ptr->PcieErrorData[i].PcieData[w] = badData;
             }
         }
-
-        // PCIe severity derived from root error status (first DWORD),
-        // mirroring APML dumpProcErrorSection behavior for category==2.
-        uint32_t rootErrStatus = ptr->PcieErrorData[i].PcieData[0];
-        severity[i] = rootErrStatus & 0xFF;
 
         std::snprintf(ptr->SectionDescriptor[i].FruString,
                       sizeof(ptr->SectionDescriptor[i].FruString), "P%u",


### PR DESCRIPTION
Discard the AMD custom severity DWORD from PCIe CPER section data while preserving it for section severity calculation and debug logging.

- Remove AMD custom severity DWORD from PCIe CPER body
- Use first DWORD only to derive PCIe error severity
- Add logging for discarded AMD severity data
- Update APML and PLDM paths for consistent PCIe handling

Tests:
Verified the functionality successfully