### PR TITLE
Clear SBRMI SwAsyncAlertSts bit to re-arm GPIO alert after handling RAS errors

### DIFF
--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -30,6 +30,7 @@ namespace apml
 {
 constexpr size_t base16 = 16;
 constexpr size_t sbrmiControlRegister = 0x1;
+constexpr size_t sbrmiStatusRegister = 0x02;
 constexpr size_t sysMgmtCtrlErr = 0x4;
 constexpr size_t shutdownError = 0x40;
 
@@ -675,6 +676,22 @@ void Manager::clearSbrmiAlertMask(uint8_t socNum)
         {
             lg2::info("Socket {SOC}: Failed to read SBRMIx[0x{REG}] ", "SOC",
                       socNum, "REG", lg2::hex, alert_status[i]);
+        }
+    }
+
+    // Clear SBRMIx02 bit 3 (SwAsyncAlertSts) to re-arm GPIO alert
+    uint8_t sbrmiStatus;
+    if (read_sbrmi_status(socNum, &sbrmiStatus) == OOB_SUCCESS)
+    {
+        if (sbrmiStatus & 0x08)
+        {
+            // Register 0x02 is write-one-to-clear, write 0x08 to clear bit 3
+            ret = esmi_oob_write_byte(socNum, sbrmiStatusRegister, SBRMI, 0x08);
+            if (ret != OOB_SUCCESS)
+            {
+                lg2::error("Socket {SOC}: Failed to clear SBRMIx02 bit 3",
+                           "SOC", socNum);
+            }
         }
     }
 }
@@ -2478,6 +2495,19 @@ bool Manager::decodeInterrupt(uint8_t socNum)
     {
         lg2::debug("Socket {SOC}: Read status register. Value: 0x{BUF}", "SOC",
                    socNum, "BUF", lg2::hex, buf);
+
+        // Clear SBRMIx02 bit 3 (SwAsyncAlertSts) to re-arm GPIO alert
+        if (buf & 0x08)
+        {
+            // Register 0x02 is write-one-to-clear, write 0x08 to clear bit 3
+            oob_status_t ret =
+                esmi_oob_write_byte(socNum, sbrmiStatusRegister, SBRMI, 0x08);
+            if (ret != OOB_SUCCESS)
+            {
+                lg2::error("Socket {SOC}: Failed to clear SBRMIx02 bit 3",
+                           "SOC", socNum);
+            }
+        }
 
         /*Check if Alert Status bit is set and clear AlertSts*/
         if (buf & 0x1)


### PR DESCRIPTION
**Description**
After handling a RAS error, SBRMI register 0x02 bit 3 (SwAsyncAlertSts) remains set. Since APML_ALERT_L GPIO is level-triggered by this bit, subsequent errors cannot generate a falling edge to trigger new alerts. This causes missed RAS errors after the first one.

**Changes**
***SBRMI Status Bit 3 Clearing***
  - Added sbrmiStatusRegister constant for register 0x02
  - Clear bit 3 in clearSbrmiAlertMask() during platform initialization
  - Clear bit 3 at entry of decodeInterrupt() GPIO path before harvesting

**Issue**
  - Multiple consecutive RAS errors are not detected. Only the first error after boot generates a CPER record. 
  - Subsequent errors are lost because the GPIO stays low and no falling edge occurs.

**Fix**
 - Clear SBRMI register 0x02 bit 3 (SwAsyncAlertSts) using write-one-to-clear (W1C) to re-arm the GPIO alert.

**Testing**
  - Manual verification with apml_tool confirmed W1C behavior (0x18 → 0x10)
<img width="377" height="316" alt="image" src="https://github.com/user-attachments/assets/be29c0f0-4270-45d5-817c-078c51406534" />

  - Multiple consecutive error injections now generate CPERs
  - Test logs:  [clear_sbrmi_status.zip](https://github.com/user-attachments/files/31399058/clear_sbrmi_status.zip)
