### PR TITLE
Use persistent D-Bus matches for state signals

### DIFF
--- a/include/apml_manager.hpp
+++ b/include/apml_manager.hpp
@@ -119,6 +119,9 @@ class Manager : public amd::ras::Manager
     std::string alertHandleMode;
     std::vector<std::string> socketNames;
 
+    /** @brief D-Bus match rule for the watchdog PropertiesChanged signal. */
+    std::unique_ptr<sdbusplus::bus::match_t> watchdogStateMatch;
+
     /**
      * @brief Handler for alert events.
      *

--- a/include/base_manager.hpp
+++ b/include/base_manager.hpp
@@ -127,6 +127,9 @@ class Manager
     /** @brief D-Bus match rule for the PMFW status notification signal. */
     std::unique_ptr<sdbusplus::bus::match_t> pmfwStatusMatch;
 
+    /** @brief D-Bus match rule for the host state PropertiesChanged signal. */
+    std::unique_ptr<sdbusplus::bus::match_t> hostStateMatch;
+
     /** @brief Subscribe to the PMFW status signal from amd-host-manager.
      *
      *  @details Registers a single D-Bus signal match for the per-node PMFW

--- a/src/apml_manager.cpp
+++ b/src/apml_manager.cpp
@@ -360,11 +360,8 @@ void Manager::init()
     // polling) and CPUID reads require PMFW. They are deferred until the PMFW
     // ready signal is received from amd-host-manager.
 
-    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
-    boost::system::error_code ec;
-
-    static auto match = sdbusplus::bus::match::match(
-        bus,
+    watchdogStateMatch = std::make_unique<sdbusplus::bus::match_t>(
+        static_cast<sdbusplus::bus_t&>(*systemBus),
         "type='signal',member='PropertiesChanged', "
         "interface='org.freedesktop.DBus.Properties', "
         "arg0='xyz.openbmc_project.State.Watchdog'",

--- a/src/base_manager.cpp
+++ b/src/base_manager.cpp
@@ -304,10 +304,8 @@ void Manager::loadPlatformConfig()
 
 void Manager::currentHostStateMonitor()
 {
-    sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
-
-    static auto match = sdbusplus::bus::match::match(
-        bus,
+    hostStateMatch = std::make_unique<sdbusplus::bus::match_t>(
+        static_cast<sdbusplus::bus_t&>(*systemBus),
         "type='signal',member='PropertiesChanged', "
         "interface='org.freedesktop.DBus.Properties', "
         "arg0='xyz.openbmc_project.State.Host'",


### PR DESCRIPTION
Preserve D-Bus signal match objects using class members

The watchdog and host state signal subscriptions were previously created as local static D-Bus match objects using a separate bus instance. This can lead to lifecycle and ownership issues when integrating with the manager's system bus.

Store the watchdog and host state D-Bus match objects as manager class members and bind them to the existing systemBus instance. This ensures the signal subscriptions remain active for the lifetime of the manager object and aligns signal monitoring with the manager's D-Bus connection.

Impact:
- Ensures host state and watchdog state signal monitoring remains valid throughout manager lifetime.
- Avoids dependence on function-local static match objects.
- Uses the manager's existing systemBus for consistent D-Bus event handling.