### PR TITLE
Ignore RAS alerts after control fabric error

### DIFF
--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -101,6 +101,11 @@ class Manager : public amd::ras::Manager
     bool pmfwRuntimeReady;
     bool platformInitialized;
     bool runtimeErrPollingSupported;
+    /** @brief Set once a control fabric error (RasStatus[reset_ctrl_err]) is
+     *  detected. While set, incoming RAS error alerts are ignored until the
+     *  host is rebooted, since the system is expected to be reset by policy.
+     */
+    bool cfErrorReceived;
     std::vector<bool> cpuAlertProcessed;
     boost::asio::deadline_timer* McaErrorPollingEvent;
     boost::asio::deadline_timer* DramCeccErrorPollingEvent;
@@ -169,6 +174,15 @@ class Manager : public amd::ras::Manager
      *  skipped until PMFW is ready again.
      */
     void pmfwNotReadyHandler() override;
+
+    /** @brief Deactivate runtime error polling.
+     *
+     *  @details Cancels the MCA, DRAM CECC and PCIe AER runtime error polling
+     *  timers. Invoked when a control fabric error (RasStatus[reset_ctrl_err])
+     *  is detected, since the system is expected to be reset based on policy
+     *  and further runtime polling is no longer meaningful.
+     */
+    void deactivateRuntimeErrorPolling();
 
     /** @brief Stream descriptor for handling  APML alert events.
      *

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -114,14 +114,22 @@ Manager::Manager(amd::ras::config::Manager& manager,
     amd::ras::Manager(manager, systemBus, node), objectServer(objectServer),
     watchdogTimerCounter(0), io(io), pmfwRuntimeReady(false),
     platformInitialized(false), runtimeErrPollingSupported(false),
-    McaErrorPollingEvent(nullptr), DramCeccErrorPollingEvent(nullptr),
-    PcieAerErrorPollingEvent(nullptr), ApmlAlertEvent(nullptr),
-    mcaErrorHarvestMtx(), dramErrorHarvestMtx(), pcieErrorHarvestMtx()
+    cfErrorReceived(false), McaErrorPollingEvent(nullptr),
+    DramCeccErrorPollingEvent(nullptr), PcieAerErrorPollingEvent(nullptr),
+    ApmlAlertEvent(nullptr), mcaErrorHarvestMtx(), dramErrorHarvestMtx(),
+    pcieErrorHarvestMtx()
 {}
 
 void Manager::onHostStateChanged(bool hostOff)
 {
+    lg2::info("Host state changed. Host is now {STATE}", "STATE",
+              hostOff ? "OFF" : "ON");
     pmfwRuntimeReady = false;
+
+    // A host state transition indicates a reboot/power cycle. Clear the
+    // control fabric error latch so RAS error alerts are serviced again once
+    // the host is back up.
+    cfErrorReceived = false;
 
     if (!hostOff)
     {
@@ -473,6 +481,25 @@ void Manager::pmfwNotReadyHandler()
     // stop runtime error polling and clear pmfwRuntimeReady so runtime
     // validity checks are skipped until PMFW is ready again.
     pmfwRuntimeReady = false;
+
+    if (McaErrorPollingEvent != nullptr)
+    {
+        McaErrorPollingEvent->cancel();
+    }
+    if (DramCeccErrorPollingEvent != nullptr)
+    {
+        DramCeccErrorPollingEvent->cancel();
+    }
+    if (PcieAerErrorPollingEvent != nullptr)
+    {
+        PcieAerErrorPollingEvent->cancel();
+    }
+}
+
+void Manager::deactivateRuntimeErrorPolling()
+{
+    lg2::info("Deactivating runtime error polling due to control fabric error "
+              "(RasStatus[reset_ctrl_err])");
 
     if (McaErrorPollingEvent != nullptr)
     {
@@ -1085,6 +1112,7 @@ void Manager::runTimeErrorInfoCheck(uint8_t errType, uint8_t reqType)
             "Harvesting runtime error. Error Type: {ERRTYPE} Request Type: {REQTYPE}",
             "ERRTYPE", getErrorTypeStr(errType), "REQTYPE",
             getRequestTypeStr(reqType));
+
         if (errType == mcaErr)
         {
             if (mcaPtr == nullptr)
@@ -2149,6 +2177,17 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
     bool nonMcaShutdownError = false;
     cpuAlertProcessed.resize(cpuCount, false);
 
+    // Once a control fabric error (RasStatus[reset_ctrl_err]) has been
+    // detected, the system is expected to be reset based on policy. Ignore any
+    // further RAS error alerts until the host is rebooted.
+    if (cfErrorReceived == true)
+    {
+        lg2::info("Control fabric error already latched. Ignoring RAS error "
+                  "alert for SOC {SOC} until host reboot",
+                  "SOC", socNum);
+        return true;
+    }
+
     if ((src & 0xFF) == 0)
     {
         lg2::debug("Nothing to Harvest. Not RAS Error");
@@ -2176,6 +2215,14 @@ bool Manager::decodeInterrupt(uint8_t socNum, uint32_t src)
                             LOG_ERR, "REDFISH_MESSAGE_ID=%s",
                             "OpenBMC.0.1.CPUError", "REDFISH_MESSAGE_ARGS=%s",
                             rasErrMsg.c_str(), NULL);
+
+            /* RasStatus[reset_ctrl_err] is set: the system will be reset
+               based on policy, so stop runtime error polling. */
+            deactivateRuntimeErrorPolling();
+
+            /* Latch the control fabric error so subsequent RAS error alerts
+               are ignored until the host is rebooted. */
+            cfErrorReceived = true;
 
             harvestBreakEvent(socNum);
             cpuAlertProcessed.assign(cpuCount, true);
