### PR TITLE
Increase DRAM CECC leak rate to 25 for reliable error detection

### DIFF
--- a/config/ras_config.json
+++ b/config/ras_config.json
@@ -97,7 +97,7 @@
         {
             "DramCeccLeakRate": {
                 "Description": "DRAM CECC leaky bucket leak rate (0x00-0x1F). Only used when DramCeccOobEcMode=2",
-                "Value": 20,
+                "Value": 25,
                 "MaxBoundLimit": 31
             }
         },


### PR DESCRIPTION
**Description**
Change DramCeccLeakRate to 25 since a slower leak rate provides more reliable DRAM CE error detection during manual injection testing, ensuring the error counter threshold is reached before the bucket leaks

**Changes**
- Increase the leak rate value in the ras_config.json to 25.

**Tested**
Injected 40 DRAM CE and verified the working
- GPIO interrupts: 93,759 → 133,423 (+39,664 total)
- SBRMI 0x02: 0x0 (bit 3 cleared after each harvest)
- SBRMI 0x4C: 0x0 (no overflow)
- CPERs: 10 files wrapping correctly in /var/lib/bmc-ras/
- PPR files: 20 generated (10 rtppr + 10 btppr)

***Test Logs***: 
[dramce-injection-raw-log.txt](https://github.com/user-attachments/files/32132961/dramce-injection-raw-log.txt)