@@ -2474,6 +2521,17 @@ bool Manager::decodeInterrupt(uint8_t socNum)
     bool nonMcaShutdownError = false;
     cpuAlertProcessed.resize(cpuCount, false);
 
+    // Once a control fabric error (RasStatus[reset_ctrl_err]) has been
+    // detected, the system is expected to be reset based on policy. Ignore any
+    // further RAS error alerts until the host is rebooted.
+    if (cfErrorReceived == true)
+    {
+        lg2::info("Control fabric error already latched. Ignoring RAS error "
+                  "alert for SOC {SOC} until host reboot",
+                  "SOC", socNum);
+        return true;
+    }
+
     if (read_sbrmi_status(socNum, &buf) == OOB_SUCCESS)
     {
         lg2::debug("Socket {SOC}: Read status register. Value: 0x{BUF}", "SOC",
@@ -2557,6 +2615,14 @@ bool Manager::decodeInterrupt(uint8_t socNum)
                         "MESSAGE=%s", rasErrMsg.c_str(), "PRIORITY=%i", LOG_ERR,
                         "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.CPUError",
                         "REDFISH_MESSAGE_ARGS=%s", rasErrMsg.c_str(), NULL);
+
+                    /* RasStatus[reset_ctrl_err] is set: the system will be
+                       reset based on policy, so stop runtime error polling. */
+                    deactivateRuntimeErrorPolling();
+
+                    /* Latch the control fabric error so subsequent RAS error
+                       alerts are ignored until the host is rebooted. */
+                    cfErrorReceived = true;
 
                     harvestBreakEvent(socNum);
                     cpuAlertProcessed.assign(cpuCount, true);


### PR DESCRIPTION
Ignore RAS alerts after control fabric error

When RasStatus[reset_ctrl_err] is detected, the platform is expected to be reset according to system policy. Continuing to process new RAS alerts or perform runtime error polling during this state can lead to redundant error handling and unnecessary polling activity.

Add a control fabric error latch (cfErrorReceived) to track the condition and ignore subsequent RAS error alerts until the host is rebooted. Runtime MCA, DRAM CECC, and PCIe AER polling are also deactivated once the control fabric error is detected.

The latch is cleared on host state transition, allowing normal RAS monitoring and alert processing after the system comes back online.

Impact:
 - Prevents repeated processing of RAS alerts after a fatal control fabric error.
 - Stops unnecessary runtime error polling when a system reset is expected.
 - Restores normal RAS handling automatically after host reboot.